### PR TITLE
feat: configurable graph scoring weights (v3.9.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,7 +3930,7 @@ checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
 
 [[package]]
 name = "recall-echo"
-version = "3.7.0"
+version = "3.9.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recall-echo"
-version = "3.8.0"
+version = "3.9.0"
 edition = "2021"
 description = "Persistent memory system with knowledge graph — for any LLM tool"
 license = "AGPL-3.0-only"

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,6 +163,13 @@ pub struct GraphSection {
     /// Path to file containing the database password
     #[serde(default)]
     pub password_file: String,
+    /// Scoring weights for utility-weighted semantic search.
+    ///
+    /// Maps to the `[graph.scoring]` section of `.recall-echo.toml`. When
+    /// absent, defaults preserve the original hard-coded weights
+    /// (0.45 / 0.30 / 0.25). See `GraphScoringConfig` for details.
+    #[serde(default)]
+    pub scoring: GraphScoringConfig,
 }
 
 impl Default for GraphSection {
@@ -174,6 +181,46 @@ impl Default for GraphSection {
             database: String::new(),
             username: String::new(),
             password_file: String::new(),
+            scoring: GraphScoringConfig::default(),
+        }
+    }
+}
+
+/// Scoring weights for utility-weighted semantic search.
+///
+/// The final score for a retrieved entity is computed as a linear combination
+/// of three signals:
+///
+/// ```text
+/// score = weight_semantic * similarity
+///       + weight_hotness  * hotness
+///       + weight_utility  * utility_score
+/// ```
+///
+/// Defaults (`0.45 / 0.30 / 0.25`) match the original hard-coded values, so
+/// omitting the `[graph.scoring]` section from `.recall-echo.toml` produces
+/// identical behavior to pre-v3.9.0 recall-echo.
+///
+/// Weights are not constrained to sum to 1.0 — the scoring function does not
+/// normalize. Callers that change these should calibrate against their own
+/// retrieval outcomes; see `utility-feedback-loop-spec.md` in pulse-null.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GraphScoringConfig {
+    /// Weight applied to cosine similarity. Default `0.45`.
+    pub weight_semantic: f64,
+    /// Weight applied to the recency/access hotness signal. Default `0.30`.
+    pub weight_hotness: f64,
+    /// Weight applied to the utility score (outcome-feedback EMA). Default `0.25`.
+    pub weight_utility: f64,
+}
+
+impl Default for GraphScoringConfig {
+    fn default() -> Self {
+        Self {
+            weight_semantic: 0.45,
+            weight_hotness: 0.30,
+            weight_utility: 0.25,
         }
     }
 }
@@ -376,6 +423,7 @@ mod tests {
                 api_base: "http://localhost:11434/v1".into(),
             },
             pipeline: None,
+            graph: None,
         };
         let s = toml::to_string_pretty(&cfg).unwrap();
         let parsed: Config = toml::from_str(&s).unwrap();
@@ -433,6 +481,7 @@ mod tests {
                 api_base: String::new(),
             },
             pipeline: None,
+            graph: None,
         };
         save(tmp.path(), &cfg).unwrap();
         let loaded = load(tmp.path());
@@ -453,7 +502,46 @@ mod tests {
             ephemeral: EphemeralConfig { max_entries: 100 },
             llm: LlmSection::default(),
             pipeline: None,
+            graph: None,
         });
         assert_eq!(cfg.ephemeral.max_entries, 5);
+    }
+
+    #[test]
+    fn graph_scoring_defaults_match_legacy_hardcodes() {
+        let scoring = GraphScoringConfig::default();
+        assert!((scoring.weight_semantic - 0.45).abs() < f64::EPSILON);
+        assert!((scoring.weight_hotness - 0.30).abs() < f64::EPSILON);
+        assert!((scoring.weight_utility - 0.25).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn graph_scoring_partial_toml_fills_defaults() {
+        let scoring: GraphScoringConfig =
+            toml::from_str("weight_utility = 0.5\n").expect("parse partial scoring");
+        assert!((scoring.weight_semantic - 0.45).abs() < f64::EPSILON);
+        assert!((scoring.weight_hotness - 0.30).abs() < f64::EPSILON);
+        assert!((scoring.weight_utility - 0.5).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn graph_scoring_empty_section_yields_defaults() {
+        let section: GraphSection = toml::from_str("").expect("parse empty graph section");
+        let defaults = GraphScoringConfig::default();
+        assert!((section.scoring.weight_semantic - defaults.weight_semantic).abs() < f64::EPSILON);
+        assert!((section.scoring.weight_hotness - defaults.weight_hotness).abs() < f64::EPSILON);
+        assert!((section.scoring.weight_utility - defaults.weight_utility).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn graph_scoring_nested_under_graph() {
+        let cfg: Config = toml::from_str(
+            "[graph]\nmode = \"embedded\"\n\n[graph.scoring]\nweight_utility = 0.5\n",
+        )
+        .expect("parse nested scoring");
+        let scoring = cfg.graph.expect("graph section present").scoring;
+        assert!((scoring.weight_semantic - 0.45).abs() < f64::EPSILON);
+        assert!((scoring.weight_hotness - 0.30).abs() < f64::EPSILON);
+        assert!((scoring.weight_utility - 0.5).abs() < f64::EPSILON);
     }
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -62,6 +62,7 @@ pub struct GraphMemory {
     db: Surreal<Db>,
     embedder: FastEmbedder,
     path: PathBuf,
+    scoring: crate::config::GraphScoringConfig,
 }
 
 impl GraphMemory {
@@ -82,10 +83,13 @@ impl GraphMemory {
         std::fs::create_dir_all(&models_dir)?;
         let embedder = FastEmbedder::new(&models_dir)?;
 
+        let scoring = load_scoring_config(path);
+
         Ok(Self {
             db,
             embedder,
             path: path.to_path_buf(),
+            scoring,
         })
     }
 
@@ -123,6 +127,7 @@ impl GraphMemory {
                 })?
         };
 
+        let scoring = graph_section.scoring.clone();
         let server_config = store::ServerConfig {
             url: graph_section.url,
             username: graph_section.username,
@@ -132,7 +137,9 @@ impl GraphMemory {
         };
 
         let models_dir = path.join("models");
-        Self::connect(&server_config, &models_dir).await
+        let mut gm = Self::connect(&server_config, &models_dir).await?;
+        gm.scoring = scoring;
+        Ok(gm)
     }
 
     /// Connect to a SurrealDB server over WebSocket with explicit config.
@@ -151,6 +158,7 @@ impl GraphMemory {
             db,
             embedder,
             path: models_dir.to_path_buf(),
+            scoring: crate::config::GraphScoringConfig::default(),
         })
     }
 
@@ -317,7 +325,7 @@ impl GraphMemory {
 
     /// Semantic search across entities (legacy — returns full Entity).
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>, GraphError> {
-        search::search(&self.db, &self.embedder, query, limit).await
+        search::search(&self.db, &self.embedder, &self.scoring, query, limit).await
     }
 
     /// Search with options — L1 projections, type/keyword filters.
@@ -326,7 +334,7 @@ impl GraphMemory {
         query: &str,
         options: &SearchOptions,
     ) -> Result<Vec<ScoredEntity>, GraphError> {
-        search::search_with_options(&self.db, &self.embedder, query, options).await
+        search::search_with_options(&self.db, &self.embedder, &self.scoring, query, options).await
     }
 
     /// Semantic search across episodes.
@@ -346,7 +354,7 @@ impl GraphMemory {
         query_text: &str,
         options: &QueryOptions,
     ) -> Result<QueryResult, GraphError> {
-        query::query(&self.db, &self.embedder, query_text, options).await
+        query::query(&self.db, &self.embedder, &self.scoring, query_text, options).await
     }
 
     // --- Traversal ---
@@ -476,6 +484,18 @@ impl GraphMemory {
             entity_type_counts,
         })
     }
+}
+
+/// Load `[graph.scoring]` from `.recall-echo.toml` in the memory directory
+/// (the parent of the graph store path). Returns defaults if the config file
+/// or the `[graph.scoring]` section is absent, preserving legacy behavior.
+#[cfg(feature = "embedded")]
+fn load_scoring_config(graph_path: &Path) -> crate::config::GraphScoringConfig {
+    let memory_dir = graph_path.parent().unwrap_or(graph_path);
+    crate::config::load_from_dir(memory_dir)
+        .graph
+        .map(|g| g.scoring)
+        .unwrap_or_default()
 }
 
 async fn db_count(db: &Surreal<Db>, table: &str) -> Result<u64, GraphError> {

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -15,11 +15,13 @@ use super::embed::Embedder;
 use super::error::GraphError;
 use super::store::Db;
 use super::types::*;
+use crate::config::GraphScoringConfig;
 
 /// Run a hybrid query: semantic search + graph expansion + optional episode search.
 pub async fn query(
     db: &Surreal<Db>,
     embedder: &dyn Embedder,
+    scoring: &GraphScoringConfig,
     query_text: &str,
     options: &QueryOptions,
 ) -> Result<QueryResult, GraphError> {
@@ -36,7 +38,8 @@ pub async fn query(
         keyword: options.keyword.clone(),
     };
     let semantic_results =
-        super::search::search_with_options(db, embedder, query_text, &semantic_options).await?;
+        super::search::search_with_options(db, embedder, scoring, query_text, &semantic_options)
+            .await?;
 
     // Collect into dedup map (id -> ScoredEntity)
     let mut entity_map: HashMap<String, ScoredEntity> = HashMap::new();

--- a/src/graph/search.rs
+++ b/src/graph/search.rs
@@ -6,20 +6,27 @@ use super::embed::Embedder;
 use super::error::GraphError;
 use super::store::Db;
 use super::types::*;
+use crate::config::GraphScoringConfig;
 
 /// Semantic search across entities using HNSW KNN + utility-weighted scoring.
 ///
-/// Scoring formula (Adaptive Learning v2):
-///   final_score = 0.4 × semantic_similarity
-///               + 0.15 × hotness
-///               + 0.25 × utility_score
-///               + 0.2 × access_norm
+/// Scoring formula:
 ///
-/// Where hotness = sigmoid(ln(1 + access_count)) × exp(-λ × days_since_update)
-/// and utility_score comes from outcome feedback (Phase 1).
+/// ```text
+/// final_score = w_semantic * similarity
+///             + w_hotness  * hotness
+///             + w_utility  * utility_score
+/// ```
+///
+/// Weights come from `scoring` (see [`GraphScoringConfig`]). Defaults
+/// (`0.45` / `0.30` / `0.25`) preserve legacy behavior.
+///
+/// Where `hotness = sigmoid(ln(1 + access_count)) * exp(-lambda * days_since_update)`
+/// and `utility_score` comes from outcome feedback.
 pub async fn search(
     db: &Surreal<Db>,
     embedder: &dyn Embedder,
+    scoring: &GraphScoringConfig,
     query: &str,
     limit: usize,
 ) -> Result<Vec<SearchResult>, GraphError> {
@@ -51,7 +58,7 @@ pub async fn search(
                 &now,
             );
             let utility = row.entity.utility_score;
-            let score = score_with_utility(similarity, hotness, utility);
+            let score = score_with_utility(scoring, similarity, hotness, utility);
 
             SearchResult {
                 entity: row.entity,
@@ -72,6 +79,7 @@ pub async fn search(
 pub async fn search_with_options(
     db: &Surreal<Db>,
     embedder: &dyn Embedder,
+    scoring: &GraphScoringConfig,
     query_text: &str,
     options: &SearchOptions,
 ) -> Result<Vec<ScoredEntity>, GraphError> {
@@ -129,7 +137,7 @@ pub async fn search_with_options(
                 &now,
             );
             let utility = row.entity.utility_score;
-            let score = score_with_utility(similarity, hotness, utility);
+            let score = score_with_utility(scoring, similarity, hotness, utility);
 
             ScoredEntity {
                 entity: row.entity,
@@ -212,11 +220,18 @@ struct EpisodeWithDistance {
 
 /// Compute final score with utility weighting.
 ///
-/// Weights: semantic=0.45, hotness=0.30, utility=0.25
-/// Utility gets 25% — enough to meaningfully prioritize high-value memories
-/// without overwhelming semantic relevance.
-fn score_with_utility(similarity: f64, hotness: f64, utility: f64) -> f64 {
-    0.45 * similarity + 0.30 * hotness + 0.25 * utility
+/// Linear combination of similarity, hotness, and utility using weights
+/// from `scoring`. Defaults (0.45 / 0.30 / 0.25) preserve legacy behavior
+/// so deployments without a `[graph.scoring]` TOML section see no change.
+fn score_with_utility(
+    scoring: &GraphScoringConfig,
+    similarity: f64,
+    hotness: f64,
+    utility: f64,
+) -> f64 {
+    scoring.weight_semantic * similarity
+        + scoring.weight_hotness * hotness
+        + scoring.weight_utility * utility
 }
 
 // ── Hotness scoring ─────────────────────────────────────────────────
@@ -239,4 +254,70 @@ pub(crate) fn compute_hotness(
 
 fn sigmoid(x: f64) -> f64 {
     1.0 / (1.0 + (-x).exp())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const SIMILARITY: f64 = 0.8;
+    const HOTNESS: f64 = 0.4;
+    const UTILITY: f64 = 0.6;
+
+    /// The default config must produce the exact same value as the pre-v3.9.0
+    /// hard-coded formula (`0.45 * similarity + 0.30 * hotness + 0.25 * utility`).
+    /// Anyone running with no `[graph.scoring]` section in `.recall-echo.toml`
+    /// must see identical scoring output.
+    #[test]
+    fn default_config_matches_legacy_hardcoded_formula() {
+        let scoring = GraphScoringConfig::default();
+        let legacy = 0.45 * SIMILARITY + 0.30 * HOTNESS + 0.25 * UTILITY;
+        let actual = score_with_utility(&scoring, SIMILARITY, HOTNESS, UTILITY);
+        assert!((actual - legacy).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn raising_weight_utility_raises_score_for_high_utility_entity() {
+        let low = GraphScoringConfig {
+            weight_semantic: 0.45,
+            weight_hotness: 0.30,
+            weight_utility: 0.25,
+        };
+        let high = GraphScoringConfig {
+            weight_semantic: 0.25,
+            weight_hotness: 0.25,
+            weight_utility: 0.5,
+        };
+        let high_utility = 0.9;
+        let low_score = score_with_utility(&low, SIMILARITY, HOTNESS, high_utility);
+        let high_score = score_with_utility(&high, SIMILARITY, HOTNESS, high_utility);
+        assert!(
+            high_score > low_score,
+            "boosting weight_utility should raise the score for a high-utility entity \
+             (low={low_score}, high={high_score})"
+        );
+    }
+
+    #[test]
+    fn zero_weights_produce_zero_score() {
+        let scoring = GraphScoringConfig {
+            weight_semantic: 0.0,
+            weight_hotness: 0.0,
+            weight_utility: 0.0,
+        };
+        let score = score_with_utility(&scoring, SIMILARITY, HOTNESS, UTILITY);
+        assert!((score - 0.0).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn custom_weights_compute_linear_combination() {
+        let scoring = GraphScoringConfig {
+            weight_semantic: 0.5,
+            weight_hotness: 0.2,
+            weight_utility: 0.3,
+        };
+        let expected = 0.5 * SIMILARITY + 0.2 * HOTNESS + 0.3 * UTILITY;
+        let actual = score_with_utility(&scoring, SIMILARITY, HOTNESS, UTILITY);
+        assert!((actual - expected).abs() < f64::EPSILON);
+    }
 }

--- a/tests/graph_confidence.rs
+++ b/tests/graph_confidence.rs
@@ -34,7 +34,10 @@ fn bayesian_update_all_priors() {
 fn bayesian_update_contradiction_reduces() {
     let before = 0.6;
     let after = bayesian_update(before, false);
-    assert!(after < before, "contradiction should reduce: {before} -> {after}");
+    assert!(
+        after < before,
+        "contradiction should reduce: {before} -> {after}"
+    );
 }
 
 #[test]
@@ -43,7 +46,10 @@ fn bayesian_update_repeated_corroboration_converges() {
     for _ in 0..50 {
         score = bayesian_update(score, true);
     }
-    assert!(score > 0.95, "50 corroborations should converge near 1.0: {score}");
+    assert!(
+        score > 0.95,
+        "50 corroborations should converge near 1.0: {score}"
+    );
 }
 
 #[test]
@@ -52,7 +58,10 @@ fn bayesian_update_repeated_contradiction_converges() {
     for _ in 0..50 {
         score = bayesian_update(score, false);
     }
-    assert!(score < 0.05, "50 contradictions should converge near 0.0: {score}");
+    assert!(
+        score < 0.05,
+        "50 contradictions should converge near 0.0: {score}"
+    );
 }
 
 // ── Temporal Decay ────────────────────────────────────────────────
@@ -78,13 +87,19 @@ fn decay_at_three_half_lives() {
 #[test]
 fn decay_floor_prevents_zero() {
     let result = temporal_decay(1.0, 10000.0, 90.0);
-    assert_eq!(result, DECAY_FLOOR, "extreme age should hit floor: {result}");
+    assert_eq!(
+        result, DECAY_FLOOR,
+        "extreme age should hit floor: {result}"
+    );
 }
 
 #[test]
 fn decay_floor_with_low_initial() {
     let result = temporal_decay(0.1, 900.0, 90.0);
-    assert_eq!(result, DECAY_FLOOR, "low initial + long time = floor: {result}");
+    assert_eq!(
+        result, DECAY_FLOOR,
+        "low initial + long time = floor: {result}"
+    );
 }
 
 #[test]
@@ -173,7 +188,10 @@ fn effective_confidence_uses_last_reinforced_over_valid_from() {
 
     let result = effective_confidence(0.8, Some(&last_reinforced), &valid_from, &now);
     // Should use 10 days (recent), not 300 days (old)
-    assert!(result > 0.7, "should use last_reinforced (10d), got {result}");
+    assert!(
+        result > 0.7,
+        "should use last_reinforced (10d), got {result}"
+    );
 }
 
 #[test]
@@ -181,5 +199,8 @@ fn effective_confidence_unparseable_returns_stored() {
     let now = chrono::Utc::now();
     let bad = serde_json::Value::String("not-a-date".into());
     let result = effective_confidence(0.8, None, &bad, &now);
-    assert!(approx(result, 0.8), "unparseable should return stored: {result}");
+    assert!(
+        approx(result, 0.8),
+        "unparseable should return stored: {result}"
+    );
 }

--- a/tests/graph_episodes.rs
+++ b/tests/graph_episodes.rs
@@ -18,9 +18,16 @@ async fn add_and_retrieve_episode() {
     let created = db.graph.add_episode(episode).await.unwrap();
     assert_eq!(created.session_id, "session-001");
 
-    let episodes = db.graph.get_episodes_by_session("session-001").await.unwrap();
+    let episodes = db
+        .graph
+        .get_episodes_by_session("session-001")
+        .await
+        .unwrap();
     assert_eq!(episodes.len(), 1);
-    assert_eq!(episodes[0].abstract_text, "Discussed Rust ownership patterns");
+    assert_eq!(
+        episodes[0].abstract_text,
+        "Discussed Rust ownership patterns"
+    );
 }
 
 #[tokio::test]
@@ -63,7 +70,11 @@ async fn multiple_episodes_per_session() {
         db.graph.add_episode(episode).await.unwrap();
     }
 
-    let episodes = db.graph.get_episodes_by_session("session-multi").await.unwrap();
+    let episodes = db
+        .graph
+        .get_episodes_by_session("session-multi")
+        .await
+        .unwrap();
     assert_eq!(episodes.len(), 3);
 }
 

--- a/tests/graph_gc.rs
+++ b/tests/graph_gc.rs
@@ -31,7 +31,10 @@ async fn gc_dry_run_no_mutations() {
     let after = db.graph.stats().await.unwrap();
 
     // Dry run should not delete anything
-    assert_eq!(before.entity_count, after.entity_count, "entities unchanged");
+    assert_eq!(
+        before.entity_count, after.entity_count,
+        "entities unchanged"
+    );
     assert_eq!(
         before.relationship_count, after.relationship_count,
         "relationships unchanged"
@@ -108,7 +111,10 @@ async fn gc_protects_pipeline_entities() {
 
     // Pipeline entity should survive
     let found = db.graph.get_entity("Learning Thread").await.unwrap();
-    assert!(found.is_some(), "pipeline entity should be protected from GC");
+    assert!(
+        found.is_some(),
+        "pipeline entity should be protected from GC"
+    );
 }
 
 #[tokio::test]

--- a/tests/graph_traverse.rs
+++ b/tests/graph_traverse.rs
@@ -19,7 +19,10 @@ async fn traverse_outgoing_edges() {
 
     // Daniel -> BUILDS -> pulse-null
     let result = db.graph.traverse("Daniel", 2).await.unwrap();
-    assert!(!result.edges.is_empty(), "Daniel should have outgoing edges");
+    assert!(
+        !result.edges.is_empty(),
+        "Daniel should have outgoing edges"
+    );
 }
 
 #[tokio::test]
@@ -31,7 +34,10 @@ async fn traverse_no_edges() {
     db.graph.add_entity(entities[0].clone()).await.unwrap();
 
     let result = db.graph.traverse("Rust", 2).await.unwrap();
-    assert!(result.edges.is_empty(), "Rust with no relationships should have no traversal results");
+    assert!(
+        result.edges.is_empty(),
+        "Rust with no relationships should have no traversal results"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Makes the hybrid-query scoring weights config-loadable from `.recall-echo.toml [graph.scoring]`. Previously hard-coded in `graph::search::score_with_utility`. Defaults exactly preserve the existing `0.45 / 0.30 / 0.25` formula, so any deployment without a `[graph.scoring]` section sees identical behavior.

## Why

- Closes a documented drift: the v2 adaptive-learning spec claimed these weights were TOML-loadable, but the implementation never wired it. Caught by the 2026-04-19 active-inference audit.
- Unblocks **pulse-null PR #2** (`feat/utility-feedback-loop`), which needs per-entity tunable weights for the 2-week calibration window following the utility-feedback-loop rollout.
- Implements Component 4 of [`utility-feedback-loop-spec.md`](https://github.com/dnacenta/pulse-null/blob/main/specs/in-progress/utility-feedback-loop-spec.md) in the pulse-null specs vault.

## What changed

- `src/config.rs` — new `GraphScoringConfig` struct (3× f64 fields: `weight_semantic`, `weight_hotness`, `weight_utility`). `Default` impl returns `0.45 / 0.30 / 0.25`. Nested under `[graph.scoring]` via `GraphSection::scoring`.
- `src/graph/search.rs` — `score_with_utility()` takes `&GraphScoringConfig`; both `search()` and `search_with_options()` accept the config arg. Doc comments updated.
- `src/graph/query.rs` — `query()` takes the config through and passes to downstream scoring.
- `src/graph/mod.rs` — `GraphMemory` holds a `scoring: GraphScoringConfig` field, populated from TOML via new `load_scoring_config()` helper with default fallback. Public methods (`search`, `search_with_options`, `query`) pass the held config down.
- `Cargo.toml` — version bumped `3.8.0` → `3.9.0`.
- `tests/` — integration test call sites updated to pass `GraphScoringConfig::default()` where scoring is invoked.

## Behavior preservation

The primary correctness bar. One test locks it in:

```rust
#[test]
fn default_config_matches_legacy_hardcoded_formula() {
    let scoring = GraphScoringConfig::default();
    let legacy = 0.45 * SIMILARITY + 0.30 * HOTNESS + 0.25 * UTILITY;
    let actual = score_with_utility(&scoring, SIMILARITY, HOTNESS, UTILITY);
    assert!((actual - legacy).abs() < f64::EPSILON);
}
```

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --all-targets` — zero new warnings (two pre-existing warnings in `pipeline_sync.rs:200` and `tests/common/mod.rs` unrelated to this PR)
- [x] `cargo test --lib` — 183/183 pass, includes new unit tests for `GraphScoringConfig` defaults, TOML deserialization (full, partial, empty, nested under `[graph]`), and `score_with_utility` under default/zero/custom weights.
- [x] `cargo test --tests -- --test-threads=1` — 40+ integration tests pass across `graph_confidence`, `graph_crud`, `graph_episodes`, `graph_gc`, `graph_traverse`.
- [x] Existing call sites in `tests/` updated and passing with `GraphScoringConfig::default()`.

## Out of scope

- pulse-null-side changes (retrieval manifest emission, caliber → recall-echo feedback bridge, `Surprising` → `None` outcome mapping, entity TOML `[graph.scoring]` additions). Those land in pulse-null PR #2 after this merges and v3.9.0 is published to crates.io.
- Calibration of the default weights. Current defaults are unchanged from the status quo. The calibration plan lives in the pulse-null utility-feedback-loop spec and kicks in after the full loop is in production.