### PR TITLE
feat: SessionStart consume hook + Bayesian writeup + LoCoMo bench spec (v3.11.0)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,7 +3930,7 @@ checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
 
 [[package]]
 name = "recall-echo"
-version = "3.10.0"
+version = "3.11.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recall-echo"
-version = "3.10.0"
+version = "3.11.0"
 edition = "2021"
 description = "Persistent memory system with knowledge graph — for any LLM tool"
 license = "AGPL-3.0-only"

--- a/docs/bayesian-confidence.md
+++ b/docs/bayesian-confidence.md
@@ -1,0 +1,200 @@
+# Bayesian Confidence for Agent Memory Graphs
+
+How `recall-echo` treats every relationship in its knowledge graph as a probability distribution, why that matters for long-running autonomous agents, and how it differs from every other open-source memory system currently in the space.
+
+## TL;DR
+
+Most agent-memory systems treat the relationship between two facts as a boolean with a timestamp. `recall-echo` treats it as a Beta distribution. Each edge in the graph carries a calibrated confidence in `[0, 1]` that is updated with a Beta-Binomial conjugate prior on every new observation, then decayed over time with a 90-day half-life at read time. Multi-hop traversal multiplies confidence along the path, so weak chains attenuate automatically without an explicit pruning rule. Outcome feedback flows back through an EMA on per-entity utility scores. A linear combination of semantic similarity, hotness, and utility produces the final retrieval score.
+
+The implementation is a few hundred lines of Rust in `src/graph/confidence.rs`, `src/graph/utility.rs`, `src/graph/search.rs`, and `src/graph/query.rs`. The novelty is not the math — Beta-Binomial is textbook — it is that, as far as I can tell, no other open-source agent-memory system applies it to graph edges.
+
+## Why edge updates matter
+
+An autonomous agent that runs for weeks or months hits the same recurring problem: yesterday's confidently-stated fact is today's stale lie, and the system has no principled way to know which is which. The two dominant patterns in the open-source agent-memory space both fall short here.
+
+**Deterministic timestamps with bi-temporal invalidation** (Graphiti's approach) capture *when* something was true but not *how much* the system should trust it. A relationship that the agent observed once last Tuesday is treated identically to one it has heard nine times across nine independent conversations. Contradiction is binary — either you invalidate the old edge and write a new one, or you don't.
+
+**ADD-only accumulation with a conflict detector** (mem0's approach) sidesteps merge entirely. New observations get appended; conflicts get flagged. This works for short-horizon agents, but for an entity running for months the accumulated noise grows unbounded, and "is this still true?" becomes a query the system cannot answer.
+
+**Full graph rewrites** (Cognee's approach) regenerate the structure when contradictions accumulate. This loses history.
+
+What all three miss: facts decay at different rates, observations have different trustworthiness, and the right merge of "stated three times, contradicted once" is not a deletion or an append — it is a posterior.
+
+## The model — three primitives
+
+### 1. Beta-Binomial confidence on edges
+
+Every relationship starts with a prior determined by how it was extracted, defined in `src/graph/confidence.rs:13-33`:
+
+```
+Authoritative → 1.0
+Explicit      → 0.9
+Inferred      → 0.6
+Speculative   → 0.3
+```
+
+The pseudocount is fixed at 10 (`confidence.rs:10`). This is the only knob that shapes how fast the posterior moves; everything else falls out of conjugacy.
+
+The stored confidence `c` is interpreted as the mean of a Beta distribution with concentration `PSEUDOCOUNT = 10`:
+
+```
+α = c · 10
+β = 10 − α
+```
+
+When a new observation arrives, we add one success (corroboration) or one failure (contradiction):
+
+```
+corroborate:  c' = (α + 1) / (α + β + 1) = (α + 1) / 11
+contradict:   c' =       α / (α + β + 1) =       α / 11
+```
+
+The full implementation is six lines (`confidence.rs:57-66`).
+
+**Worked example.** Take a fact extracted as `Inferred`, so the prior is 0.6 (α=6, β=4).
+
+| Step | Event | α | β | Posterior |
+|------|-------|---|---|-----------|
+| 0 | prior (Inferred) | 6 | 4 | 0.600 |
+| 1 | corroborate | 7 | 4 | 0.636 |
+| 2 | corroborate | 8 | 4 | 0.667 |
+| 3 | corroborate | 9 | 4 | 0.692 |
+| 4 | contradict | 9 | 5 | 0.643 |
+
+Three statements followed by one contradiction land at 0.643 — meaningfully above the prior, well below "certain". This is the property we want. A single contradictory mention does not erase three corroborations, but it does register. Tests in `confidence.rs:139-172` lock the math.
+
+### 2. Temporal decay layered on top
+
+The Bayesian posterior is what's stored. Effective confidence at read time also accounts for staleness:
+
+```
+effective = stored × 0.5^(days_since_reinforced / 90)
+```
+
+implemented in `confidence.rs:85-97`, floored at `DECAY_FLOOR = 0.05` (`confidence.rs:73`). Decay is computed against `last_reinforced` if present, otherwise against `valid_from` (`confidence.rs:102-119`). A corroborating update calls `reinforce_relationship` (see `mod.rs:259-265`), which resets the decay clock — so a fact that keeps getting confirmed never decays.
+
+Why layer decay on top of the posterior rather than baking it into the update? Two reasons:
+
+1. **Decoupling.** The posterior captures *evidence*; decay captures *recency*. A fact stated nine times two years ago and a fact stated three times yesterday are different things, and the system should be able to tell them apart. Mixing the two into one update loses information.
+2. **Cheap reads, cheap writes.** Decay is computed at query time from the timestamp. No background job has to walk the graph and re-score edges every night.
+
+The floor at 0.05 is a deliberate choice: edges never disappear through decay alone. They become low-priority. Garbage collection is a separate concern handled in `src/graph/gc.rs`.
+
+### 3. Path confidence as the edge product
+
+Multi-hop traversal compounds confidence multiplicatively (`confidence.rs:127-129`):
+
+```
+path_confidence([0.8, 0.7, 0.9]) = 0.504
+```
+
+This falls naturally out of treating edges as independent probabilities. The practical effect is that the long tail of weak chains is automatically suppressed. Two hops over 0.9 edges is a stronger signal than four hops over 0.7 edges (`0.81` vs `0.24`) — no special-case pruning needed.
+
+The hybrid query in `src/graph/query.rs:51-97` applies this directly: after the semantic phase identifies the top candidates, graph expansion adds neighbors scored as `parent_score · effective_confidence` (line 83). The effective confidence is computed with temporal decay at read time (`query.rs:158-163`), and edges below 0.1 effective confidence are filtered out (`query.rs:166-168`).
+
+```
+  semantic                graph expansion
+  ─────────               ──────────────
+    [E1: 0.84] ──[0.9]──→ [N1: 0.756]
+       │                      │
+       └───────[0.6]───────→  [N2: 0.504]   ← scored, not pruned
+                                            ← attenuates over hops
+    [E2: 0.71] ──[0.4]──→ [N3: 0.284]       ← below filter floor
+                                              after second hop
+```
+
+## Adaptive utility scoring
+
+The Bayesian model handles *epistemic* uncertainty about whether a relationship holds. A separate layer handles *instrumental* utility: did this entity, when retrieved, actually help the agent succeed?
+
+`src/graph/utility.rs` implements an exponential moving average over per-entity utility scores. Outcomes have rewards (`utility.rs:23-33`):
+
+```
+Success → 1.0
+Partial → 0.5
+Failed  → 0.0
+```
+
+When a session completes, retrieved entities receive an EMA update. The alpha depends on whether the entity was actually used in the response (`utility.rs:62-68`):
+
+```
+USED_ALPHA   = 0.1     // retrieved AND used → full signal
+UNUSED_ALPHA = 0.05    // retrieved but not used → muted
+UNUSED_REWARD = 0.3    // "you retrieved me and ignored me" → slight negative
+```
+
+The update is `new = (1 − α) · current + α · reward`, applied atomically in a single SurrealDB query to avoid read-modify-write races (`utility.rs:239-263`). The convergence test (`utility.rs:342-354`) confirms that ~50 successive successes push a score from 0.5 to >0.99.
+
+These utility scores feed the final retrieval composition in `src/graph/search.rs:226-235`:
+
+```
+final_score = w_semantic · similarity
+            + w_hotness  · hotness
+            + w_utility  · utility_score
+```
+
+Default weights are `0.45 / 0.30 / 0.25` (`search.rs:22-23`), configurable per deployment via `[graph.scoring]` in `.recall-echo.toml`. Hotness itself is a separate signal — `sigmoid(ln(1 + access_count)) · exp(−ln(2)/7 · days)` — capturing recent activity with a 7-day half-life (`search.rs:239-253`).
+
+So the system has two decay clocks operating on different signals at different rates: 7 days for hotness (engagement), 90 days for confidence (epistemic decay). Both are tunable.
+
+## Comparison to the landscape
+
+| System | Edge model | Contradiction handling | Stale-fact handling | Reinforcement |
+|---|---|---|---|---|
+| Graphiti | Bi-temporal validity intervals | Invalidate + new edge | Explicit `valid_to` | None — observation count not tracked |
+| mem0 | ADD-only with conflict tags | Flagged, manual resolve | None | Not represented |
+| Cognee | Graph rewrite on conflict | Regenerate region | Implicit via rewrite | Lost on rewrite |
+| recall-echo | Beta-Binomial posterior | Single contradiction shifts posterior, multiple erode it | Half-life decay at read time | α += 1 + clock reset |
+
+A few honest notes.
+
+**Graphiti's bi-temporal model gives you something Bayesian confidence does not: point-in-time queries.** "What did this agent believe about X on March 14?" is a clean SQL-like query against `valid_from`/`valid_to`. Against a Beta-Binomial graph, the equivalent question is "what was the posterior at that timestamp?" — answerable only if you log every update, which `recall-echo` does not currently do. If point-in-time auditability matters more than calibrated uncertainty for your use case, bi-temporal is the right design.
+
+**mem0's strength is operational simplicity.** No conjugate priors, no half-lives. For short-horizon agents that won't accumulate enough observations for the math to matter, that simplicity is the correct call.
+
+**Cognee's rewrite approach is the most aggressive about consistency** but trades history for it. For an agent whose memory needs to support "why did you think X?" introspection, that's a hard trade.
+
+The case for probabilistic edges is specifically about long-running autonomous entities — systems whose memory is being shaped by hundreds or thousands of observations over months, where the noise floor is high and "this is still probably true" is a useful concept. That is the design center for `recall-echo`.
+
+## Implementation notes
+
+The whole confidence model is ~130 lines of Rust including tests (`src/graph/confidence.rs`). The utility layer is ~365 lines including the SurrealDB feedback edges (`src/graph/utility.rs`). It runs on:
+
+- **SurrealDB** (embedded SurrealKV by default, WebSocket server optional) as the graph store and HNSW vector index
+- **FastEmbed** for local 384-dimension cosine embeddings
+- **Tokio** for async, with `futures::future::join_all` for concurrent per-entity feedback updates (`utility.rs:134`)
+- **AGPL-3.0**, version 3.11.0 at time of writing
+
+A few design choices worth pulling out:
+
+- `PSEUDOCOUNT = 10` was chosen so that ~10 observations are needed to fully overwhelm the prior. Lower values make the posterior twitchy; higher values make corroboration too slow to register. Ten is the conventional weak-prior choice and it tested well in practice.
+- Half-life of 90 days is a default; the constant lives at `confidence.rs:70` and the function signature accepts a per-call value, so per-domain tuning is mechanical.
+- The decay floor at 0.05 is deliberate. Edges below it are still queryable but ranked near the bottom. Hard deletion is a GC concern.
+- The hybrid query filters effective confidence below 0.1 during graph expansion (`query.rs:166`). Below this, the multiplicative chain attenuates results to noise.
+
+## Reproducibility
+
+Source: [`github.com/dnacenta/recall-echo`](https://github.com/dnacenta/recall-echo), AGPL-3.0.
+
+Read in this order:
+
+- `src/graph/confidence.rs` — the Bayesian update, decay, and path composition (~300 lines including tests)
+- `src/graph/utility.rs` — EMA feedback loop and outcome edges
+- `src/graph/search.rs` — final scoring composition
+- `src/graph/query.rs` — hybrid query with confidence-weighted graph expansion
+
+The test suite in `confidence.rs:131-297` covers the update math, the decay function, the floor, and the path product. The utility tests in `utility.rs:301-365` cover EMA math, convergence behavior, and the used-vs-unused asymmetry. Run `cargo test -p recall-echo graph::confidence` and `cargo test -p recall-echo graph::utility` to reproduce.
+
+## Open questions
+
+A few directions that would extend this naturally:
+
+**Learned per-relation-type priors.** The four extraction-context priors (`Authoritative` / `Explicit` / `Inferred` / `Speculative`) are hand-tuned constants. A more honest approach would track the calibration of each context over time — what fraction of "Speculative" claims actually held up under corroboration — and adjust the prior accordingly. This is straightforward Bayesian model-averaging and is currently future work.
+
+**Integration with bi-temporal validity intervals.** The two approaches are not actually in conflict. A Beta-Binomial posterior could be stored alongside `valid_from`/`valid_to` intervals to get both point-in-time queries *and* calibrated uncertainty. The cost is schema complexity. Whether it pays off depends on whether anyone's agent actually issues point-in-time queries — for `recall-echo`'s current use, they don't.
+
+**Per-observation logs.** Storing every update event would enable replay, calibration analysis, and rollback. It would also bloat the graph considerably. The current design treats the posterior as sufficient.
+
+---
+
+`recall-echo` exists because the entity it serves — `pulse-null`, a long-running autonomous Rust runtime — needed a memory layer that wouldn't degrade into noise after a few months of operation. The Bayesian model is the part that earns its keep. The rest is plumbing.

--- a/specs/locomo-benchmark.md
+++ b/specs/locomo-benchmark.md
@@ -1,0 +1,284 @@
+# Spec: LoCoMo Benchmark Harness for recall-echo
+
+**Status**: PROPOSED
+**Scope**: Out-of-tree harness at `/opt/recall-echo-locomo/`; minor library exposure inside `/opt/recall-echo/`
+**Author**: Vigil (drafted) + D (to approve)
+**Date**: 2026-05-13
+
+## Problem
+
+recall-echo has no published benchmark number. Competitors do:
+
+- **mem0** reports 91.6 (LLM-as-judge "J" metric, GPT-4o-mini) on LoCoMo across 1,540 questions, 5 categories.
+- **Zep/Graphiti** reports 94.8% on DMR (different benchmark). On LoCoMo itself the methodology is disputed — Zep originally claimed 84%, mem0 recalculated 58.44%, Zep counter-claimed 75.14%. Both vendors contest each other's setup.
+- **MemMachine, Engram, MemoryLake, Memobase, Backboard** all publish LoCoMo runs.
+
+LoCoMo (snap-research/locomo, arxiv 2402.17753) is the de-facto agent-memory yardstick. Without a number, recall-echo can't be compared. The goal is **one credible, reproducible score** — not chart-topping. The harness must be honest about methodology so we don't end up in a Zep-vs-mem0 dispute.
+
+## Goal
+
+Produce a reproducible LoCoMo run that:
+
+1. Ingests the 10 LoCoMo conversations as recall-echo archives + knowledge-graph extractions.
+2. Answers the 1,540 QA pairs using recall-echo as the retrieval layer behind an LLM agent.
+3. Scores results with the same LLM-as-judge protocol mem0 publishes (GPT-4o-mini, binary J), so numbers are comparable.
+4. Also reports the original LoCoMo F1 (Maharana et al.) so the dispute is sidestepped.
+5. Produces a markdown report with per-category breakdown, token/latency costs, and a methodology section.
+
+## Non-Goals
+
+- Event summarization task (LoCoMo task 2). QA only.
+- Multimodal dialogue generation (LoCoMo task 3). Text only.
+- Beating mem0 or Zep. We want a defensible number, not a marketing claim.
+- Multi-run statistical analysis (mem0 does 10 runs ± stddev). v1 is single-run.
+- DMR benchmark — separate spec if useful later.
+
+## Current State
+
+| Component | File | Status |
+|-----------|------|--------|
+| `archive::archive_session` | `src/archive.rs` | Public, takes JSONL transcript path |
+| `graph::ingest::ingest_archive` | `src/graph/ingest.rs` | Public, takes archive markdown path |
+| `graph::extract` (LLM extraction) | `src/graph/extract.rs` | CLI-only, `--log <N>` per archive |
+| `graph::query::hybrid_query` | `src/graph/query.rs` | Public, semantic + expansion + episodes |
+| `search::ranked_search` | `src/search.rs` | Public, archive line search |
+| `recall_echo::config::Config` | `src/config.rs` | Loads `.recall-echo.toml` |
+| LLM provider abstraction | `src/llm_provider.rs` | Anthropic + OpenAI + Ollama + claude-code |
+| LoCoMo dataset | external | CC BY-NC 4.0, `data/locomo10.json` upstream |
+| LoCoMo eval harness | external | `task_eval/evaluate_qa.py` (F1) — Python |
+| mem0 J-metric harness | external | `mem0/evaluation/metrics/llm_judge.py` — Python |
+
+**Gap**: no Rust-side "drive a conversation through recall-echo programmatically as if it were N entity sessions, then ask M questions" entry point. We need one, but a thin Python harness shelling out to the `recall-echo` CLI is acceptable — and matches how mem0's harness drives its own Python SDK.
+
+## Design
+
+### Layout
+
+A new sibling repo, not inside `/opt/recall-echo/` (LoCoMo data is CC BY-NC, harness pulls in Python deps, separate concern):
+
+```
+/opt/recall-echo-locomo/
+├── README.md
+├── pyproject.toml                 # uv-managed Python env
+├── data/
+│   ├── locomo10.json              # downloaded, gitignored (license)
+│   └── .gitkeep
+├── harness/
+│   ├── __init__.py
+│   ├── ingest.py                  # LoCoMo conv → recall-echo archives
+│   ├── answer.py                  # QA pipeline using recall-echo
+│   ├── judge.py                   # GPT-4o-mini J-metric (mem0-compatible)
+│   ├── f1.py                      # Original LoCoMo F1 (port of snap-research)
+│   ├── report.py                  # Markdown report generator
+│   └── cli.py                     # Typer/argparse entry
+├── runs/                          # per-run outputs (gitignored)
+│   └── 2026-05-XX/
+│       ├── predictions.jsonl
+│       ├── judged.jsonl
+│       ├── scores.json
+│       └── report.md
+└── Makefile                       # make ingest / answer / score / report
+```
+
+Inside `/opt/recall-echo/`, expose two new library functions so the harness doesn't shell out 1,540 times:
+
+- `recall_echo::bench::ingest_conversation(entity_root, conversation_id, sessions)` — accept a LoCoMo `sessions` vec directly, write per-session archives with the correct timestamps, run graph ingest + extract.
+- `recall_echo::bench::answer_question(entity_root, question, provider)` — wraps `graph::hybrid_query` + ranked archive search + MEMORY.md read, builds prompt, calls LLM, returns answer + retrieval trace.
+
+Gated behind a `bench` Cargo feature so production builds don't ship it. Bench feature also exposes a `recall-echo bench` CLI subcommand (`bench answer <question>`, `bench ingest <conv-json>`) so the Python harness can call it cleanly via subprocess.
+
+### Data Flow
+
+```
+┌────────────────────────────────────────────────────────────────────┐
+│  LoCoMo conv (locomo10.json sample_id=conv-1)                      │
+│  ~35 sessions, ~300 turns, ~150 QA pairs                           │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ harness/ingest.py
+┌────────────────────────────────────────────────────────────────────┐
+│  Per-conv entity root: runs/<date>/entities/conv-1/memory/         │
+│  - One archive per session, dated session.timestamp                │
+│  - ARCHIVE.md, EPHEMERAL.md populated as if entity ran live        │
+│  - graph/surreal/ embedded DB                                      │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ recall-echo graph extract --all
+┌────────────────────────────────────────────────────────────────────┐
+│  KG populated: entities, relations, episodes, Bayesian confidence  │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ harness/answer.py (for each QA)
+┌────────────────────────────────────────────────────────────────────┐
+│  recall-echo bench answer "<question>"                             │
+│  → graph hybrid_query + ranked archive search → context bundle     │
+│  → LLM (configurable; default GPT-4o-mini for parity)              │
+│  → predicted_answer + retrieval_trace                              │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ harness/judge.py + harness/f1.py
+┌────────────────────────────────────────────────────────────────────┐
+│  J-metric (GPT-4o-mini, 0/1 binary)                                │
+│  F1-metric (token overlap, normalized)                             │
+│  Per-category aggregates (single/multi/temporal/open/adversarial)  │
+└────────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼ harness/report.py
+┌────────────────────────────────────────────────────────────────────┐
+│  runs/<date>/report.md with scores, methodology, costs             │
+└────────────────────────────────────────────────────────────────────┘
+```
+
+### Why Python harness driving a Rust binary
+
+- LoCoMo upstream tooling is Python; staying compatible with their JSON shape costs nothing.
+- mem0's harness is Python; reusing their judge prompt verbatim avoids prompt-drift disputes.
+- recall-echo's interesting work (graph, retrieval, ingestion) stays in Rust where it lives.
+- Python only orchestrates: read JSON, call `recall-echo bench …`, collect predictions, judge, aggregate.
+
+## Phases
+
+### Phase 1 — Harness scaffold + dataset ingestion
+
+**Goal**: one LoCoMo conversation ingested end-to-end with a populated graph.
+
+Tasks:
+
+1. Bootstrap `/opt/recall-echo-locomo/` with `pyproject.toml`, uv lockfile, Makefile, `.gitignore` (exclude `data/`, `runs/`).
+2. Add `bench` Cargo feature to `/opt/recall-echo/Cargo.toml`. Behind feature: `src/bench/mod.rs`, `src/bench/ingest.rs`, `src/bench/answer.rs`. Wire `bench` subcommand into `src/main.rs`.
+3. Write `harness/ingest.py`:
+   - Parse `data/locomo10.json` (10 conversations).
+   - For each conversation, create `runs/<date>/entities/<sample_id>/`.
+   - Map sessions → archive files. Use session timestamp as `date:` frontmatter. Each session becomes one archive (`conversation-NNN.md`) with speakers as `### User`/`### Assistant` blocks.
+   - Shell out: `recall-echo bench ingest --entity-root <path> --conv-json <session-json>` per session.
+   - After all sessions: `recall-echo graph extract --all --provider openai --model gpt-4o-mini`.
+4. `make ingest CONV=conv-1` works end-to-end. `recall-echo graph status` shows entities + relationships.
+
+Effort: **2 days** (1 day Rust bench feature + library, 1 day Python ingest + dataset wrangling).
+
+Deliverable: one conv ingested, graph populated, archives readable.
+
+### Phase 2 — Question-answering pipeline
+
+**Goal**: answer all 1,540 QA pairs using recall-echo retrieval.
+
+Tasks:
+
+1. Implement `recall_echo::bench::answer_question`:
+   - Call `graph::query::hybrid_query(question, depth=2, episodes=true, limit=20)`.
+   - Fall back to `search::ranked_search` for archive lines (top-5).
+   - Read MEMORY.md (curated layer, but for LoCoMo it'll be empty — that's fine, we document it).
+   - Compose prompt: system instruction + retrieved facts + retrieved episodes + question.
+   - Call LLM via `llm_provider`. Return `BenchAnswer { answer, retrieved_facts, retrieved_episodes, tokens_in, tokens_out, latency_ms }`.
+2. `recall-echo bench answer --entity-root <path> --question "<q>" --model gpt-4o-mini` → JSON to stdout.
+3. `harness/answer.py`:
+   - Iterate `qa[]` for each conversation in `locomo10.json`.
+   - Skip `category == "adversarial"` answers where ground-truth is "no answer" — still ask, judge separately (these are intentionally unanswerable).
+   - Parallel: 10 concurrent (matches mem0's default).
+   - Write `runs/<date>/predictions.jsonl`: `{sample_id, qa_id, category, question, gold_answer, predicted_answer, tokens, latency}`.
+4. `make answer CONV=all` produces predictions.jsonl with 1,540 rows.
+
+Effort: **3 days** (1.5 day Rust answer pipeline + prompt engineering, 1.5 day Python orchestration + rate limiting + checkpointing for resume).
+
+Deliverable: predictions.jsonl complete. Spot-check 20 answers manually before phase 3.
+
+### Phase 3 — Scoring + result reporting
+
+**Goal**: J and F1 scores with per-category breakdown.
+
+Tasks:
+
+1. `harness/judge.py`:
+   - Port mem0's judge prompt verbatim from `mem0/evaluation/metrics/llm_judge.py`. Cite source in comment.
+   - Model: `gpt-4o-mini`. Temperature 0. Binary output 0/1.
+   - Input: question, gold_answer, predicted_answer. Output: `{score: 0|1, reasoning}`.
+   - Parallel 20-wide.
+   - Write `runs/<date>/judged.jsonl`.
+2. `harness/f1.py`:
+   - Port `task_eval/evaluation.py` F1 from snap-research/locomo. Same normalization (lowercase, strip punctuation, strip articles, whitespace-tokenize, set overlap → F1).
+   - Compute per QA, write into judged.jsonl.
+3. `harness/report.py`:
+   - Aggregate by category: single-hop, multi-hop, temporal, open-domain, adversarial.
+   - Emit `scores.json` and `report.md` with: overall J, overall F1, per-category J + F1, total tokens, total cost (rough $), median + p95 latency, methodology section.
+4. `make score` and `make report`.
+
+Effort: **2 days** (judge port + F1 port + report rendering).
+
+Deliverable: `runs/<date>/report.md` with a credible number.
+
+### Phase 4 — Comparison report vs mem0/Graphiti
+
+**Goal**: a public-facing one-pager comparing recall-echo to published competitors.
+
+Tasks:
+
+1. Add comparison table to report.md using public numbers:
+
+   | System | J overall | Single | Multi | Temporal | Open | Adv | Source |
+   |--------|-----------|--------|-------|----------|------|-----|--------|
+   | mem0 (token-efficient) | 91.6 | 76.6 | 92.3 | 93.3 | 70.2 | 57.3 | mem0.ai/research-2 |
+   | Zep | disputed | — | — | — | — | — | arxiv 2501.13956 + issue #5 |
+   | recall-echo | <ours> | … | … | … | … | … | this run |
+
+2. Methodology disclosure section in report:
+   - Judge model + prompt SHA.
+   - Answer model.
+   - Embedding model (FastEmbed default: bge-small-en-v1.5).
+   - Graph config (depth, limit, episode count).
+   - LoCoMo data version (commit SHA of snap-research/locomo).
+   - Total LLM cost.
+3. Write `/opt/recall-echo/docs/benchmarks/locomo.md` summarizing the result with a link to the run output and the harness repo.
+4. Optionally: README badge `LoCoMo J: <score>%`.
+
+Effort: **1 day** (writing + cross-checking competitor numbers).
+
+Deliverable: shareable result, link-ready, with methodology that survives scrutiny.
+
+## Total Effort
+
+**8 days end-to-end** (~64 hours). Realistic with one engineer focused; double it if interleaved.
+
+| Phase | Days | LLM $ rough |
+|-------|------|-------------|
+| 1 — Ingest | 2 | ~$5 (extraction across 10 convs) |
+| 2 — Answer | 3 | ~$15 (1,540 q × gpt-4o-mini) |
+| 3 — Score | 2 | ~$3 (judge runs) |
+| 4 — Report | 1 | $0 |
+
+Total LLM cost per full run: **~$25** using GPT-4o-mini end-to-end. Re-runs cheap.
+
+## Open Questions
+
+1. **Should we use Anthropic models (Sonnet) for answer LLM to match recall-echo's primary provider?** Then we're not apples-to-apples with mem0's GPT-4o-mini. Decision: run **both** — primary = GPT-4o-mini for comparability, secondary = Claude Sonnet 4.7 for "what does recall-echo actually do in production?" Report both. ~$50 total.
+2. **MEMORY.md curation during ingestion?** LoCoMo doesn't simulate a curating agent. Leave MEMORY.md empty and document the limitation, or auto-distill from extracted graph entities? Default: leave empty (faithful to "raw memory" baseline). Note in methodology.
+3. **One entity per conversation, or one entity for all 10?** Cross-conv contamination is bad. Default: one entity root per conv, scrub between.
+4. **Adversarial handling.** Some adversarial QA expect "unanswerable" / refusal. Judge prompt must handle this — mem0's prompt does, we inherit it.
+5. **Re-extraction on re-run.** Graph extraction is non-deterministic. Cache extracted graph by `(conv_id, extract_model, prompt_hash)` to keep re-runs cheap and comparable.
+
+## Risks
+
+- **Cost overrun.** GPT-4o-mini at 1,540 questions × multiple retrievals × judge × possibly Sonnet rerun. Mitigation: per-phase budget gate (`make answer LIMIT=50` for dev runs). Hard ceiling $200/run; abort if exceeded.
+- **Methodology dispute (Zep vs mem0 redux).** Publish judge prompt SHA, dataset SHA, full code; refuse to claim a single number out of context. Always present J alongside F1 alongside cost.
+- **LoCoMo license (CC BY-NC 4.0).** Non-commercial. Harness is fine; results are fine to publish. Don't bundle dataset in our repo — download script only.
+- **Graph extraction latency.** 10 convs × ~35 sessions × extraction ≈ 350 LLM calls during phase 1. With `--delay-ms 200` and concurrency 10, ~15 minutes. Acceptable.
+- **Bench feature drift from production code paths.** If `bench::answer_question` reimplements retrieval instead of reusing existing CLI paths, scores reflect the harness, not recall-echo. Mitigation: `bench::answer_question` is a thin wrapper around `graph::hybrid_query` + `search::ranked_search` + `llm_provider` — same calls a real agent would make. PR review should enforce this.
+- **Judge model deprecation.** GPT-4o-mini may be retired. Pin OpenAI model version (`gpt-4o-mini-2024-07-18` style); document in report.
+
+## Acceptance Criteria
+
+- `make all` runs ingest → answer → score → report end-to-end on a single command.
+- `runs/<date>/report.md` exists with overall J, F1, per-category breakdown, methodology disclosure.
+- Score landed: **target band 60-85% J** (honest expectation; mem0's 91.6% is best-in-class with a tuned algorithm; we want a respectable first number, not a #1 claim).
+- Harness reproducible from clean checkout in <2 hours of wall time.
+- One paragraph in `/opt/recall-echo/docs/benchmarks/locomo.md` linking to the run + methodology.
+
+## References
+
+- LoCoMo paper: https://arxiv.org/abs/2402.17753
+- LoCoMo repo: https://github.com/snap-research/locomo
+- mem0 paper: https://arxiv.org/abs/2504.19413
+- mem0 eval framework: https://github.com/mem0ai/mem0/tree/main/evaluation
+- mem0 91.6% writeup: https://mem0.ai/research-2
+- Zep paper: https://arxiv.org/abs/2501.13956
+- Zep/mem0 methodology dispute: https://github.com/getzep/zep-papers/issues/5
+- MemMachine LoCoMo blog: https://memmachine.ai/blog/2025/09/memmachine-reaches-new-heights-on-locomo/

--- a/src/init.rs
+++ b/src/init.rs
@@ -207,6 +207,7 @@ fn configure_hooks(_entity_root: &Path) -> bool {
 
     let archive_cmd = format!("{recall_bin} archive-session");
     let checkpoint_cmd = format!("{recall_bin} checkpoint --trigger precompact");
+    let consume_cmd = format!("{recall_bin} consume");
 
     // Load existing settings or start fresh
     let mut settings: serde_json::Value = if settings_path.exists() {
@@ -233,6 +234,24 @@ fn configure_hooks(_entity_root: &Path) -> bool {
     };
 
     let mut changed = false;
+
+    // Add SessionStart hook if not already present
+    // Fires once per session (on startup or resume) — injects EPHEMERAL.md
+    // into context via stdout. Skips `clear` (user reset) and `compact`
+    // (we just recovered from a compaction, no prior session to surface).
+    if !hook_exists(hooks, "SessionStart", &consume_cmd) {
+        let arr = hooks
+            .entry("SessionStart")
+            .or_insert_with(|| serde_json::json!([]))
+            .as_array_mut();
+        if let Some(arr) = arr {
+            arr.push(serde_json::json!({
+                "matcher": "startup|resume",
+                "hooks": [{"type": "command", "command": consume_cmd}]
+            }));
+            changed = true;
+        }
+    }
 
     // Add SessionEnd hook if not already present
     if !hook_exists(hooks, "SessionEnd", &archive_cmd) {
@@ -268,7 +287,7 @@ fn configure_hooks(_entity_root: &Path) -> bool {
                 Ok(()) => {
                     print_status(
                         Status::Created,
-                        "Configured SessionEnd + PreCompact hooks in settings.json",
+                        "Configured SessionStart + SessionEnd + PreCompact hooks in settings.json",
                     );
                     return true;
                 }
@@ -306,6 +325,9 @@ fn hook_exists(
                         }
                         if cmd.contains("recall-echo checkpoint") && command.contains("checkpoint")
                         {
+                            return true;
+                        }
+                        if cmd.contains("recall-echo consume") && command.contains("consume") {
                             return true;
                         }
                     }
@@ -437,6 +459,34 @@ mod tests {
         let mut reader = Cursor::new(b"" as &[u8]);
         let result = run_with_reader(Path::new("/nonexistent/path"), &mut reader);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn hook_exists_recognizes_consume_command() {
+        let hooks_json: serde_json::Value = serde_json::json!({
+            "SessionStart": [{
+                "matcher": "startup|resume",
+                "hooks": [{"type": "command", "command": "/usr/local/bin/recall-echo consume"}]
+            }]
+        });
+        let hooks = hooks_json.as_object().unwrap();
+        assert!(hook_exists(hooks, "SessionStart", "recall-echo consume"));
+        assert!(!hook_exists(hooks, "SessionEnd", "recall-echo consume"));
+    }
+
+    #[test]
+    fn hook_exists_distinguishes_archive_from_consume() {
+        let hooks_json: serde_json::Value = serde_json::json!({
+            "SessionEnd": [{
+                "hooks": [{"type": "command", "command": "recall-echo archive-session"}]
+            }]
+        });
+        let hooks = hooks_json.as_object().unwrap();
+        assert!(hook_exists(
+            hooks,
+            "SessionEnd",
+            "recall-echo archive-session"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Three improvements bundled, all in service of closing the gaps identified in the project audit:

### 1. SessionStart hook installation (the missing automation)
The v0.5 spec described a PreToolUse hook to auto-inject EPHEMERAL.md into session context. The CLI command (`recall-echo consume`) shipped, but `init` never wired up the hook. This PR adds it — using `SessionStart` with a `startup|resume` matcher, which is the correct hook today (didn't exist when v0.5 was written) and avoids the per-tool re-injection problem PreToolUse would cause since `consume` is non-destructive.

This is the biggest UX gap in the dev-tool story. After this lands, `cargo install recall-echo && recall-echo init` gives developers fully automatic memory: archive on session end, checkpoint on compact, **and** prior-session context injected on session start.

### 2. Bayesian confidence writeup (`docs/bayesian-confidence.md`)
Technical deep-dive on the project's strongest novelty claim — Beta-Binomial confidence on graph edges, decoupled temporal decay, path confidence as edge product, and the adaptive utility/EMA layer. Grounded throughout in `src/graph/confidence.rs`, `utility.rs`, `search.rs`, `query.rs` with line references. Publishable as a blog post or short paper. Compares honestly against Graphiti (bi-temporal), mem0 (ADD-only), and Cognee (rewrite), including limitations.

### 3. LoCoMo benchmark spec (`specs/locomo-benchmark.md`, **PROPOSED**)
Per-SDD spec for producing a credible LoCoMo number so the project has something to point to alongside mem0's 91.6 and Zep's disputed numbers. Out-of-tree Python harness driving a new `bench` Cargo feature. 4 phases, ~8 days, ~$25-50/run. Target band 60-85% J (honest first-number expectation, not chart-topping). **Awaits review** before any implementation.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets --no-default-features -- -D warnings` clean
- [x] `cargo test --lib init::` — 6 pass (4 existing + 2 new for `hook_exists` recognizing consume command and scoping by event name)
- [ ] CI green on tag push for v3.11.0
- [ ] Manual: `recall-echo init` on a fresh Claude Code install produces SessionStart + SessionEnd + PreCompact entries in settings.json

## Versioning
Minor bump 3.10.0 → 3.11.0. Public behavior change: `init` now installs an additional hook (the others are unchanged; existing settings are preserved idempotently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)