### PR TITLE
v3.11.1: SessionEnd hook fix for non-persisted sessions + first CI test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  test:
+    name: fmt + clippy + test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format check
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Test
+        run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3930,7 +3930,7 @@ checksum = "bbc4a4ea2a66a41a1152c4b3d86e8954dc087bdf33af35446e6e176db4e73c8c"
 
 [[package]]
 name = "recall-echo"
-version = "3.11.0"
+version = "3.11.1"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "recall-echo"
-version = "3.11.0"
+version = "3.11.1"
 edition = "2021"
 description = "Persistent memory system with knowledge graph — for any LLM tool"
 license = "AGPL-3.0-only"

--- a/specs/phase0-unblock-measurement.md
+++ b/specs/phase0-unblock-measurement.md
@@ -1,0 +1,57 @@
+# Phase 0 — Unblock Measurement
+
+**Status**: In progress
+**Date**: 2026-08-04
+**Parent roadmap**: `/opt/pulse-vault/pulse-null/specs/todo/recall-echo-v4-roadmap-spec.md` (Phase 0 of 5)
+**Doctrine**: "No number, no claim" — every later phase (confidence rework, retrieval modernization) must land as a measured before/after. This phase makes measurement possible.
+
+## Problem
+
+Three blockers prevent any measured claim about recall-echo today:
+
+1. **Pending fixes unreleased.** The SessionEnd hook fix (`src/archive.rs`: exit 0 when transcript is missing — the `claude -p --no-session-persistence` case) sits uncommitted; the bench Cargo feature (commit `9491daa`) sits unreleased past the v3.11.0 tag. Downstream (Echo's scheduler) depends on a `|| true` workaround.
+2. **Exclusive lock.** Embedded SurrealKV takes a process-exclusive file lock. Two concurrent invocations hard-fail with a raw LOCK error; this killed the only benchmark pilot run. Server-mode store code exists but is compile-time mutually exclusive with embedded. The constraint is documented nowhere.
+3. **Zero benchmark numbers.** The LoCoMo harness (`/opt/recall-echo-locomo/`) produced one prediction, and it was the LOCK error. LoCoMo itself is discredited (6.4% wrong answer key; judge accepts up to 63% of wrong answers); LongMemEval is the credible target. The hybrid recall path (`src/graph/query.rs`) has zero tests.
+
+## Work items
+
+### 1. Release v3.11.1
+- Commit the `archive.rs` hook fix (already in working tree, verified needed).
+- Delete stray `history.txt`.
+- Tag `v3.11.1`, let CI build binaries, publish to crates.io. Release notes cover: hook fix, bench feature.
+
+### 2. Runtime server mode + transparent auto-start
+- Make embedded-vs-server a **runtime** decision (config + CLI flag), not a compile-time feature split. Both backends compiled in by default.
+- `recall-echo serve` subcommand: long-running daemon owning the DB, listening on a unix socket (default) with idle auto-shutdown (configurable timeout, default 15 min).
+- **Transparent auto-start**: CLI commands and hooks try the socket first; if absent, spawn the daemon in the background and proceed. No user ever needs to run `serve` manually. (D's decision 2026-08-04: no opt-in.)
+- Embedded direct-open remains as fallback (config-disable of serve) and gains lock detection: friendly error naming the constraint + bounded retry/backoff instead of a raw SurrealKV LOCK panic.
+- Document the concurrency model in README (currently zero mentions).
+- One `FastEmbedder` instance lives in the daemon → eliminates per-invocation ONNX model reload as a side effect.
+
+### 3. Benchmark baseline
+- Golden-set fixtures + tests for `query.rs` (hybrid recall path — currently untested).
+- Run LongMemEval (headline) + LoCoMo (legacy, labeled as such) on the current stack (BGE-Small, dense-only), via server mode.
+- Report **retrieval metrics (recall@k, MRR) separately from answer accuracy**; include full-context and filesystem/grep baselines; publish judge prompts.
+- Results land in `docs/benchmarks/baseline-2026-08.md` — the reference every later phase diffs against.
+
+## Acceptance criteria
+
+### Happy path
+- [ ] `v3.11.1` tagged; CI release drafted with binaries; crates.io published; SessionEnd hook with a missing transcript exits 0 with an explanatory note.
+- [ ] Two concurrent `recall-echo graph search` invocations both succeed (via shared daemon) — the pilot's LOCK failure mode is gone.
+- [ ] First CLI/hook invocation with no daemon running transparently starts one and completes; daemon idle-shuts-down after the configured timeout.
+- [ ] Full LongMemEval run completes and `docs/benchmarks/baseline-2026-08.md` exists with retrieval metrics, answer metrics, and both baselines.
+- [ ] `query.rs` golden-set tests pass in CI.
+
+### Edge cases
+- [ ] Stale socket (daemon crashed): client detects, cleans up, respawns, completes.
+- [ ] `serve` disabled by config: embedded path works as before, and a lock collision yields the friendly retry/error, not a raw LOCK panic.
+- [ ] Concurrent auto-start race (two clients, no daemon): exactly one daemon wins; both clients complete.
+
+### Failure modes
+- [ ] Daemon cannot start (port/socket denied): clear error + automatic embedded fallback; no silent hang.
+- [ ] Benchmark harness against a genuinely locked embedded DB: named, actionable error — never a panic.
+
+## Out of scope
+
+Confidence/provenance changes (Phase 1), retrieval changes (Phase 2), MCP server (Phase 3 — but `serve` is designed so MCP can mount on it), default-feature changes (Phase 3).

--- a/specs/phase0-unblock-measurement.md
+++ b/specs/phase0-unblock-measurement.md
@@ -18,11 +18,13 @@ Three blockers prevent any measured claim about recall-echo today:
 ### 1. Release v3.11.1
 - Commit the `archive.rs` hook fix (already in working tree, verified needed).
 - Delete stray `history.txt`.
+- Add a CI test job (`cargo test` + clippy) — the release workflow currently builds only.
 - Tag `v3.11.1`, let CI build binaries, publish to crates.io. Release notes cover: hook fix, bench feature.
+- Ships as its own early PR from this branch, merged and tagged before serve work continues — the hook fix is blocking Echo today and the release must not carry unfinished daemon code.
 
 ### 2. Runtime server mode + transparent auto-start
-- Make embedded-vs-server a **runtime** decision (config + CLI flag), not a compile-time feature split. Both backends compiled in by default.
-- `recall-echo serve` subcommand: long-running daemon owning the DB, listening on a unix socket (default) with idle auto-shutdown (configurable timeout, default 15 min).
+- Make embedded-vs-server a **runtime** decision (config + CLI flag), not a compile-time feature split. Both backends compiled in by default. Mechanism: `surrealdb::engine::any` (`surrealkv://` or `ws://` chosen from config) — also enables pointing at an external SurrealDB server (benchmark harness, VPS).
+- `recall-echo serve` subcommand: long-running daemon owning the DB, listening on a unix socket (default) with idle auto-shutdown (configurable timeout, default 15 min). Protocol: command-level JSON over the socket (the SurrealDB SDK cannot serve its own wire protocol); the daemon holds the single `FastEmbedder`, eliminating per-invocation ONNX reload.
 - **Transparent auto-start**: CLI commands and hooks try the socket first; if absent, spawn the daemon in the background and proceed. No user ever needs to run `serve` manually. (D's decision 2026-08-04: no opt-in.)
 - Embedded direct-open remains as fallback (config-disable of serve) and gains lock detection: friendly error naming the constraint + bounded retry/backoff instead of a raw SurrealKV LOCK panic.
 - Document the concurrency model in README (currently zero mentions).

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -443,6 +443,22 @@ pub fn archive_from_jsonl(
 /// Reads hook input from stdin.
 pub fn run_from_hook() -> Result<(), RecallError> {
     let hook_input = crate::jsonl::read_hook_input()?;
+    run_with_hook_input(&hook_input)
+}
+
+/// Archive the session named by a hook input.
+///
+/// Sessions run with --no-session-persistence never write a transcript.
+/// A missing file is a normal no-op for the hook, not an error — failing
+/// here makes the entire `claude -p` invocation exit nonzero.
+pub fn run_with_hook_input(hook_input: &crate::jsonl::HookInput) -> Result<(), RecallError> {
+    if !Path::new(&hook_input.transcript_path).exists() {
+        eprintln!(
+            "recall-echo: no transcript at {} (session not persisted), nothing to archive",
+            hook_input.transcript_path
+        );
+        return Ok(());
+    }
     let base_dir = crate::paths::claude_dir()?;
     archive_from_jsonl(
         &base_dir,
@@ -720,5 +736,17 @@ mod tests {
 
         let result = archive_conversation(memory, &conv, &summary, "test").unwrap();
         assert_eq!(result.log_number, 0);
+    }
+
+    #[test]
+    fn hook_missing_transcript_exits_ok() {
+        let hook_input = crate::jsonl::HookInput {
+            session_id: "no-persist".into(),
+            transcript_path: "/nonexistent/path/transcript.jsonl".into(),
+            _cwd: None,
+            _hook_event_name: None,
+        };
+        // --no-session-persistence sessions have no transcript: must be Ok, not Err.
+        assert!(run_with_hook_input(&hook_input).is_ok());
     }
 }

--- a/src/dashboard.rs
+++ b/src/dashboard.rs
@@ -279,7 +279,7 @@ pub fn render(recall: &RecallEcho, entity_name: &str, version: &str, max_memory_
         );
 
         let mut sorted: Vec<_> = memory_stats.sections.iter().collect();
-        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        sorted.sort_by_key(|entry| std::cmp::Reverse(entry.1));
         let top: Vec<String> = sorted
             .iter()
             .take(3)
@@ -749,11 +749,7 @@ pub fn parse_ephemeral_entries(recall: &RecallEcho) -> Vec<EphemeralEntry> {
 
 fn memory_bar(count: usize, max: usize) -> String {
     let width = 10;
-    let filled = if max > 0 {
-        (count * width / max).min(width)
-    } else {
-        0
-    };
+    let filled = (count * width).checked_div(max).map_or(0, |f| f.min(width));
     let empty = width - filled;
 
     let color = if count > max * 90 / 100 {

--- a/src/graph/pipeline_sync.rs
+++ b/src/graph/pipeline_sync.rs
@@ -197,9 +197,9 @@ async fn cross_reference_episodes(
                 source: Some("pipeline:cross-ref".into()),
             };
 
-            match gm.add_relationship(new_rel).await {
-                Ok(_) => report.relationships_created += 1,
-                Err(_) => {} // Silently skip — entity name might not match graph entity name
+            // Errors silently skipped — entity name might not match graph entity name
+            if gm.add_relationship(new_rel).await.is_ok() {
+                report.relationships_created += 1;
             }
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -25,7 +25,10 @@ impl TestDb {
     }
 }
 
-// Re-export fixture builders
+// Re-export fixture builders.
+// Each integration-test binary compiles this module independently; not every
+// binary uses every fixture, so unused-code lints don't apply here.
+#[allow(dead_code)]
 pub mod fixtures {
     use recall_echo::graph::types::{EntityType, NewEntity, NewRelationship};
 


### PR DESCRIPTION
Phase 0 / RE-29 increment 1, shipped early because the hook fix is blocking downstream (pulse-null scheduler currently relies on a `|| true` workaround).

- SessionEnd hook exits 0 when the transcript is missing (`--no-session-persistence` sessions never write one) — previously failed the entire `claude -p` invocation
- First CI test job: fmt + clippy + test on push/PR
- Clippy 1.96 lint debt cleared (lib + test targets)
- Version bump 3.11.1; also releases the bench feature (#28) which sat unreleased past v3.11.0

Refs #29