### PR TITLE
feat: GraphMemory::record_outcome_feedback wrapper (v3.10.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,7 +3930,7 @@ checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
 
 [[package]]
 name = "recall-echo"
-version = "3.9.0"
+version = "3.10.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recall-echo"
-version = "3.9.0"
+version = "3.10.0"
 edition = "2021"
 description = "Persistent memory system with knowledge graph — for any LLM tool"
 license = "AGPL-3.0-only"

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -440,6 +440,27 @@ impl GraphMemory {
         vigil_sync::sync_vigil(self, signals_path, outcomes_path).await
     }
 
+    /// Record outcome feedback: link retrieved entities to a session outcome and
+    /// update their `utility_score` via EMA. `used_entity_ids` distinguishes the
+    /// entities the response actually leaned on (full alpha) from retrieved-but-
+    /// unused (muted alpha). Pass `None` to treat all retrieved as used.
+    pub async fn record_outcome_feedback(
+        &self,
+        session_id: &str,
+        outcome: utility::OutcomeKind,
+        retrieved_entity_ids: &[String],
+        used_entity_ids: Option<&[String]>,
+    ) -> Result<utility::FeedbackReport, GraphError> {
+        utility::record_outcome_feedback(
+            &self.db,
+            session_id,
+            outcome,
+            retrieved_entity_ids,
+            used_entity_ids,
+        )
+        .await
+    }
+
     // --- Garbage Collection ---
 
     /// Run garbage collection with the given config.


### PR DESCRIPTION
## Summary

- Adds public wrapper method `GraphMemory::record_outcome_feedback` delegating to the existing `utility::record_outcome_feedback` module function.
- Bumps version to 3.10.0.

## Why

`utility::record_outcome_feedback` was added in v3.8.0 but is unreachable to external callers — `GraphMemory.db` is private and no accessor exists. pulse-null cannot push outcome feedback through the public API today. This unblocks pulse-null v0.30.0 (utility-feedback-loop consumer, Component 3 of `utility-feedback-loop-spec.md`).

## Shape

Matches existing wrapper pattern (`run_gc`, `delete_relationship`, `sync_outcomes`):

```rust
pub async fn record_outcome_feedback(
    &self,
    session_id: &str,
    outcome: utility::OutcomeKind,
    retrieved_entity_ids: &[String],
    used_entity_ids: Option<&[String]>,
) -> Result<utility::FeedbackReport, GraphError>
```

## Test plan

- [x] cargo build --release --no-default-features --features pulse-null,server
- [x] cargo fmt --check
- [x] cargo clippy (no new warnings — the pre-existing `single_match` in vigil_sync.rs is untouched)
- [ ] pulse-null v0.30.0 calls this in three call sites (next PR)