### PR TITLE
chore: bump fastrand 2.4.0 → 2.4.1 (yanked)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,9 +1431,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fax"


### PR DESCRIPTION
## Summary
- `fastrand 2.4.0` was yanked from crates.io; bump to `2.4.1` to clear the warning that surfaced during `cargo publish` of v3.10.0.
- Transitive dep (surrealdb → phf, tempfile); lockfile-only change.

## Followup not in this PR
- `core2 0.4.0` is also yanked but the crate has no other published versions. Removing it requires bumping `fastembed 4.9.1 → 5.x` up through `image → ravif → rav1e → bitstream-io`. Tracked separately.

## Test plan
- [x] `cargo check` passes
- [ ] CI green