### PR TITLE
chore(RE-4): gitignore .claude/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 *.swp
 *.swo
 .DS_Store
+
+# AI tooling (local only)
+.claude/


### PR DESCRIPTION
## Summary
- Add `.claude/` to `.gitignore` — AI tooling stays local

Closes #4