### PR TITLE
Phase 0: unblock measurement — daemon, runtime backend, golden tests, LongMemEval harness

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,9 @@ reqwest = { version = "0.12", default-features = false, features = ["json", "rus
 pulse-system-types = { version = "0.6", optional = true }
 
 [features]
-default = ["embedded"]
+# Both storage backends are compiled in by default; the active one is chosen
+# at runtime via the `[graph] mode` config key (embedded | server).
+default = ["embedded", "server"]
 embedded = ["surrealdb/kv-surrealkv"]
 server = ["surrealdb/protocol-ws"]
 llm = ["reqwest"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ dirs = "6"
 # Graph — knowledge graph with SurrealDB + fastembed
 surrealdb = { version = "3", default-features = false }
 fastembed = { version = "4", default-features = false, features = ["ort-download-binaries", "hf-hub-rustls-tls"] }
-tokio = { version = "1", features = ["rt-multi-thread", "process", "io-util"] }
+tokio = { version = "1", features = ["rt-multi-thread", "process", "io-util", "net", "time", "sync", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }
 thiserror = "2"
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -251,6 +251,11 @@ Knowledge graph operations. See the Architecture section above for the full comm
 - `graph ingest-all` — Scan conversations/ and ingest all un-ingested archives.
 - `graph extract` — LLM-powered entity extraction. Supports `--log <N>` (single archive), `--all` (all un-extracted), `--dry-run`, `--model`, `--provider` (anthropic or openai), `--delay-ms`.
 
+**Daemon:**
+
+- `graph daemon status` — Socket path, pid, version and uptime of the daemon serving this graph.
+- `graph daemon stop` — Stop that daemon. The next graph command starts a fresh one.
+
 **Pipeline & integrations:**
 
 - `graph pipeline sync` — Sync pipeline documents (LEARNING.md, THOUGHTS.md, CURIOSITY.md, REFLECTIONS.md, PRAXIS.md) into the graph. Idempotent — diffs parsed entries vs existing graph entities.
@@ -258,6 +263,19 @@ Knowledge graph operations. See the Architecture section above for the full comm
 - `graph pipeline flow <entity>` — Trace an entity's lineage through the pipeline stages.
 - `graph pipeline stale` — List stale pipeline entities. Supports `--days` (threshold, default 7).
 - `graph vigil-sync` — Sync vigil-pulse metacognitive signals and caliber outcomes into the graph as Measurement and Outcome entities. Supports `--signals-path` and `--outcomes-path`.
+
+### `recall-echo serve`
+
+Runs the graph daemon for a memory directory. You never need to run this by
+hand — graph commands and hooks start it automatically. It exists for
+supervised deployments:
+
+```bash
+recall-echo serve --dir /path/to/memory --foreground
+```
+
+`--foreground` logs to stderr as well as `<memory_dir>/graph/daemon.log` and
+disables idle shutdown, leaving lifetime to systemd.
 
 ## Archive Format
 
@@ -313,6 +331,10 @@ auto_sync = true               # Auto-sync pipeline docs to graph on archive
 [graph]
 mode = "embedded"            # Storage backend: "embedded" (default) or "server"
 url = "ws://localhost:8787"  # SurrealDB server URL (server mode only)
+
+[serve]
+socket_path = ""             # Daemon socket override (default: XDG runtime dir)
+idle_timeout_secs = 3600     # Shut the daemon down after this much inactivity (0 = never)
 ```
 
 | Section | Key | Default | Description |
@@ -325,21 +347,48 @@ url = "ws://localhost:8787"  # SurrealDB server URL (server mode only)
 | `pipeline` | `auto_sync` | `false` | Sync pipeline documents to the knowledge graph on archive |
 | `graph` | `mode` | `embedded` | Storage backend: `embedded` (single-process SurrealKV) or `server` (shared SurrealDB) |
 | `graph` | `url` | `ws://localhost:8787` | SurrealDB server URL, `server` mode only |
+| `serve` | `socket_path` | XDG runtime dir | Daemon socket path override |
+| `serve` | `idle_timeout_secs` | `3600` | Daemon idle shutdown timeout (`0` disables) |
 
 All settings have sensible defaults. Missing file or invalid values fall back silently.
 
 ## Concurrency
 
 The default `embedded` backend (SurrealKV) takes a **process-exclusive file
-lock** on the graph store: one recall-echo process at a time. A second
-process retries briefly with backoff, then fails with a `store locked` error
-naming the holder scenario — it never crashes with a raw LOCK panic.
+lock** on the graph store: one process may hold it at a time. recall-echo
+resolves that with a small daemon rather than with locking rules you have to
+remember.
 
-If you need concurrent access (parallel sessions, benchmarking, other tools
-reading the graph), set `[graph] mode = "server"` and point `url` at a
-running SurrealDB server — the backend is chosen at runtime, no rebuild
-needed. Flat-file layers (MEMORY.md, EPHEMERAL.md, archives) are unaffected
-by any of this.
+**How it works.** The first graph command or hook that needs the store starts
+a daemon in the background (`recall-echo serve`) and talks to it over a unix
+socket in `$XDG_RUNTIME_DIR/recall-echo/`. Every later command — from any
+number of concurrent sessions — goes through that same daemon, so concurrent
+searches, queries and ingests all succeed. The daemon owns the store and the
+embedding model, which also removes the per-command ONNX model reload. After
+`[serve] idle_timeout_secs` of inactivity (default one hour) it exits.
+
+- One daemon **per memory directory**: separate graphs never share a process.
+- **Crash-only**: the daemon keeps no state outside the database. Kill it at
+  any moment; the next command cleans up the dead socket and starts a new one.
+- **No silent fallback**: if the daemon cannot start, the command fails with a
+  named error explaining what went wrong, including the tail of
+  `<memory_dir>/graph/daemon.log`.
+- **Admin commands take the store exclusively.** `graph init`, `gc`,
+  `extract`, `ingest-all`, `pipeline …`, `vigil-sync` and `decay-report` stop
+  the daemon, run in-process, and let the next command start a fresh daemon —
+  so there is exactly one owner of the store at every instant.
+- Inspect it with `graph daemon status`; stop it with `graph daemon stop`.
+
+**External SurrealDB (advanced).** For deployments that already run a
+SurrealDB server (benchmark rigs, shared entity hosts), set
+`[graph] mode = "server"` and point `url` at it. Commands then connect
+directly and no daemon is involved. The backend is chosen at runtime — no
+rebuild needed.
+
+If the embedded store is locked by a foreign process, the daemon retries with
+backoff and then fails with a named `store locked` error — never a raw LOCK
+panic. Flat-file layers (MEMORY.md, EPHEMERAL.md, archives) are unaffected by
+any of this.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -309,6 +309,10 @@ api_base = ""                # Custom API base URL (provider default if empty)
 [pipeline]
 docs_dir = "/path/to/journal"  # Directory containing pipeline documents
 auto_sync = true               # Auto-sync pipeline docs to graph on archive
+
+[graph]
+mode = "embedded"            # Storage backend: "embedded" (default) or "server"
+url = "ws://localhost:8787"  # SurrealDB server URL (server mode only)
 ```
 
 | Section | Key | Default | Description |
@@ -319,8 +323,23 @@ auto_sync = true               # Auto-sync pipeline docs to graph on archive
 | `llm` | `api_base` | provider default | Custom API base URL |
 | `pipeline` | `docs_dir` | — | Path to pipeline documents (LEARNING.md, THOUGHTS.md, etc.) |
 | `pipeline` | `auto_sync` | `false` | Sync pipeline documents to the knowledge graph on archive |
+| `graph` | `mode` | `embedded` | Storage backend: `embedded` (single-process SurrealKV) or `server` (shared SurrealDB) |
+| `graph` | `url` | `ws://localhost:8787` | SurrealDB server URL, `server` mode only |
 
 All settings have sensible defaults. Missing file or invalid values fall back silently.
+
+## Concurrency
+
+The default `embedded` backend (SurrealKV) takes a **process-exclusive file
+lock** on the graph store: one recall-echo process at a time. A second
+process retries briefly with backoff, then fails with a `store locked` error
+naming the holder scenario — it never crashes with a raw LOCK panic.
+
+If you need concurrent access (parallel sessions, benchmarking, other tools
+reading the graph), set `[graph] mode = "server"` and point `url` at a
+running SurrealDB server — the backend is chosen at runtime, no rebuild
+needed. Flat-file layers (MEMORY.md, EPHEMERAL.md, archives) are unaffected
+by any of this.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -374,9 +374,16 @@ embedding model, which also removes the per-command ONNX model reload. After
   named error explaining what went wrong, including the tail of
   `<memory_dir>/graph/daemon.log`.
 - **Admin commands take the store exclusively.** `graph init`, `gc`,
-  `extract`, `ingest-all`, `pipeline …`, `vigil-sync` and `decay-report` stop
-  the daemon, run in-process, and let the next command start a fresh daemon —
-  so there is exactly one owner of the store at every instant.
+  `extract`, `ingest-all`, `pipeline status`/`flow`/`stale`, `vigil-sync` and
+  `decay-report` take an admin lock beside the socket, stop the daemon and run
+  in-process. A command that arrives while that lock is held waits for it
+  instead of starting a daemon, and the lock is released only after the store
+  is closed — so there is exactly one owner of the store at every instant.
+- **Owner-only, both ends.** The socket and its directory are `0700`/`0600`
+  and both ends check the peer's uid, so no other local user can read what you
+  ingest or answer your queries. A `[serve] socket_path` you configure must
+  already exist as a directory only you can write into: recall-echo validates
+  it, but never creates or chmods a directory it did not derive itself.
 - Inspect it with `graph daemon status`; stop it with `graph daemon stop`.
 
 **External SurrealDB (advanced).** For deployments that already run a

--- a/docs/benchmarks/baseline-2026-08.md
+++ b/docs/benchmarks/baseline-2026-08.md
@@ -1,0 +1,57 @@
+# LongMemEval Baseline — August 2026 (Provisional, N=10)
+
+**Run date**: 2026-08-04 · **recall-echo**: feat/RE-29 branch (v3.11.1 + daemon + runtime backend; retrieval stack = BGE-Small-EN-v1.5 384d, dense-only HNSW, 1-hop confidence-weighted expansion)
+**Dataset**: LongMemEval-S (Wu et al.), deterministic stratified 10-question subset (seed 42): 3 temporal-reasoning, 2 multi-session, 2 knowledge-update, 1 each single-session-user/assistant/preference (one `_abs` abstention row among them).
+**Doctrine**: no number, no claim — this is the "before" picture every later phase diffs against. Single run, point estimates, N=10: treat every number as coarse.
+
+## Setup (exact, for reproducibility)
+
+| Stage | Provider | Model |
+|---|---|---|
+| Ingest (extraction + dedup) | Anthropic API | claude-haiku-4-5-20251001 |
+| Answer | claude-code CLI | sonnet |
+| Judge | claude-code CLI | sonnet — LongMemEval's official per-type prompts, verbatim (upstream commit d6dc8b5) |
+
+Harness: `/opt/recall-echo-locomo` @ a8c71e7, `scripts/lme-run.sh` + follow-up stages. One entity root per question; ~540 sessions ingested with LLM extraction. Retrieval ground truth: `answer_session_ids` from the oracle file; retrieval metrics computed independently of the judge.
+
+## Results
+
+### Retrieval (evidence-session recall, n=9 answerable)
+
+| Metric | Value |
+|---|---|
+| MRR | **0.778** |
+| Recall@1 | 0.38 |
+| Recall@3 | 0.648 |
+| Recall@5 / @10 / @full | 0.676 |
+
+### Answer accuracy (official LongMemEval judges, n=9 headline + 1 abstention)
+
+| Category | n | J-score |
+|---|---|---|
+| **Headline (all answerable)** | 9 | **0.0%** |
+| Abstention | 1 | 100% |
+| temporal-reasoning | 3 | 0% |
+| multi-session | 2 | 0% |
+| knowledge-update | 2 | 0% |
+| single-session (u/a/p) | 3 | 0% |
+
+## The headline finding: retrieval works, answer assembly doesn't
+
+The gap between 68% evidence recall and 0% answer accuracy is the result. The failures are not hallucinations — they are honest partial assemblies ("2 items: the boots and the blazer" where gold is 3) and honest give-ups ("I don't have enough information") on questions whose evidence *was retrieved*. The answer path (`bench answer`: top-20 graph facts + top-5 archive snippets + MEMORY.md into one prompt) is structurally insufficient for LongMemEval's dominant question classes — cross-session aggregation and temporal reasoning — which require assembling *many* small facts, not finding one good passage.
+
+Implications for Phase 2 (retrieval modernization): reranking and hybrid retrieval will lift Recall@1 (0.38 is weak — the right session is usually present but not first), but the larger lever this baseline exposes is **answer-context assembly** — how much retrieved material reaches the answering model and in what form. The golden-set findings (graph expansion inert on small result sets; graph corroboration discarded; near-binary confidence at retrieval) compound the same direction.
+
+Field context, not comparable directly (different N, different answer stacks): Zep reports 63.8% LongMemEval; full-context GPT-class baselines ~60-80% by type. recall-echo's current answer stage was never tuned for this benchmark; that is precisely what makes this a useful "before."
+
+## Cost findings (unplanned but load-bearing)
+
+Ingest via API consumed ~$30 for ~540 sessions (~$3/question) — ~5× the pre-run estimate. Per-conversation ingest wall-time varied 600s→5,400s (9×): consistent with **dedup escalation** — each new entity triggers LLM dedup against a growing candidate set, so cost scales super-linearly with graph size. This is empirical confirmation of the audit's dedup-gating concern and a Phase 2 cost target in its own right: fixing dedup cheapens every future benchmark run ~5×.
+
+## Known gaps in this run (honest list)
+
+- **N=10.** The 50-question stratified run is specced and scripted; deferred until dedup costs drop (or credits allow). Same subset-selection code guarantees comparability.
+- **Full-context and grep baselines not yet run** (would cost more than the system run itself at 115k tokens/question); required before any *published* comparison.
+- Answer/judge ran via CLI (subscription), ingest via API — model families documented above; the judged system is unaffected by judge transport.
+- Single run, no variance estimate. Provider defaults for temperature.
+- Question dates injected as a `[Current date: …]` prefix (bench answer has no native date parameter); judges see the bare question.

--- a/specs/phase0-unblock-measurement.md
+++ b/specs/phase0-unblock-measurement.md
@@ -1,6 +1,6 @@
 # Phase 0 — Unblock Measurement
 
-**Status**: In progress
+**Status**: Done (2026-08-04) — AC4 delivered as provisional N=10 baseline; 50-question run + full-context/grep baselines deferred by decision (see drift note on AC4)
 **Date**: 2026-08-04
 **Parent roadmap**: `/opt/pulse-vault/pulse-null/specs/todo/recall-echo-v4-roadmap-spec.md` (Phase 0 of 5)
 **Doctrine**: "No number, no claim" — every later phase (confidence rework, retrieval modernization) must land as a measured before/after. This phase makes measurement possible.
@@ -43,7 +43,7 @@ Three blockers prevent any measured claim about recall-echo today:
 - [ ] `v3.11.1` tagged; CI release drafted with binaries; crates.io published; SessionEnd hook with a missing transcript exits 0 with an explanatory note.
 - [ ] Two concurrent `recall-echo graph search` invocations both succeed (via shared daemon) — the pilot's LOCK failure mode is gone.
 - [ ] First CLI/hook invocation with no daemon running transparently starts one and completes; daemon idle-shuts-down after the configured timeout.
-- [ ] Full LongMemEval run completes and `docs/benchmarks/baseline-2026-08.md` exists with retrieval metrics, answer metrics, and both baselines.
+- [x] *(rescoped 2026-08-04)* Provisional N=10 LongMemEval run complete; `docs/benchmarks/baseline-2026-08.md` exists with retrieval metrics (MRR .778, R@3 .648) separated from answer metrics (0/9 headline — assembly bottleneck identified). 50-question run and full-context/grep baselines deferred until Phase 2 reduces dedup cost (~5x ingest-estimate overrun, D's decision); same subset code guarantees comparability.
 - [ ] `query.rs` golden-set tests pass in CI.
 
 ### Edge cases

--- a/specs/phase0-unblock-measurement.md
+++ b/specs/phase0-unblock-measurement.md
@@ -26,7 +26,8 @@ Three blockers prevent any measured claim about recall-echo today:
 - Make embedded-vs-server a **runtime** decision (config + CLI flag), not a compile-time feature split. Both backends compiled in by default. Mechanism: `surrealdb::engine::any` (`surrealkv://` or `ws://` chosen from config) — also enables pointing at an external SurrealDB server (benchmark harness, VPS).
 - `recall-echo serve` subcommand: long-running daemon owning the DB, listening on a unix socket (default) with idle auto-shutdown (configurable timeout, default 15 min). Protocol: command-level JSON over the socket (the SurrealDB SDK cannot serve its own wire protocol); the daemon holds the single `FastEmbedder`, eliminating per-invocation ONNX reload.
 - **Transparent auto-start**: CLI commands and hooks try the socket first; if absent, spawn the daemon in the background and proceed. No user ever needs to run `serve` manually. (D's decision 2026-08-04: no opt-in.)
-- Embedded direct-open remains as fallback (config-disable of serve) and gains lock detection: friendly error naming the constraint + bounded retry/backoff instead of a raw SurrealKV LOCK panic.
+- **Daemon-only UX** (D's decision 2026-08-04, supersedes the earlier fallback design): every graph command and hook goes through the daemon — no embedded fallback path, no user-facing mode switch, no `serve.enabled` toggle. If the daemon cannot start, that is a clear error, not a silent degradation. The direct embedded open remains **internal only** (it is what the daemon and the test suite use). The `[graph] mode = "server"` key survives as an *advanced* config for deployments with an external SurrealDB (Echo's VPS, benchmark rigs) and is documented as such, not as a normal choice.
+- Embedded open (inside the daemon) keeps lock detection: friendly error naming the constraint + bounded retry/backoff instead of a raw SurrealKV LOCK panic — covers a stale daemon or foreign process holding the store.
 - Document the concurrency model in README (currently zero mentions).
 - One `FastEmbedder` instance lives in the daemon → eliminates per-invocation ONNX model reload as a side effect.
 
@@ -47,12 +48,12 @@ Three blockers prevent any measured claim about recall-echo today:
 
 ### Edge cases
 - [ ] Stale socket (daemon crashed): client detects, cleans up, respawns, completes.
-- [ ] `serve` disabled by config: embedded path works as before, and a lock collision yields the friendly retry/error, not a raw LOCK panic.
+- [ ] Advanced `mode = "server"` config (external SurrealDB): commands connect directly, no daemon involved — Echo's VPS layout keeps working.
 - [ ] Concurrent auto-start race (two clients, no daemon): exactly one daemon wins; both clients complete.
 
 ### Failure modes
-- [ ] Daemon cannot start (port/socket denied): clear error + automatic embedded fallback; no silent hang.
-- [ ] Benchmark harness against a genuinely locked embedded DB: named, actionable error — never a panic.
+- [ ] Daemon cannot start (socket denied, spawn fails): clear, named error telling the user what failed — no silent hang, no silent fallback.
+- [ ] Daemon (or foreign process) already holds the store when a new daemon starts: bounded retry, then named `store locked` error — never a raw LOCK panic.
 
 ## Out of scope
 

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -307,33 +307,35 @@ pub fn pipeline_sync_on_archive(memory_dir: &Path) {
         }
     };
 
-    if let Err(e) = rt.block_on(async {
-        let gm = crate::graph::GraphMemory::open(&graph_dir)
-            .await
-            .map_err(|e| format!("graph open: {e}"))?;
+    // Pipeline sync is an admin operation: it takes the store exclusively,
+    // stopping the daemon the ingest above may have started. The next graph
+    // command starts a fresh one.
+    if let Err(e) = rt.block_on(crate::serve_client::exclusive(
+        memory_dir,
+        |gm| async move {
+            let docs = crate::graph::types::PipelineDocuments {
+                learning: read_opt_file(&docs_dir, "LEARNING.md"),
+                thoughts: read_opt_file(&docs_dir, "THOUGHTS.md"),
+                curiosity: read_opt_file(&docs_dir, "CURIOSITY.md"),
+                reflections: read_opt_file(&docs_dir, "REFLECTIONS.md"),
+                praxis: read_opt_file(&docs_dir, "PRAXIS.md"),
+            };
 
-        let docs = crate::graph::types::PipelineDocuments {
-            learning: read_opt_file(&docs_dir, "LEARNING.md"),
-            thoughts: read_opt_file(&docs_dir, "THOUGHTS.md"),
-            curiosity: read_opt_file(&docs_dir, "CURIOSITY.md"),
-            reflections: read_opt_file(&docs_dir, "REFLECTIONS.md"),
-            praxis: read_opt_file(&docs_dir, "PRAXIS.md"),
-        };
+            let report = gm.sync_pipeline(&docs).await?;
 
-        let report = gm.sync_pipeline(&docs).await.map_err(|e| format!("{e}"))?;
+            if report.entities_created > 0
+                || report.entities_updated > 0
+                || report.entities_archived > 0
+            {
+                eprintln!(
+                    "recall-echo: pipeline synced — +{} created, ~{} updated, -{} archived",
+                    report.entities_created, report.entities_updated, report.entities_archived
+                );
+            }
 
-        if report.entities_created > 0
-            || report.entities_updated > 0
-            || report.entities_archived > 0
-        {
-            eprintln!(
-                "recall-echo: pipeline synced — +{} created, ~{} updated, -{} archived",
-                report.entities_created, report.entities_updated, report.entities_archived
-            );
-        }
-
-        Ok::<(), String>(())
-    }) {
+            Ok(())
+        },
+    )) {
         eprintln!("recall-echo: pipeline sync warning: {e}");
     }
 }
@@ -370,23 +372,19 @@ async fn pipeline_sync_on_archive_async(memory_dir: &Path) {
         return;
     }
 
-    let gm = match crate::graph::GraphMemory::open(&graph_dir).await {
-        Ok(gm) => gm,
-        Err(e) => {
-            eprintln!("recall-echo: pipeline sync open error: {e}");
-            return;
-        }
-    };
+    let synced = crate::serve_client::exclusive(memory_dir, |gm| async move {
+        let docs = crate::graph::types::PipelineDocuments {
+            learning: read_opt_file(&docs_dir, "LEARNING.md"),
+            thoughts: read_opt_file(&docs_dir, "THOUGHTS.md"),
+            curiosity: read_opt_file(&docs_dir, "CURIOSITY.md"),
+            reflections: read_opt_file(&docs_dir, "REFLECTIONS.md"),
+            praxis: read_opt_file(&docs_dir, "PRAXIS.md"),
+        };
+        Ok(gm.sync_pipeline(&docs).await?)
+    })
+    .await;
 
-    let docs = crate::graph::types::PipelineDocuments {
-        learning: read_opt_file(&docs_dir, "LEARNING.md"),
-        thoughts: read_opt_file(&docs_dir, "THOUGHTS.md"),
-        curiosity: read_opt_file(&docs_dir, "CURIOSITY.md"),
-        reflections: read_opt_file(&docs_dir, "REFLECTIONS.md"),
-        praxis: read_opt_file(&docs_dir, "PRAXIS.md"),
-    };
-
-    match gm.sync_pipeline(&docs).await {
+    match synced {
         Ok(report) => {
             if report.entities_created > 0
                 || report.entities_updated > 0

--- a/src/archive.rs
+++ b/src/archive.rs
@@ -249,7 +249,7 @@ pub fn graph_ingest(memory_dir: &Path, result: &ArchiveResult) {
     if result.log_number == 0 {
         return;
     }
-    let rt = match tokio::runtime::Runtime::new() {
+    let rt = match client_runtime() {
         Ok(rt) => rt,
         Err(e) => {
             eprintln!("recall-echo: graph runtime error: {e}");
@@ -266,14 +266,22 @@ pub fn graph_ingest(memory_dir: &Path, result: &ArchiveResult) {
     }
 }
 
-/// Sync pipeline documents into the graph (if auto_sync enabled).
-///
-/// Non-blocking: logs warnings on failure but never fails the caller.
-pub fn pipeline_sync_on_archive(memory_dir: &Path) {
+/// A runtime for a client-side command: a handful of socket round-trips, plus
+/// whatever the daemon does on our behalf. One thread is enough — the worker
+/// pool of a multi-thread runtime exists to be idle here.
+fn client_runtime() -> std::io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+}
+
+/// The pipeline documents to sync, or `None` when auto-sync is off, no
+/// `docs_dir` is configured, or there is no graph to sync into.
+fn pipeline_docs_to_sync(memory_dir: &Path) -> Option<crate::graph::types::PipelineDocuments> {
     let cfg = config::load_from_dir(memory_dir);
     let pipeline = match cfg.pipeline {
         Some(ref p) if p.auto_sync == Some(true) => p,
-        _ => return,
+        _ => return None,
     };
 
     let docs_dir = match pipeline.docs_dir {
@@ -284,107 +292,52 @@ pub fn pipeline_sync_on_archive(memory_dir: &Path) {
                     "recall-echo: pipeline docs_dir not found: {}",
                     path.display()
                 );
-                return;
+                return None;
             }
             path
         }
         None => {
             eprintln!("recall-echo: pipeline auto_sync enabled but no docs_dir configured");
-            return;
+            return None;
         }
     };
 
-    let graph_dir = memory_dir.join("graph");
-    if !graph_dir.exists() {
-        return;
+    if !memory_dir.join("graph").exists() {
+        return None;
     }
+    Some(read_pipeline_docs(&docs_dir))
+}
 
-    let rt = match tokio::runtime::Runtime::new() {
+/// Sync pipeline documents into the graph (if auto_sync enabled).
+///
+/// Non-blocking: logs warnings on failure but never fails the caller.
+pub fn pipeline_sync_on_archive(memory_dir: &Path) {
+    let Some(docs) = pipeline_docs_to_sync(memory_dir) else {
+        return;
+    };
+    let rt = match client_runtime() {
         Ok(rt) => rt,
         Err(e) => {
             eprintln!("recall-echo: pipeline sync runtime error: {e}");
             return;
         }
     };
-
-    // Pipeline sync is an admin operation: it takes the store exclusively,
-    // stopping the daemon the ingest above may have started. The next graph
-    // command starts a fresh one.
-    if let Err(e) = rt.block_on(crate::serve_client::exclusive(
-        memory_dir,
-        |gm| async move {
-            let docs = crate::graph::types::PipelineDocuments {
-                learning: read_opt_file(&docs_dir, "LEARNING.md"),
-                thoughts: read_opt_file(&docs_dir, "THOUGHTS.md"),
-                curiosity: read_opt_file(&docs_dir, "CURIOSITY.md"),
-                reflections: read_opt_file(&docs_dir, "REFLECTIONS.md"),
-                praxis: read_opt_file(&docs_dir, "PRAXIS.md"),
-            };
-
-            let report = gm.sync_pipeline(&docs).await?;
-
-            if report.entities_created > 0
-                || report.entities_updated > 0
-                || report.entities_archived > 0
-            {
-                eprintln!(
-                    "recall-echo: pipeline synced — +{} created, ~{} updated, -{} archived",
-                    report.entities_created, report.entities_updated, report.entities_archived
-                );
-            }
-
-            Ok(())
-        },
-    )) {
-        eprintln!("recall-echo: pipeline sync warning: {e}");
-    }
+    report_pipeline_sync(rt.block_on(crate::graph_bridge::sync_pipeline_into_graph(
+        memory_dir, docs,
+    )));
 }
 
 /// Async version of pipeline_sync_on_archive for use in async contexts (pulse-null).
 #[cfg(feature = "pulse-null")]
 async fn pipeline_sync_on_archive_async(memory_dir: &Path) {
-    let cfg = config::load_from_dir(memory_dir);
-    let pipeline = match cfg.pipeline {
-        Some(ref p) if p.auto_sync == Some(true) => p.clone(),
-        _ => return,
-    };
-
-    let docs_dir = match pipeline.docs_dir {
-        Some(ref d) => {
-            let path = std::path::PathBuf::from(shellexpand_path(d));
-            if !path.exists() {
-                eprintln!(
-                    "recall-echo: pipeline docs_dir not found: {}",
-                    path.display()
-                );
-                return;
-            }
-            path
-        }
-        None => {
-            eprintln!("recall-echo: pipeline auto_sync enabled but no docs_dir configured");
-            return;
-        }
-    };
-
-    let graph_dir = memory_dir.join("graph");
-    if !graph_dir.exists() {
+    let Some(docs) = pipeline_docs_to_sync(memory_dir) else {
         return;
-    }
+    };
+    report_pipeline_sync(crate::graph_bridge::sync_pipeline_into_graph(memory_dir, docs).await);
+}
 
-    let synced = crate::serve_client::exclusive(memory_dir, |gm| async move {
-        let docs = crate::graph::types::PipelineDocuments {
-            learning: read_opt_file(&docs_dir, "LEARNING.md"),
-            thoughts: read_opt_file(&docs_dir, "THOUGHTS.md"),
-            curiosity: read_opt_file(&docs_dir, "CURIOSITY.md"),
-            reflections: read_opt_file(&docs_dir, "REFLECTIONS.md"),
-            praxis: read_opt_file(&docs_dir, "PRAXIS.md"),
-        };
-        Ok(gm.sync_pipeline(&docs).await?)
-    })
-    .await;
-
-    match synced {
+fn report_pipeline_sync(result: Result<crate::graph::types::PipelineSyncReport, RecallError>) {
+    match result {
         Ok(report) => {
             if report.entities_created > 0
                 || report.entities_updated > 0
@@ -397,6 +350,16 @@ async fn pipeline_sync_on_archive_async(memory_dir: &Path) {
             }
         }
         Err(e) => eprintln!("recall-echo: pipeline sync warning: {e}"),
+    }
+}
+
+fn read_pipeline_docs(docs_dir: &Path) -> crate::graph::types::PipelineDocuments {
+    crate::graph::types::PipelineDocuments {
+        learning: read_opt_file(docs_dir, "LEARNING.md"),
+        thoughts: read_opt_file(docs_dir, "THOUGHTS.md"),
+        curiosity: read_opt_file(docs_dir, "CURIOSITY.md"),
+        reflections: read_opt_file(docs_dir, "REFLECTIONS.md"),
+        praxis: read_opt_file(docs_dir, "PRAXIS.md"),
     }
 }
 
@@ -420,7 +383,8 @@ fn shellexpand_path(path: &str) -> String {
 /// Archive a session from a JSONL transcript file.
 ///
 /// Parses JSONL, generates algorithmic summary, archives, and optionally
-/// ingests into the knowledge graph.
+/// ingests into the knowledge graph. Both graph steps are daemon requests, so
+/// the hook pays for one warm store and one embedding-model load, not two.
 pub fn archive_from_jsonl(
     base_dir: &Path,
     session_id: &str,

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use std::path::Path;
 use serde::{Deserialize, Serialize};
 
 const DEFAULT_MAX_ENTRIES: usize = 5;
+const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 3600;
 const CONFIG_FILE: &str = ".recall-echo.toml";
 
 // ── Provider enum ────────────────────────────────────────────────────────
@@ -71,6 +72,8 @@ pub struct Config {
     pub pipeline: Option<PipelineSection>,
     #[serde(default)]
     pub graph: Option<GraphSection>,
+    #[serde(default)]
+    pub serve: ServeSection,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -182,6 +185,31 @@ impl Default for GraphSection {
             username: String::new(),
             password_file: String::new(),
             scoring: GraphScoringConfig::default(),
+        }
+    }
+}
+
+/// Settings for the `recall-echo serve` graph daemon.
+///
+/// Maps to the `[serve]` section of `.recall-echo.toml`. The daemon is started
+/// transparently by graph commands and hooks when `[graph] mode = "embedded"`
+/// (the default); these keys only tune where it listens and how long it lives.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ServeSection {
+    /// Override the unix socket path. Defaults to
+    /// `$XDG_RUNTIME_DIR/recall-echo/<hash of memory dir>.sock`.
+    pub socket_path: Option<String>,
+    /// Seconds of inactivity before the daemon shuts itself down.
+    /// `0` disables idle shutdown. Default `3600`.
+    pub idle_timeout_secs: u64,
+}
+
+impl Default for ServeSection {
+    fn default() -> Self {
+        Self {
+            socket_path: None,
+            idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
         }
     }
 }
@@ -351,6 +379,21 @@ impl Config {
                 section.auto_sync = Some(b);
                 Ok(())
             }
+            "serve.idle_timeout_secs" => {
+                let secs: u64 = value
+                    .parse()
+                    .map_err(|_| RecallError::Config(format!("invalid number: {value}")))?;
+                self.serve.idle_timeout_secs = secs;
+                Ok(())
+            }
+            "serve.socket_path" => {
+                self.serve.socket_path = if value.trim().is_empty() {
+                    None
+                } else {
+                    Some(value.to_string())
+                };
+                Ok(())
+            }
             other => Err(RecallError::Config(format!("unknown config key: {other}"))),
         }
     }
@@ -388,6 +431,31 @@ mod tests {
         let g = cfg.graph.unwrap();
         assert_eq!(g.mode, "server");
         assert_eq!(g.url, "ws://db.local:8787");
+    }
+
+    #[test]
+    fn serve_defaults_when_section_absent() {
+        let cfg: Config = toml::from_str("[ephemeral]\nmax_entries = 3\n").unwrap();
+        assert_eq!(cfg.serve.idle_timeout_secs, DEFAULT_IDLE_TIMEOUT_SECS);
+        assert!(cfg.serve.socket_path.is_none());
+    }
+
+    #[test]
+    fn serve_section_parses_overrides() {
+        let cfg: Config = toml::from_str(
+            "[serve]\nsocket_path = \"/run/re/graph.sock\"\nidle_timeout_secs = 60\n",
+        )
+        .unwrap();
+        assert_eq!(cfg.serve.idle_timeout_secs, 60);
+        assert_eq!(cfg.serve.socket_path.as_deref(), Some("/run/re/graph.sock"));
+    }
+
+    #[test]
+    fn set_key_serve_idle_timeout() {
+        let mut cfg = Config::default();
+        cfg.set_key("serve.idle_timeout_secs", "120").unwrap();
+        assert_eq!(cfg.serve.idle_timeout_secs, 120);
+        assert!(cfg.set_key("serve.idle_timeout_secs", "soon").is_err());
     }
 
     #[test]
@@ -439,6 +507,7 @@ mod tests {
             },
             pipeline: None,
             graph: None,
+            serve: ServeSection::default(),
         };
         let s = toml::to_string_pretty(&cfg).unwrap();
         let parsed: Config = toml::from_str(&s).unwrap();
@@ -497,6 +566,7 @@ mod tests {
             },
             pipeline: None,
             graph: None,
+            serve: ServeSection::default(),
         };
         save(tmp.path(), &cfg).unwrap();
         let loaded = load(tmp.path());
@@ -518,6 +588,7 @@ mod tests {
             llm: LlmSection::default(),
             pipeline: None,
             graph: None,
+            serve: ServeSection::default(),
         });
         assert_eq!(cfg.ephemeral.max_entries, 5);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -376,6 +376,21 @@ mod tests {
     }
 
     #[test]
+    fn graph_mode_defaults_to_embedded() {
+        let cfg: Config = toml::from_str("[graph]\n").unwrap();
+        assert_eq!(cfg.graph.unwrap().mode, "embedded");
+    }
+
+    #[test]
+    fn graph_mode_parses_server() {
+        let cfg: Config =
+            toml::from_str("[graph]\nmode = \"server\"\nurl = \"ws://db.local:8787\"\n").unwrap();
+        let g = cfg.graph.unwrap();
+        assert_eq!(g.mode, "server");
+        assert_eq!(g.url, "ws://db.local:8787");
+    }
+
+    #[test]
     fn parse_llm_section() {
         let cfg: Config = toml::from_str(
             "[llm]\nprovider = \"openai\"\nmodel = \"llama3.1\"\napi_base = \"http://myhost:11434/v1\"\n",

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,6 +36,15 @@ pub enum RecallError {
     #[error("graph: {0}")]
     Graph(#[from] GraphError),
 
+    /// The graph daemon could not be reached or started. Carries an actionable
+    /// message — there is no silent fallback to a direct store open.
+    #[error("graph daemon: {0}")]
+    Daemon(String),
+
+    /// A failure reported by the graph daemon, with its stable error code.
+    #[error("{message}")]
+    Remote { code: String, message: String },
+
     /// General errors that don't fit other categories.
     #[error("{0}")]
     Other(String),

--- a/src/graph/embed.rs
+++ b/src/graph/embed.rs
@@ -30,6 +30,48 @@ impl FastEmbedder {
     }
 }
 
+/// Lazily-initialized [`FastEmbedder`].
+///
+/// Construction is free — the ONNX model is loaded (and downloaded on first
+/// ever use) only when an operation actually needs an embedding. Operations
+/// that never embed (schema init, CRUD reads, GC, status) never touch the
+/// network or pay the model-load cost. This also keeps unit tests that open
+/// a graph store fully offline.
+pub struct LazyEmbedder {
+    cache_dir: std::path::PathBuf,
+    cell: std::sync::OnceLock<FastEmbedder>,
+    init_lock: std::sync::Mutex<()>,
+}
+
+impl LazyEmbedder {
+    pub fn new(cache_dir: &Path) -> Self {
+        Self {
+            cache_dir: cache_dir.to_path_buf(),
+            cell: std::sync::OnceLock::new(),
+            init_lock: std::sync::Mutex::new(()),
+        }
+    }
+
+    /// Get the embedder, initializing it on first use.
+    pub fn get(&self) -> Result<&FastEmbedder, GraphError> {
+        if let Some(e) = self.cell.get() {
+            return Ok(e);
+        }
+        // Serialize initialization; losers of the race find the cell filled.
+        let _guard = self
+            .init_lock
+            .lock()
+            .map_err(|_| GraphError::Embed("embedder init lock poisoned".into()))?;
+        if self.cell.get().is_none() {
+            let embedder = FastEmbedder::new(&self.cache_dir)?;
+            let _ = self.cell.set(embedder);
+        }
+        self.cell
+            .get()
+            .ok_or_else(|| GraphError::Embed("embedder cell empty after init".into()))
+    }
+}
+
 impl Embedder for FastEmbedder {
     fn embed(&self, texts: Vec<&str>) -> Result<Vec<Vec<f32>>, GraphError> {
         let docs: Vec<String> = texts.into_iter().map(|t| t.to_string()).collect();

--- a/src/graph/error.rs
+++ b/src/graph/error.rs
@@ -6,6 +6,9 @@ pub enum GraphError {
     #[error("database: {0}")]
     Db(#[from] surrealdb::Error),
 
+    #[error("store locked: {0}")]
+    Locked(String),
+
     #[error("embedding: {0}")]
     Embed(String),
 

--- a/src/graph/ingest.rs
+++ b/src/graph/ingest.rs
@@ -87,6 +87,23 @@ pub async fn extract_from_archive(
     Ok(report)
 }
 
+/// Extract one chunk, tagged with its index.
+///
+/// A named async fn rather than an inline `async move` block: the inline form
+/// makes the resulting stream non-`Send` (the closure would have to implement
+/// `FnOnce` for any two lifetimes), and the serve daemon runs ingestion inside
+/// a spawned tokio task.
+async fn extract_indexed(
+    llm: &dyn LlmProvider,
+    chunk: &str,
+    session_id: &str,
+    log_number: Option<u32>,
+    index: usize,
+) -> (usize, Result<ExtractionResult, GraphError>) {
+    let result = extract::extract_from_chunk(llm, chunk, session_id, log_number).await;
+    (index, result)
+}
+
 /// Shared extraction logic — parallel extraction, sequential dedup.
 ///
 /// Four phases:
@@ -102,13 +119,18 @@ async fn process_extraction(
     llm: &dyn LlmProvider,
     report: &mut IngestionReport,
 ) -> Result<(), GraphError> {
-    // Phase 1: Extract all chunks in parallel
+    // Phase 1: Extract all chunks in parallel.
+    // The per-chunk futures are built by the iterator, not by a stream
+    // combinator: a closure applied inside the stream would have to be
+    // higher-ranked over the item lifetime, which makes the whole stream
+    // non-`Send` and would bar ingestion from the serve daemon's tasks.
+    let pending: Vec<_> = chunks
+        .iter()
+        .enumerate()
+        .map(|(i, chunk)| extract_indexed(llm, chunk, session_id, log_number, i))
+        .collect();
     let extraction_results: Vec<(usize, Result<ExtractionResult, GraphError>)> =
-        stream::iter(chunks.iter().enumerate())
-            .map(|(i, chunk)| async move {
-                let result = extract::extract_from_chunk(llm, chunk, session_id, log_number).await;
-                (i, result)
-            })
+        stream::iter(pending)
             .buffer_unordered(LLM_CONCURRENCY)
             .collect()
             .await;

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -26,10 +26,9 @@ pub mod vigil_sync;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
-use embed::FastEmbedder;
+use embed::{FastEmbedder, LazyEmbedder};
 use error::GraphError;
 use store::Db;
-#[cfg(feature = "server")]
 pub use store::ServerConfig;
 #[allow(unused_imports)] // Required in scope for SurrealValue derive macro expansion
 use surrealdb::types::SurrealValue;
@@ -60,7 +59,7 @@ pub(crate) fn deserialize_take_opt<T: serde::de::DeserializeOwned>(
 /// The main entry point for graph memory operations.
 pub struct GraphMemory {
     db: Surreal<Db>,
-    embedder: FastEmbedder,
+    embedder: LazyEmbedder,
     path: PathBuf,
     scoring: crate::config::GraphScoringConfig,
 }
@@ -68,12 +67,28 @@ pub struct GraphMemory {
 impl GraphMemory {
     /// Open a graph store at the given path.
     ///
-    /// In embedded mode: opens SurrealKV at `path/surreal/`.
-    /// In server mode: reads `.recall-echo.toml` from the parent directory
-    /// to get connection settings, then connects via WebSocket.
-    /// The `path` is still used for the FastEmbed models cache.
-    #[cfg(feature = "embedded")]
+    /// The backend is chosen at runtime from the `[graph] mode` key of
+    /// `.recall-echo.toml` in the parent directory (memory_dir):
+    /// `embedded` (default) opens SurrealKV at `path/surreal/`; `server`
+    /// connects to a SurrealDB server via the configured URL.
+    /// The `path` is used for the FastEmbed models cache in both modes.
     pub async fn open(path: &Path) -> Result<Self, GraphError> {
+        let memory_dir = path.parent().unwrap_or(path);
+        let config = crate::config::load_from_dir(memory_dir);
+        let mode = config
+            .graph
+            .as_ref()
+            .map(|g| g.mode.clone())
+            .unwrap_or_else(|| "embedded".to_string());
+
+        match mode.as_str() {
+            "server" => Self::open_server(path).await,
+            _ => Self::open_embedded(path).await,
+        }
+    }
+
+    /// Open the embedded SurrealKV store at `path/surreal/`.
+    pub async fn open_embedded(path: &Path) -> Result<Self, GraphError> {
         std::fs::create_dir_all(path)?;
 
         let db = store::open(path).await?;
@@ -81,7 +96,7 @@ impl GraphMemory {
 
         let models_dir = path.join("models");
         std::fs::create_dir_all(&models_dir)?;
-        let embedder = FastEmbedder::new(&models_dir)?;
+        let embedder = LazyEmbedder::new(&models_dir);
 
         let scoring = load_scoring_config(path);
 
@@ -93,13 +108,10 @@ impl GraphMemory {
         })
     }
 
-    /// Open a graph store at the given path.
-    ///
-    /// In server mode: reads `.recall-echo.toml` from the parent directory
-    /// (memory_dir) to get connection settings, then connects via WebSocket.
+    /// Connect to a SurrealDB server using `[graph]` settings from
+    /// `.recall-echo.toml` in the parent directory (memory_dir).
     /// The `path` is still used for the FastEmbed models cache.
-    #[cfg(feature = "server")]
-    pub async fn open(path: &Path) -> Result<Self, GraphError> {
+    pub async fn open_server(path: &Path) -> Result<Self, GraphError> {
         let memory_dir = path.parent().unwrap_or(path);
         let config = crate::config::load_from_dir(memory_dir);
 
@@ -143,7 +155,6 @@ impl GraphMemory {
     }
 
     /// Connect to a SurrealDB server over WebSocket with explicit config.
-    #[cfg(feature = "server")]
     pub async fn connect(
         config: &store::ServerConfig,
         models_dir: &Path,
@@ -152,7 +163,7 @@ impl GraphMemory {
         store::init_schema(&db).await?;
 
         std::fs::create_dir_all(models_dir)?;
-        let embedder = FastEmbedder::new(models_dir)?;
+        let embedder = LazyEmbedder::new(models_dir);
 
         Ok(Self {
             db,
@@ -173,17 +184,17 @@ impl GraphMemory {
         &self.db
     }
 
-    /// Internal access to the embedder.
+    /// Internal access to the embedder (initializes it on first use).
     #[allow(dead_code)]
-    pub(crate) fn embedder(&self) -> &FastEmbedder {
-        &self.embedder
+    pub(crate) fn embedder(&self) -> Result<&FastEmbedder, GraphError> {
+        self.embedder.get()
     }
 
     // --- Entity CRUD ---
 
     /// Add a new entity to the graph.
     pub async fn add_entity(&self, entity: NewEntity) -> Result<Entity, GraphError> {
-        crud::add_entity(&self.db, &self.embedder, entity).await
+        crud::add_entity(&self.db, self.embedder.get()?, entity).await
     }
 
     /// Get an entity by name.
@@ -202,7 +213,7 @@ impl GraphMemory {
         id: &str,
         updates: EntityUpdate,
     ) -> Result<Entity, GraphError> {
-        crud::update_entity(&self.db, &self.embedder, id, updates).await
+        crud::update_entity(&self.db, self.embedder.get()?, id, updates).await
     }
 
     /// Delete an entity and its relationships.
@@ -268,7 +279,7 @@ impl GraphMemory {
 
     /// Add a new episode to the graph.
     pub async fn add_episode(&self, episode: NewEpisode) -> Result<Episode, GraphError> {
-        crud::add_episode(&self.db, &self.embedder, episode).await
+        crud::add_episode(&self.db, self.embedder.get()?, episode).await
     }
 
     /// Get episodes by session ID.
@@ -325,7 +336,7 @@ impl GraphMemory {
 
     /// Semantic search across entities (legacy — returns full Entity).
     pub async fn search(&self, query: &str, limit: usize) -> Result<Vec<SearchResult>, GraphError> {
-        search::search(&self.db, &self.embedder, &self.scoring, query, limit).await
+        search::search(&self.db, self.embedder.get()?, &self.scoring, query, limit).await
     }
 
     /// Search with options — L1 projections, type/keyword filters.
@@ -334,7 +345,14 @@ impl GraphMemory {
         query: &str,
         options: &SearchOptions,
     ) -> Result<Vec<ScoredEntity>, GraphError> {
-        search::search_with_options(&self.db, &self.embedder, &self.scoring, query, options).await
+        search::search_with_options(
+            &self.db,
+            self.embedder.get()?,
+            &self.scoring,
+            query,
+            options,
+        )
+        .await
     }
 
     /// Semantic search across episodes.
@@ -343,7 +361,7 @@ impl GraphMemory {
         query: &str,
         limit: usize,
     ) -> Result<Vec<EpisodeSearchResult>, GraphError> {
-        search::search_episodes(&self.db, &self.embedder, query, limit).await
+        search::search_episodes(&self.db, self.embedder.get()?, query, limit).await
     }
 
     // --- Hybrid Query ---
@@ -354,7 +372,14 @@ impl GraphMemory {
         query_text: &str,
         options: &QueryOptions,
     ) -> Result<QueryResult, GraphError> {
-        query::query(&self.db, &self.embedder, &self.scoring, query_text, options).await
+        query::query(
+            &self.db,
+            self.embedder.get()?,
+            &self.scoring,
+            query_text,
+            options,
+        )
+        .await
     }
 
     // --- Traversal ---
@@ -510,7 +535,6 @@ impl GraphMemory {
 /// Load `[graph.scoring]` from `.recall-echo.toml` in the memory directory
 /// (the parent of the graph store path). Returns defaults if the config file
 /// or the `[graph.scoring]` section is absent, preserving legacy behavior.
-#[cfg(feature = "embedded")]
 fn load_scoring_config(graph_path: &Path) -> crate::config::GraphScoringConfig {
     let memory_dir = graph_path.parent().unwrap_or(graph_path);
     crate::config::load_from_dir(memory_dir)

--- a/src/graph/search.rs
+++ b/src/graph/search.rs
@@ -33,11 +33,14 @@ pub async fn search(
     let query_embedding = embedder.embed_single(query)?;
 
     // HNSW KNN — uses the entity_vector index (HNSW DIMENSION 384 DIST COSINE)
-    // KNN operator requires literal integers (not bind params)
-    let ef = (limit * 4).max(40);
+    // KNN operator requires literal integers (not bind params).
+    // `limit` can arrive over the daemon socket, so every derived count
+    // saturates instead of wrapping.
+    let ef = limit.saturating_mul(4).max(40);
     let sql = format!(
         r#"SELECT *,
                 vector::distance::knn() AS distance
+            OMIT embedding
             FROM entity
             WHERE embedding <|{limit}, {ef}|> $query_vec
             ORDER BY distance"#,
@@ -93,8 +96,12 @@ pub async fn search_with_options(
     let has_filters = options.entity_type.is_some() || options.keyword.is_some();
 
     // KNN doesn't support post-filter AND clauses, so fetch more and filter in Rust
-    let fetch_limit = if has_filters { limit * 4 } else { limit };
-    let ef = (fetch_limit * 4).max(40);
+    let fetch_limit = if has_filters {
+        limit.saturating_mul(4)
+    } else {
+        limit
+    };
+    let ef = fetch_limit.saturating_mul(4).max(40);
     let sql = format!(
         r#"SELECT id, name, entity_type, abstract, overview, attributes,
                   access_count, utility_score, updated_at, source,
@@ -165,10 +172,13 @@ pub async fn search_episodes(
 ) -> Result<Vec<EpisodeSearchResult>, GraphError> {
     let query_embedding = embedder.embed_single(query_text)?;
 
-    let ef = (limit * 4).max(40);
+    let ef = limit.saturating_mul(4).max(40);
+    // Episode embeddings are 384 floats each and no caller reads them; leaving
+    // them out of the projection keeps them out of the row and off the wire.
     let sql = format!(
         r#"SELECT *,
                 vector::distance::knn() AS distance
+            OMIT embedding
             FROM episode
             WHERE embedding <|{limit}, {ef}|> $query_vec
             ORDER BY distance"#,

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -1,26 +1,31 @@
-//! SurrealDB store — embedded (kv-surrealkv) or server (WebSocket).
+//! SurrealDB store — embedded (kv-surrealkv) or server (WebSocket), selected
+//! at runtime via the `[graph] mode` config key (`embedded` | `server`).
+//!
+//! Both engines are compiled in by default and dispatched through
+//! `surrealdb::engine::any`, so switching backends is a config change,
+//! not a rebuild.
+//!
+//! Concurrency: the embedded SurrealKV backend takes a process-exclusive
+//! file lock. Concurrent access from a second process fails with
+//! [`GraphError::Locked`] after a bounded retry. Server mode (or the serve
+//! daemon) is the supported way to share one store between processes.
 
-#[cfg(all(feature = "embedded", feature = "server"))]
-compile_error!("Features `embedded` and `server` are mutually exclusive. Choose one.");
+use std::path::Path;
+use std::time::Duration;
 
+use surrealdb::engine::any::Any;
 use surrealdb::Surreal;
 
 use super::error::GraphError;
 
-#[cfg(feature = "embedded")]
-use std::path::Path;
+pub type Db = Any;
 
-#[cfg(feature = "embedded")]
-use surrealdb::engine::local::SurrealKv;
-
-#[cfg(feature = "embedded")]
-pub type Db = surrealdb::engine::local::Db;
-
-#[cfg(feature = "server")]
-pub type Db = surrealdb::engine::remote::ws::Client;
+/// How many times to retry opening an embedded store that is locked by
+/// another process, and the base backoff between attempts (doubled each try).
+const LOCK_RETRY_ATTEMPTS: u32 = 4;
+const LOCK_RETRY_BASE: Duration = Duration::from_millis(250);
 
 /// Connection config for server mode.
-#[cfg(feature = "server")]
 #[derive(Clone)]
 pub struct ServerConfig {
     pub url: String,
@@ -30,7 +35,6 @@ pub struct ServerConfig {
     pub database: String,
 }
 
-#[cfg(feature = "server")]
 impl std::fmt::Debug for ServerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ServerConfig")
@@ -43,8 +47,20 @@ impl std::fmt::Debug for ServerConfig {
     }
 }
 
+/// True if a SurrealDB error indicates the embedded store's process-exclusive
+/// file lock is held by another process.
+fn is_lock_error(err: &surrealdb::Error) -> bool {
+    is_lock_message(&err.to_string().to_lowercase())
+}
+
+fn is_lock_message(msg: &str) -> bool {
+    msg.contains("lock") && (msg.contains("already") || msg.contains("held"))
+}
+
 /// Open (or create) a SurrealDB embedded store at the given path.
-#[cfg(feature = "embedded")]
+///
+/// Retries briefly if another process holds the store lock, then fails with
+/// [`GraphError::Locked`] carrying an actionable message.
 pub async fn open(path: &Path) -> Result<Surreal<Db>, GraphError> {
     let surreal_path = path.join("surreal");
     std::fs::create_dir_all(&surreal_path)?;
@@ -55,16 +71,37 @@ pub async fn open(path: &Path) -> Result<Surreal<Db>, GraphError> {
             "graph store path contains non-UTF8 characters",
         ))
     })?;
-    let db: Surreal<Db> = Surreal::new::<SurrealKv>(path_str).await?;
+
+    let endpoint = format!("surrealkv://{path_str}");
+    let mut attempt: u32 = 0;
+    let db: Surreal<Db> = loop {
+        match surrealdb::engine::any::connect(&endpoint).await {
+            Ok(db) => break db,
+            Err(e) if is_lock_error(&e) && attempt < LOCK_RETRY_ATTEMPTS => {
+                attempt += 1;
+                tokio::time::sleep(LOCK_RETRY_BASE * 2u32.pow(attempt - 1)).await;
+            }
+            Err(e) if is_lock_error(&e) => {
+                return Err(GraphError::Locked(format!(
+                    "graph store at {} is locked by another process. The embedded \
+                     backend allows one process at a time — retried {} times. \
+                     Another recall-echo command (or the serve daemon) is using it; \
+                     wait for it to finish, or use server mode to share the store.",
+                    surreal_path.display(),
+                    LOCK_RETRY_ATTEMPTS
+                )));
+            }
+            Err(e) => return Err(e.into()),
+        }
+    };
     db.use_ns("recall").use_db("graph").await?;
 
     Ok(db)
 }
 
-/// Connect to a SurrealDB server over WebSocket.
-#[cfg(feature = "server")]
+/// Connect to a SurrealDB server (e.g. `ws://localhost:8787`).
 pub async fn connect(config: &ServerConfig) -> Result<Surreal<Db>, GraphError> {
-    let db = Surreal::new::<surrealdb::engine::remote::ws::Ws>(&config.url).await?;
+    let db = surrealdb::engine::any::connect(&config.url).await?;
     db.signin(surrealdb::opt::auth::Database {
         namespace: config.namespace.clone(),
         database: config.database.clone(),
@@ -145,4 +182,24 @@ pub async fn init_schema(db: &Surreal<Db>) -> Result<(), GraphError> {
     .check()?;
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_message_detected() {
+        assert!(is_lock_message(
+            "database: the database at /x/surreal/lock is already locked by another process"
+        ));
+        assert!(is_lock_message("file lock held by another process"));
+    }
+
+    #[test]
+    fn non_lock_messages_pass_through() {
+        assert!(!is_lock_message("connection refused"));
+        assert!(!is_lock_message("lockstep protocol mismatch")); // 'lock' without already/held
+        assert!(!is_lock_message("table entity already exists"));
+    }
 }

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -22,8 +22,12 @@ pub type Db = Any;
 
 /// How many times to retry opening an embedded store that is locked by
 /// another process, and the base backoff between attempts (doubled each try).
-const LOCK_RETRY_ATTEMPTS: u32 = 4;
-const LOCK_RETRY_BASE: Duration = Duration::from_millis(250);
+///
+/// The common case is a daemon that has just been asked to stop and is
+/// releasing the store, which takes single-digit milliseconds: start far
+/// below that and spend the same total budget (~3.8s) on more attempts.
+const LOCK_RETRY_ATTEMPTS: u32 = 8;
+const LOCK_RETRY_BASE: Duration = Duration::from_millis(15);
 
 /// Connection config for server mode.
 #[derive(Clone)]

--- a/src/graph/traverse.rs
+++ b/src/graph/traverse.rs
@@ -45,8 +45,10 @@ pub async fn traverse_filtered(
     traverse_from(db, &root, max_depth, 0, &mut vec![], type_filter).await
 }
 
-type TraversalFuture<'a> =
-    std::pin::Pin<Box<dyn std::future::Future<Output = Result<TraversalNode, GraphError>> + 'a>>;
+/// `Send` matters: the serve daemon traverses inside a spawned tokio task.
+type TraversalFuture<'a> = std::pin::Pin<
+    Box<dyn std::future::Future<Output = Result<TraversalNode, GraphError>> + Send + 'a>,
+>;
 
 /// Recursive traversal with cycle detection, using L0 projections.
 fn traverse_from<'a>(

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -261,7 +261,8 @@ pub struct SearchOptions {
 }
 
 /// How an entity was found.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
 pub enum MatchSource {
     /// Found via semantic similarity.
     Semantic,
@@ -272,7 +273,7 @@ pub enum MatchSource {
 }
 
 /// A scored entity in search results.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScoredEntity {
     pub entity: EntityDetail,
     pub score: f64,
@@ -280,7 +281,7 @@ pub struct ScoredEntity {
 }
 
 /// An episode search result.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct EpisodeSearchResult {
     pub episode: Episode,
     pub score: f64,
@@ -310,14 +311,14 @@ impl Default for QueryOptions {
 }
 
 /// Result of a hybrid query.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct QueryResult {
     pub entities: Vec<ScoredEntity>,
     pub episodes: Vec<EpisodeSearchResult>,
 }
 
 /// A search result with scoring (legacy — wraps full Entity).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResult {
     pub entity: Entity,
     pub score: f64,
@@ -325,14 +326,14 @@ pub struct SearchResult {
 }
 
 /// A node in a traversal tree.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraversalNode {
     pub entity: EntitySummary,
     pub edges: Vec<TraversalEdge>,
 }
 
 /// An edge in a traversal tree.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TraversalEdge {
     pub rel_type: String,
     pub direction: String,
@@ -370,7 +371,7 @@ impl EdgeRow {
 }
 
 /// Graph-level statistics.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct GraphStats {
     pub entity_count: u64,
     pub relationship_count: u64,
@@ -594,7 +595,7 @@ pub struct PipelineEntry {
 }
 
 /// Result of a full ingestion run.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct IngestionReport {
     pub episodes_created: u32,
     pub entities_created: u32,

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -84,7 +84,9 @@ pub struct Entity {
     pub overview: String,
     pub content: Option<String>,
     pub attributes: Option<serde_json::Value>,
-    #[serde(default)]
+    /// Omitted when absent: an entity crossing the daemon socket carries no
+    /// embedding, and 384 floats of JSON text per entity is pure overhead.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding: Option<Vec<f32>>,
     #[serde(default = "default_true")]
     pub mutable: bool,
@@ -401,7 +403,8 @@ pub struct Episode {
     pub abstract_text: String,
     pub overview: Option<String>,
     pub content: Option<String>,
-    #[serde(default)]
+    /// Omitted when absent — see [`Entity::embedding`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding: Option<Vec<f32>>,
     pub log_number: Option<i64>,
 }
@@ -538,7 +541,7 @@ pub struct VigilSyncReport {
 }
 
 /// Contents of all 5 pipeline markdown files.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PipelineDocuments {
     pub learning: String,
     pub thoughts: String,
@@ -548,7 +551,7 @@ pub struct PipelineDocuments {
 }
 
 /// Report from a pipeline sync operation.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PipelineSyncReport {
     pub entities_created: u32,
     pub entities_updated: u32,
@@ -605,4 +608,57 @@ pub struct IngestionReport {
     pub relationships_skipped: u32,
     pub errors: Vec<String>,
     pub estimated_tokens: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn episode_with(embedding: Option<Vec<f32>>) -> Episode {
+        Episode {
+            id: serde_json::json!("episode:one"),
+            session_id: "s1".into(),
+            timestamp: serde_json::json!("2026-01-01T00:00:00Z"),
+            abstract_text: "a".into(),
+            overview: None,
+            content: None,
+            embedding,
+            log_number: Some(1),
+        }
+    }
+
+    /// Embeddings are 384 floats each. They exist to be searched inside the
+    /// store, never to be shipped to a caller that discards them.
+    #[test]
+    fn an_episode_without_an_embedding_carries_no_embedding_field() {
+        let json = serde_json::to_value(episode_with(None)).unwrap();
+        assert!(json.get("embedding").is_none(), "{json}");
+
+        let json = serde_json::to_value(episode_with(Some(vec![0.5; 384]))).unwrap();
+        assert!(json.get("embedding").is_some(), "{json}");
+    }
+
+    #[test]
+    fn an_episode_round_trips_without_its_embedding() {
+        let line = serde_json::to_string(&episode_with(None)).unwrap();
+        let parsed: Episode = serde_json::from_str(&line).unwrap();
+        assert!(parsed.embedding.is_none());
+        assert_eq!(parsed.session_id, "s1");
+    }
+
+    #[test]
+    fn pipeline_documents_survive_the_daemon_wire_format() {
+        let docs = PipelineDocuments {
+            learning: "# learning".into(),
+            thoughts: "# thoughts".into(),
+            curiosity: String::new(),
+            reflections: "# reflections".into(),
+            praxis: String::new(),
+        };
+        let line = serde_json::to_string(&docs).unwrap();
+        assert_eq!(
+            serde_json::from_str::<PipelineDocuments>(&line).unwrap(),
+            docs
+        );
+    }
 }

--- a/src/graph_bridge.rs
+++ b/src/graph_bridge.rs
@@ -50,6 +50,22 @@ pub async fn ingest_into_graph(
     Ok(report)
 }
 
+/// Sync the pipeline documents into the knowledge graph.
+///
+/// Pipeline sync needs no LLM provider, so it runs as an ordinary daemon
+/// request. That matters on the SessionEnd hook path: ingest and sync then
+/// share one warm daemon instead of the sync stopping the daemon the ingest
+/// just started and reloading the embedding model in-process.
+pub async fn sync_pipeline_into_graph(
+    memory_dir: &std::path::Path,
+    docs: crate::graph::types::PipelineDocuments,
+) -> Result<crate::graph::types::PipelineSyncReport, crate::error::RecallError> {
+    let request = crate::serve::Request::SyncPipeline(crate::serve::SyncPipelineArgs { docs });
+    Ok(serde_json::from_value(
+        crate::serve_client::execute(memory_dir, &request).await?,
+    )?)
+}
+
 /// Ingest with an LLM provider for entity extraction.
 ///
 /// When pulse-null feature is enabled, this bridges the LmProvider

--- a/src/graph_bridge.rs
+++ b/src/graph_bridge.rs
@@ -20,12 +20,16 @@ pub async fn ingest_into_graph(
         ));
     }
 
-    let gm = crate::graph::GraphMemory::open(&graph_dir).await?;
-
-    // No LLM provider in standalone mode — episodes only, no entity extraction
-    let report = gm
-        .ingest_archive(archive_content, session_id, log_number, None)
-        .await?;
+    // Hot path (SessionEnd hook): goes through the serve daemon so a
+    // concurrent session never collides on the embedded store lock.
+    // No LLM provider in standalone mode — episodes only, no entity extraction.
+    let request = crate::serve::Request::IngestArchive(crate::serve::IngestArchiveArgs {
+        content: archive_content.to_string(),
+        session_id: session_id.to_string(),
+        log_number,
+    });
+    let report: crate::graph::types::IngestionReport =
+        serde_json::from_value(crate::serve_client::execute(memory_dir, &request).await?)?;
 
     eprintln!(
         "recall-echo: graph ingested \u{2014} {} episodes, {} entities created, {} merged, {} skipped, {} relationships",
@@ -65,16 +69,19 @@ pub async fn ingest_into_graph_with_llm(
         ));
     }
 
-    let gm = crate::graph::GraphMemory::open(&graph_dir).await?;
+    // LLM-backed extraction cannot cross the socket (the provider lives in
+    // this process), so this path takes the store exclusively instead.
+    let report = crate::serve_client::exclusive(memory_dir, |gm| async move {
+        let bridge = provider.map(GraphLlmBridge::new);
+        let llm_ref: Option<&dyn crate::graph::llm::LlmProvider> = bridge
+            .as_ref()
+            .map(|b| b as &dyn crate::graph::llm::LlmProvider);
 
-    let bridge = provider.map(GraphLlmBridge::new);
-    let llm_ref: Option<&dyn crate::graph::llm::LlmProvider> = bridge
-        .as_ref()
-        .map(|b| b as &dyn crate::graph::llm::LlmProvider);
-
-    let report = gm
-        .ingest_archive(archive_content, session_id, log_number, llm_ref)
-        .await?;
+        Ok(gm
+            .ingest_archive(archive_content, session_id, log_number, llm_ref)
+            .await?)
+    })
+    .await?;
 
     eprintln!(
         "recall-echo: graph ingested \u{2014} {} episodes, {} entities created, {} merged, {} skipped, {} relationships",

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -5,7 +5,10 @@ use std::path::{Path, PathBuf};
 use crate::error::RecallError;
 use crate::graph::traverse::format_traversal;
 use crate::graph::types::*;
-use crate::graph::GraphMemory;
+use crate::serve::{
+    AddEntityArgs, IngestArchiveArgs, QueryArgs, RelateArgs, Request, SearchArgs, TraverseArgs,
+};
+use crate::serve_client;
 
 const GREEN: &str = "\x1b[32m";
 const CYAN: &str = "\x1b[36m";
@@ -17,7 +20,7 @@ const RESET: &str = "\x1b[0m";
 /// Initialize the graph store at {memory_dir}/graph/.
 pub async fn init(memory_dir: &Path) -> Result<(), RecallError> {
     let graph_dir = memory_dir.join("graph");
-    GraphMemory::open(&graph_dir).await?;
+    serve_client::exclusive(memory_dir, |_graph| async { Ok(()) }).await?;
     println!(
         "{GREEN}✓{RESET} Graph store initialized at {}",
         graph_dir.display()
@@ -33,8 +36,8 @@ pub async fn graph_status(memory_dir: &Path) -> Result<(), RecallError> {
             "Graph store not initialized. Run `recall-echo graph init` first.".into(),
         ));
     }
-    let gm = GraphMemory::open(&graph_dir).await?;
-    let stats = gm.stats().await?;
+    let data = serve_client::execute(memory_dir, &Request::Status).await?;
+    let stats: GraphStats = serde_json::from_value(data)?;
 
     println!("{BOLD}Graph Memory Status{RESET}");
     println!("  Entities:      {}", stats.entity_count);
@@ -49,6 +52,60 @@ pub async fn graph_status(memory_dir: &Path) -> Result<(), RecallError> {
             println!("    {t}: {count}");
         }
     }
+
+    print_daemon_line(memory_dir).await;
+    Ok(())
+}
+
+/// Print the identity of the daemon serving this graph, or why there is none.
+async fn print_daemon_line(memory_dir: &Path) {
+    println!();
+    match serve_client::daemon_info(memory_dir).await {
+        Ok(Some(info)) => println!(
+            "  {DIM}Daemon:{RESET} running — pid {}, v{}, up {}s",
+            info.pid, info.version, info.uptime_secs
+        ),
+        Ok(None) if serve_client::graph_mode(memory_dir) == "server" => {
+            println!("  {DIM}Daemon:{RESET} not used — [graph] mode = server");
+        }
+        Ok(None) => println!("  {DIM}Daemon:{RESET} not running"),
+        Err(e) => println!("  {DIM}Daemon:{RESET} unknown ({e})"),
+    }
+}
+
+/// Show daemon status without touching the graph.
+pub async fn daemon_status(memory_dir: &Path) -> Result<(), RecallError> {
+    println!("{BOLD}Graph Daemon{RESET}");
+    println!(
+        "  Socket: {}",
+        serve_client::socket_path(memory_dir)?.display()
+    );
+    match serve_client::daemon_info(memory_dir).await? {
+        Some(info) => {
+            println!("  State:  {GREEN}running{RESET}");
+            println!("  Pid:    {}", info.pid);
+            println!("  Version: {}", info.version);
+            println!("  Uptime: {}s", info.uptime_secs);
+        }
+        None if serve_client::graph_mode(memory_dir) == "server" => {
+            println!("  State:  not used — [graph] mode = server");
+        }
+        None => println!("  State:  {YELLOW}not running{RESET}"),
+    }
+    println!(
+        "  Log:    {}",
+        serve_client::daemon_log_path(memory_dir).display()
+    );
+    Ok(())
+}
+
+/// Stop the daemon serving this graph, if one is running.
+pub async fn daemon_stop(memory_dir: &Path) -> Result<(), RecallError> {
+    if serve_client::stop_daemon(memory_dir).await? {
+        println!("{GREEN}✓{RESET} Graph daemon stopped");
+    } else {
+        println!("{YELLOW}No graph daemon running.{RESET}");
+    }
     Ok(())
 }
 
@@ -61,24 +118,15 @@ pub async fn add_entity(
     overview: Option<&str>,
     source: Option<&str>,
 ) -> Result<(), RecallError> {
-    let graph_dir = memory_dir.join("graph");
-    let et: EntityType = entity_type
-        .parse()
-        .map_err(|e: String| RecallError::Other(e))?;
-
-    let gm = GraphMemory::open(&graph_dir).await?;
-
-    let entity = gm
-        .add_entity(NewEntity {
-            name: name.to_string(),
-            entity_type: et,
-            abstract_text: abstract_text.to_string(),
-            overview: overview.map(String::from),
-            content: None,
-            attributes: None,
-            source: source.map(String::from),
-        })
-        .await?;
+    let request = Request::AddEntity(AddEntityArgs {
+        name: name.to_string(),
+        entity_type: entity_type.to_string(),
+        abstract_text: abstract_text.to_string(),
+        overview: overview.map(String::from),
+        source: source.map(String::from),
+    });
+    let entity: Entity =
+        serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
 
     println!(
         "{GREEN}✓{RESET} Created entity: {BOLD}{}{RESET} ({}) [{}]",
@@ -98,19 +146,15 @@ pub async fn relate(
     description: Option<&str>,
     source: Option<&str>,
 ) -> Result<(), RecallError> {
-    let graph_dir = memory_dir.join("graph");
-    let gm = GraphMemory::open(&graph_dir).await?;
-
-    let rel = gm
-        .add_relationship(NewRelationship {
-            from_entity: from.to_string(),
-            to_entity: to.to_string(),
-            rel_type: rel_type.to_string(),
-            description: description.map(String::from),
-            confidence: None,
-            source: source.map(String::from),
-        })
-        .await?;
+    let request = Request::Relate(RelateArgs {
+        from: from.to_string(),
+        rel_type: rel_type.to_string(),
+        to: to.to_string(),
+        description: description.map(String::from),
+        source: source.map(String::from),
+    });
+    let rel: Relationship =
+        serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
 
     println!(
         "{GREEN}✓{RESET} {from} {CYAN}—[{rel_type}]→{RESET} {to} [{}]",
@@ -127,16 +171,14 @@ pub async fn search(
     entity_type: Option<&str>,
     keyword: Option<&str>,
 ) -> Result<(), RecallError> {
-    let graph_dir = memory_dir.join("graph");
-    let gm = GraphMemory::open(&graph_dir).await?;
-
-    let options = SearchOptions {
+    let request = Request::Search(SearchArgs {
+        query: query.to_string(),
         limit,
         entity_type: entity_type.map(String::from),
         keyword: keyword.map(String::from),
-    };
-
-    let results = gm.search_with_options(query, &options).await?;
+    });
+    let results: Vec<ScoredEntity> =
+        serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
 
     if results.is_empty() {
         println!("{YELLOW}No results.{RESET}");
@@ -170,11 +212,13 @@ pub async fn ingest(memory_dir: &Path, archive_path: &Path) -> Result<(), Recall
     // Extract session_id and log_number from frontmatter if available
     let (session_id, log_number) = extract_archive_metadata(&content, archive_path);
 
-    let gm = GraphMemory::open(&graph_dir).await?;
-
-    let report = gm
-        .ingest_archive(&content, &session_id, log_number, None)
-        .await?;
+    let request = Request::IngestArchive(IngestArchiveArgs {
+        content,
+        session_id,
+        log_number,
+    });
+    let report: IngestionReport =
+        serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
 
     println!(
         "{GREEN}✓{RESET} Ingested {}: {} episodes created",
@@ -215,44 +259,45 @@ pub async fn ingest_all(memory_dir: &Path) -> Result<(), RecallError> {
         return Ok(());
     }
 
-    let gm = GraphMemory::open(&graph_dir).await?;
+    serve_client::exclusive(memory_dir, |gm| async move {
+        let mut total_episodes = 0u32;
+        let mut ingested = 0u32;
+        let mut skipped = 0u32;
 
-    let mut total_episodes = 0u32;
-    let mut ingested = 0u32;
-    let mut skipped = 0u32;
+        for entry in &files {
+            let path = entry.path();
+            let content = std::fs::read_to_string(&path)?;
 
-    for entry in &files {
-        let path = entry.path();
-        let content = std::fs::read_to_string(&path)?;
+            let (session_id, log_number) = extract_archive_metadata(&content, &path);
 
-        let (session_id, log_number) = extract_archive_metadata(&content, &path);
-
-        // Check if already ingested (has episodes for this log_number)
-        if let Some(ln) = log_number {
-            if let Ok(Some(_)) = gm.get_episode_by_log_number(ln).await {
-                skipped += 1;
-                continue;
+            // Check if already ingested (has episodes for this log_number)
+            if let Some(ln) = log_number {
+                if let Ok(Some(_)) = gm.get_episode_by_log_number(ln).await {
+                    skipped += 1;
+                    continue;
+                }
             }
+
+            let report = gm
+                .ingest_archive(&content, &session_id, log_number, None)
+                .await?;
+
+            total_episodes += report.episodes_created;
+            ingested += 1;
+
+            println!(
+                "  {GREEN}✓{RESET} {} — {} episodes",
+                path.file_name().unwrap_or_default().to_string_lossy(),
+                report.episodes_created
+            );
         }
 
-        let report = gm
-            .ingest_archive(&content, &session_id, log_number, None)
-            .await?;
-
-        total_episodes += report.episodes_created;
-        ingested += 1;
-
         println!(
-            "  {GREEN}✓{RESET} {} — {} episodes",
-            path.file_name().unwrap_or_default().to_string_lossy(),
-            report.episodes_created
+            "\n{GREEN}✓{RESET} Ingested {ingested} archives ({total_episodes} episodes), skipped {skipped} already ingested"
         );
-    }
-
-    println!(
-        "\n{GREEN}✓{RESET} Ingested {ingested} archives ({total_episodes} episodes), skipped {skipped} already ingested"
-    );
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// Extract session_id and log_number from a conversation archive's frontmatter.
@@ -295,12 +340,13 @@ pub async fn traverse(
     depth: u32,
     type_filter: Option<&str>,
 ) -> Result<(), RecallError> {
-    let graph_dir = memory_dir.join("graph");
-    let gm = GraphMemory::open(&graph_dir).await?;
-
-    let tree = gm
-        .traverse_filtered(entity_name, depth, type_filter)
-        .await?;
+    let request = Request::Traverse(TraverseArgs {
+        entity: entity_name.to_string(),
+        depth,
+        type_filter: type_filter.map(String::from),
+    });
+    let tree: TraversalNode =
+        serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
 
     let output = format_traversal(&tree, 0);
     print!("{output}");
@@ -317,18 +363,16 @@ pub async fn hybrid_query(
     depth: u32,
     episodes: bool,
 ) -> Result<(), RecallError> {
-    let graph_dir = memory_dir.join("graph");
-    let gm = GraphMemory::open(&graph_dir).await?;
-
-    let options = QueryOptions {
+    let request = Request::Query(QueryArgs {
+        query: query.to_string(),
         limit,
         entity_type: entity_type.map(String::from),
         keyword: keyword.map(String::from),
-        graph_depth: depth,
-        include_episodes: episodes,
-    };
-
-    let result = gm.query(query, &options).await?;
+        depth,
+        episodes,
+    });
+    let result: QueryResult =
+        serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
 
     if result.entities.is_empty() && result.episodes.is_empty() {
         println!("{YELLOW}No results.{RESET}");
@@ -479,160 +523,161 @@ pub async fn extract(
         ));
     }
 
-    let gm = GraphMemory::open(&graph_dir).await?;
-
-    // Determine which log numbers to process
-    let log_numbers: Vec<u32> = if let Some(ln) = log {
-        vec![ln]
-    } else if all {
-        gm.unextracted_log_numbers()
-            .await?
-            .into_iter()
-            .map(|n| n as u32)
-            .collect()
-    } else {
-        return Err(RecallError::Other("Specify --log <N> or --all".into()));
-    };
-
-    if log_numbers.is_empty() {
-        println!("{YELLOW}No unextracted archives found.{RESET}");
-        return Ok(());
-    }
-
-    let conversations_dir = find_conversations_dir(memory_dir)?;
-
-    if dry_run {
-        print_extract_dry_run(&conversations_dir, &log_numbers);
-        return Ok(());
-    }
-
-    // Build LLM provider from .recall-echo.toml (CLI flags override)
-    let (llm, model_name) = crate::llm_provider::create_provider(
-        memory_dir,
-        provider_override.as_deref(),
-        model_override.as_deref(),
-    )?;
-
-    let total_count = log_numbers.len();
-    let budget_label = if max_tokens > 0 {
-        format!(" (budget: {})", format_tokens(max_tokens))
-    } else {
-        String::new()
-    };
-    println!(
-        "{BOLD}Extracting entities from {total_count} archives using {model_name}{budget_label}{RESET}",
-    );
-
-    let quarantine_path = graph_dir.join("extraction-quarantine.txt");
-    let mut totals = ExtractionTotals::default();
-
-    for (idx, ln) in log_numbers.iter().enumerate() {
-        // Budget check
-        if max_tokens > 0 && totals.estimated_tokens >= max_tokens {
-            println!(
-                "\n{YELLOW}⚠ Token budget exhausted (~{} / {}). Stopping.{RESET}",
-                format_tokens(totals.estimated_tokens),
-                format_tokens(max_tokens),
-            );
-            println!("  Re-run to continue — resume is automatic via unextracted log numbers.");
-            break;
-        }
-
-        let archive_path = match find_archive_file(&conversations_dir, *ln) {
-            Ok(p) => p,
-            Err(e) => {
-                println!(
-                    "  {YELLOW}⚠{RESET} [{}/{}] log {ln:03}: {e}",
-                    idx + 1,
-                    total_count
-                );
-                totals.errors.push(format!("log {ln:03}: {e}"));
-                continue;
-            }
+    serve_client::exclusive(memory_dir, |gm| async move {
+        // Determine which log numbers to process
+        let log_numbers: Vec<u32> = if let Some(ln) = log {
+            vec![ln]
+        } else if all {
+            gm.unextracted_log_numbers()
+                .await?
+                .into_iter()
+                .map(|n| n as u32)
+                .collect()
+        } else {
+            return Err(RecallError::Other("Specify --log <N> or --all".into()));
         };
 
-        let content = std::fs::read_to_string(&archive_path)?;
-        let (session_id, _) = extract_archive_metadata(&content, &archive_path);
+        if log_numbers.is_empty() {
+            println!("{YELLOW}No unextracted archives found.{RESET}");
+            return Ok(());
+        }
 
-        // Try extraction, retry once on failure, quarantine on second failure
-        let report = match gm
-            .extract_from_archive(&content, &session_id, Some(*ln), &*llm)
-            .await
-        {
-            Ok(r) => r,
-            Err(e) => {
+        let conversations_dir = find_conversations_dir(memory_dir)?;
+
+        if dry_run {
+            print_extract_dry_run(&conversations_dir, &log_numbers);
+            return Ok(());
+        }
+
+        // Build LLM provider from .recall-echo.toml (CLI flags override)
+        let (llm, model_name) = crate::llm_provider::create_provider(
+            memory_dir,
+            provider_override.as_deref(),
+            model_override.as_deref(),
+        )?;
+
+        let total_count = log_numbers.len();
+        let budget_label = if max_tokens > 0 {
+            format!(" (budget: {})", format_tokens(max_tokens))
+        } else {
+            String::new()
+        };
+        println!(
+            "{BOLD}Extracting entities from {total_count} archives using {model_name}{budget_label}{RESET}",
+        );
+
+        let quarantine_path = graph_dir.join("extraction-quarantine.txt");
+        let mut totals = ExtractionTotals::default();
+
+        for (idx, ln) in log_numbers.iter().enumerate() {
+            // Budget check
+            if max_tokens > 0 && totals.estimated_tokens >= max_tokens {
                 println!(
-                    "  {YELLOW}⚠{RESET} [{}/{}] log {ln:03}: failed, retrying... ({e})",
-                    idx + 1,
-                    total_count
+                    "\n{YELLOW}⚠ Token budget exhausted (~{} / {}). Stopping.{RESET}",
+                    format_tokens(totals.estimated_tokens),
+                    format_tokens(max_tokens),
                 );
-                match gm
-                    .extract_from_archive(&content, &session_id, Some(*ln), &*llm)
-                    .await
-                {
-                    Ok(r) => r,
-                    Err(e2) => {
-                        println!(
-                            "  {YELLOW}✗{RESET} [{}/{}] log {ln:03}: quarantined ({e2})",
-                            idx + 1,
-                            total_count
-                        );
-                        totals.quarantined.push(*ln);
-                        totals
-                            .errors
-                            .push(format!("log {ln:03}: quarantined after retry: {e2}"));
-                        continue;
+                println!("  Re-run to continue — resume is automatic via unextracted log numbers.");
+                break;
+            }
+
+            let archive_path = match find_archive_file(&conversations_dir, *ln) {
+                Ok(p) => p,
+                Err(e) => {
+                    println!(
+                        "  {YELLOW}⚠{RESET} [{}/{}] log {ln:03}: {e}",
+                        idx + 1,
+                        total_count
+                    );
+                    totals.errors.push(format!("log {ln:03}: {e}"));
+                    continue;
+                }
+            };
+
+            let content = std::fs::read_to_string(&archive_path)?;
+            let (session_id, _) = extract_archive_metadata(&content, &archive_path);
+
+            // Try extraction, retry once on failure, quarantine on second failure
+            let report = match gm
+                .extract_from_archive(&content, &session_id, Some(*ln), &*llm)
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    println!(
+                        "  {YELLOW}⚠{RESET} [{}/{}] log {ln:03}: failed, retrying... ({e})",
+                        idx + 1,
+                        total_count
+                    );
+                    match gm
+                        .extract_from_archive(&content, &session_id, Some(*ln), &*llm)
+                        .await
+                    {
+                        Ok(r) => r,
+                        Err(e2) => {
+                            println!(
+                                "  {YELLOW}✗{RESET} [{}/{}] log {ln:03}: quarantined ({e2})",
+                                idx + 1,
+                                total_count
+                            );
+                            totals.quarantined.push(*ln);
+                            totals
+                                .errors
+                                .push(format!("log {ln:03}: quarantined after retry: {e2}"));
+                            continue;
+                        }
                     }
                 }
+            };
+
+            println!(
+                "  {GREEN}✓{RESET} [{}/{}] log {ln:03}: +{} entities, ~{} merged, -{} skipped, {} rels (~{})",
+                idx + 1,
+                total_count,
+                report.entities_created,
+                report.entities_merged,
+                report.entities_skipped,
+                report.relationships_created,
+                format_tokens(report.estimated_tokens),
+            );
+
+            gm.mark_extracted(*ln).await?;
+
+            totals.entities_created += report.entities_created;
+            totals.entities_merged += report.entities_merged;
+            totals.entities_skipped += report.entities_skipped;
+            totals.relationships += report.relationships_created;
+            totals.errors.extend(report.errors);
+            totals.processed += 1;
+            totals.estimated_tokens += report.estimated_tokens;
+
+            // Rate limiting between archives
+            if delay_ms > 0 && *ln != *log_numbers.last().unwrap() {
+                tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
             }
-        };
-
-        println!(
-            "  {GREEN}✓{RESET} [{}/{}] log {ln:03}: +{} entities, ~{} merged, -{} skipped, {} rels (~{})",
-            idx + 1,
-            total_count,
-            report.entities_created,
-            report.entities_merged,
-            report.entities_skipped,
-            report.relationships_created,
-            format_tokens(report.estimated_tokens),
-        );
-
-        gm.mark_extracted(*ln).await?;
-
-        totals.entities_created += report.entities_created;
-        totals.entities_merged += report.entities_merged;
-        totals.entities_skipped += report.entities_skipped;
-        totals.relationships += report.relationships_created;
-        totals.errors.extend(report.errors);
-        totals.processed += 1;
-        totals.estimated_tokens += report.estimated_tokens;
-
-        // Rate limiting between archives
-        if delay_ms > 0 && *ln != *log_numbers.last().unwrap() {
-            tokio::time::sleep(std::time::Duration::from_millis(delay_ms)).await;
         }
-    }
 
-    // Write quarantine file if any archives failed
-    if !totals.quarantined.is_empty() {
-        use std::io::Write;
-        let mut file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(&quarantine_path)?;
-        for ln in &totals.quarantined {
-            writeln!(file, "{ln:03}")?;
+        // Write quarantine file if any archives failed
+        if !totals.quarantined.is_empty() {
+            use std::io::Write;
+            let mut file = std::fs::OpenOptions::new()
+                .create(true)
+                .append(true)
+                .open(&quarantine_path)?;
+            for ln in &totals.quarantined {
+                writeln!(file, "{ln:03}")?;
+            }
+            println!(
+                "\n  {YELLOW}Quarantined {} archives → {}{RESET}",
+                totals.quarantined.len(),
+                quarantine_path.display()
+            );
         }
-        println!(
-            "\n  {YELLOW}Quarantined {} archives → {}{RESET}",
-            totals.quarantined.len(),
-            quarantine_path.display()
-        );
-    }
 
-    print_extract_summary(&totals);
-    Ok(())
+        print_extract_summary(&totals);
+        Ok(())
+    })
+    .await
 }
 
 // ── Vigil sync commands ──────────────────────────────────────────────
@@ -659,28 +704,29 @@ pub async fn vigil_sync(
     let sig_path = signals_path.unwrap_or(&default_signals);
     let out_path = outcomes_path.unwrap_or(&default_outcomes);
 
-    let gm = GraphMemory::open(&graph_dir).await?;
+    serve_client::exclusive(memory_dir, |gm| async move {
+        let report = gm.sync_vigil(sig_path, out_path).await?;
 
-    let report = gm.sync_vigil(sig_path, out_path).await?;
+        println!("{BOLD}Vigil Sync{RESET}");
+        println!("  Measurements: +{}", report.measurements_created);
+        println!("  Outcomes:     +{}", report.outcomes_created);
+        println!("  Relationships: +{}", report.relationships_created);
+        println!("  Skipped:       {}", report.skipped);
 
-    println!("{BOLD}Vigil Sync{RESET}");
-    println!("  Measurements: +{}", report.measurements_created);
-    println!("  Outcomes:     +{}", report.outcomes_created);
-    println!("  Relationships: +{}", report.relationships_created);
-    println!("  Skipped:       {}", report.skipped);
-
-    if !report.errors.is_empty() {
-        println!("\n  {YELLOW}Warnings:{RESET}");
-        for err in &report.errors {
-            println!("    {DIM}{err}{RESET}");
+        if !report.errors.is_empty() {
+            println!("\n  {YELLOW}Warnings:{RESET}");
+            for err in &report.errors {
+                println!("    {DIM}{err}{RESET}");
+            }
         }
-    }
 
-    if report.measurements_created == 0 && report.outcomes_created == 0 {
-        println!("\n  {DIM}No new data — graph is in sync.{RESET}");
-    }
+        if report.measurements_created == 0 && report.outcomes_created == 0 {
+            println!("\n  {DIM}No new data — graph is in sync.{RESET}");
+        }
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 // ── Pipeline commands ──────────────────────────────────────────────────
@@ -724,32 +770,35 @@ pub async fn pipeline_sync(
     // Read pipeline documents
     let docs = read_pipeline_docs(&docs_dir)?;
 
-    let gm = GraphMemory::open(&graph_dir).await?;
+    serve_client::exclusive(memory_dir, |gm| async move {
+        let report = gm.sync_pipeline(&docs).await?;
 
-    let report = gm.sync_pipeline(&docs).await?;
+        println!("{BOLD}Pipeline Sync{RESET}");
+        println!("  Created:      {}", report.entities_created);
+        println!("  Updated:      {}", report.entities_updated);
+        println!("  Archived:     {}", report.entities_archived);
+        println!(
+            "  Relationships: +{} / ~{} skipped",
+            report.relationships_created, report.relationships_skipped
+        );
 
-    println!("{BOLD}Pipeline Sync{RESET}");
-    println!("  Created:      {}", report.entities_created);
-    println!("  Updated:      {}", report.entities_updated);
-    println!("  Archived:     {}", report.entities_archived);
-    println!(
-        "  Relationships: +{} / ~{} skipped",
-        report.relationships_created, report.relationships_skipped
-    );
-
-    if !report.errors.is_empty() {
-        println!("\n  {YELLOW}Warnings:{RESET}");
-        for err in &report.errors {
-            println!("    {DIM}{err}{RESET}");
+        if !report.errors.is_empty() {
+            println!("\n  {YELLOW}Warnings:{RESET}");
+            for err in &report.errors {
+                println!("    {DIM}{err}{RESET}");
+            }
         }
-    }
 
-    if report.entities_created == 0 && report.entities_updated == 0 && report.entities_archived == 0
-    {
-        println!("\n  {DIM}No changes — graph is in sync.{RESET}");
-    }
+        if report.entities_created == 0
+            && report.entities_updated == 0
+            && report.entities_archived == 0
+        {
+            println!("\n  {DIM}No changes — graph is in sync.{RESET}");
+        }
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// Show pipeline health stats.
@@ -761,55 +810,58 @@ pub async fn pipeline_status(memory_dir: &Path, staleness_days: u32) -> Result<(
         ));
     }
 
-    let gm = GraphMemory::open(&graph_dir).await?;
+    serve_client::exclusive(memory_dir, |gm| async move {
+        let stats = gm.pipeline_stats(staleness_days).await?;
 
-    let stats = gm.pipeline_stats(staleness_days).await?;
+        println!(
+            "{BOLD}Pipeline Status{RESET} ({} entities)",
+            stats.total_entities
+        );
 
-    println!(
-        "{BOLD}Pipeline Status{RESET} ({} entities)",
-        stats.total_entities
-    );
+        if stats.by_stage.is_empty() {
+            println!(
+                "  {DIM}No pipeline entities in graph. Run `graph pipeline sync` first.{RESET}"
+            );
+            return Ok(());
+        }
 
-    if stats.by_stage.is_empty() {
-        println!("  {DIM}No pipeline entities in graph. Run `graph pipeline sync` first.{RESET}");
-        return Ok(());
-    }
-
-    // Display stages in pipeline order
-    let stage_order = ["learning", "thoughts", "curiosity", "reflections", "praxis"];
-    for stage in &stage_order {
-        if let Some(statuses) = stats.by_stage.get(*stage) {
-            println!("\n  {CYAN}{}{RESET}", stage.to_uppercase());
-            let mut items: Vec<_> = statuses.iter().collect();
-            items.sort_by_key(|(s, _)| (*s).clone());
-            for (status, count) in items {
-                println!("    {status}: {count}");
+        // Display stages in pipeline order
+        let stage_order = ["learning", "thoughts", "curiosity", "reflections", "praxis"];
+        for stage in &stage_order {
+            if let Some(statuses) = stats.by_stage.get(*stage) {
+                println!("\n  {CYAN}{}{RESET}", stage.to_uppercase());
+                let mut items: Vec<_> = statuses.iter().collect();
+                items.sort_by_key(|(s, _)| (*s).clone());
+                for (status, count) in items {
+                    println!("    {status}: {count}");
+                }
             }
         }
-    }
 
-    if !stats.stale_thoughts.is_empty() {
-        println!("\n  {YELLOW}Stale thoughts (>{staleness_days}d):{RESET}");
-        for entity in &stats.stale_thoughts {
-            println!("    {DIM}•{RESET} {}", entity.name);
+        if !stats.stale_thoughts.is_empty() {
+            println!("\n  {YELLOW}Stale thoughts (>{staleness_days}d):{RESET}");
+            for entity in &stats.stale_thoughts {
+                println!("    {DIM}•{RESET} {}", entity.name);
+            }
         }
-    }
 
-    if !stats.stale_questions.is_empty() {
-        println!(
-            "\n  {YELLOW}Stale questions (>{}d):{RESET}",
-            staleness_days * 2
-        );
-        for entity in &stats.stale_questions {
-            println!("    {DIM}•{RESET} {}", entity.name);
+        if !stats.stale_questions.is_empty() {
+            println!(
+                "\n  {YELLOW}Stale questions (>{}d):{RESET}",
+                staleness_days * 2
+            );
+            for entity in &stats.stale_questions {
+                println!("    {DIM}•{RESET} {}", entity.name);
+            }
         }
-    }
 
-    if let Some(ref last) = stats.last_movement {
-        println!("\n  {DIM}Last movement: {last}{RESET}");
-    }
+        if let Some(ref last) = stats.last_movement {
+            println!("\n  {DIM}Last movement: {last}{RESET}");
+        }
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// Trace pipeline flow for an entity.
@@ -821,24 +873,25 @@ pub async fn pipeline_flow(memory_dir: &Path, entity_name: &str) -> Result<(), R
         ));
     }
 
-    let gm = GraphMemory::open(&graph_dir).await?;
+    serve_client::exclusive(memory_dir, |gm| async move {
+        let chain = gm.pipeline_flow(entity_name).await?;
 
-    let chain = gm.pipeline_flow(entity_name).await?;
+        if chain.is_empty() {
+            println!("{YELLOW}No pipeline relationships found for \"{entity_name}\".{RESET}");
+            return Ok(());
+        }
 
-    if chain.is_empty() {
-        println!("{YELLOW}No pipeline relationships found for \"{entity_name}\".{RESET}");
-        return Ok(());
-    }
+        println!("{BOLD}Pipeline Flow: {entity_name}{RESET}\n");
+        for (source, rel_type, target) in &chain {
+            println!(
+                "  {} ({}) {CYAN}—[{rel_type}]→{RESET} {} ({})",
+                source.name, source.entity_type, target.name, target.entity_type
+            );
+        }
 
-    println!("{BOLD}Pipeline Flow: {entity_name}{RESET}\n");
-    for (source, rel_type, target) in &chain {
-        println!(
-            "  {} ({}) {CYAN}—[{rel_type}]→{RESET} {} ({})",
-            source.name, source.entity_type, target.name, target.entity_type
-        );
-    }
-
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// List stale pipeline entities.
@@ -850,33 +903,34 @@ pub async fn pipeline_stale(memory_dir: &Path, staleness_days: u32) -> Result<()
         ));
     }
 
-    let gm = GraphMemory::open(&graph_dir).await?;
+    serve_client::exclusive(memory_dir, |gm| async move {
+        let stats = gm.pipeline_stats(staleness_days).await?;
 
-    let stats = gm.pipeline_stats(staleness_days).await?;
-
-    let total_stale = stats.stale_thoughts.len() + stats.stale_questions.len();
-    if total_stale == 0 {
-        println!("{GREEN}✓{RESET} No stale pipeline entities.");
-        return Ok(());
-    }
-
-    println!("{BOLD}Stale Pipeline Entities{RESET}\n");
-
-    if !stats.stale_thoughts.is_empty() {
-        println!("  {YELLOW}Thoughts (>{staleness_days} days):{RESET}");
-        for entity in &stats.stale_thoughts {
-            println!("    • {} {DIM}({}){RESET}", entity.name, entity.entity_type);
+        let total_stale = stats.stale_thoughts.len() + stats.stale_questions.len();
+        if total_stale == 0 {
+            println!("{GREEN}✓{RESET} No stale pipeline entities.");
+            return Ok(());
         }
-    }
 
-    if !stats.stale_questions.is_empty() {
-        println!("  {YELLOW}Questions (>{} days):{RESET}", staleness_days * 2);
-        for entity in &stats.stale_questions {
-            println!("    • {} {DIM}({}){RESET}", entity.name, entity.entity_type);
+        println!("{BOLD}Stale Pipeline Entities{RESET}\n");
+
+        if !stats.stale_thoughts.is_empty() {
+            println!("  {YELLOW}Thoughts (>{staleness_days} days):{RESET}");
+            for entity in &stats.stale_thoughts {
+                println!("    • {} {DIM}({}){RESET}", entity.name, entity.entity_type);
+            }
         }
-    }
 
-    Ok(())
+        if !stats.stale_questions.is_empty() {
+            println!("  {YELLOW}Questions (>{} days):{RESET}", staleness_days * 2);
+            for entity in &stats.stale_questions {
+                println!("    • {} {DIM}({}){RESET}", entity.name, entity.entity_type);
+            }
+        }
+
+        Ok(())
+    })
+    .await
 }
 
 /// Read pipeline documents from a directory.
@@ -942,90 +996,93 @@ pub async fn gc(
         ));
     }
 
-    let gm = GraphMemory::open(&graph_dir).await?;
-
-    if stats_only {
-        let stats = gm.gc_stats().await?;
-        println!("{BOLD}Graph Health{RESET}");
-        println!("  Entities:              {}", stats.total_entities);
-        println!("  Relationships:         {}", stats.total_relationships);
-        println!(
-            "  Pipeline entities:     {} {DIM}(protected){RESET}",
-            stats.pipeline_entities
-        );
-        println!("  Zero-access entities:  {}", stats.zero_access_entities);
-        println!(
-            "  Low confidence rels:   {} {DIM}(< 0.5){RESET}",
-            stats.low_confidence_rels
-        );
-        println!(
-            "  Very low conf. rels:   {} {DIM}(< 0.2){RESET}",
-            stats.very_low_confidence_rels
-        );
-        println!("  Superseded rels:       {}", stats.superseded_rels);
-        return Ok(());
-    }
-
-    let config = GcConfig {
-        stale_days,
-        stale_confidence,
-        dead_confidence,
-        dead_min_age_days,
-        dry_run: !execute,
-        protect_pipeline: true,
-    };
-
-    let report = gm.run_gc(&config).await?;
-
-    // Header
-    if report.dry_run {
-        println!("{BOLD}{YELLOW}GC Dry Run{RESET} {DIM}(pass --execute to actually delete){RESET}");
-    } else {
-        println!("{BOLD}{GREEN}GC Executed{RESET}");
-    }
-
-    println!("\n{BOLD}Scan{RESET}");
-    println!("  Entities scanned:      {}", report.entities_scanned);
-    println!("  Relationships scanned: {}", report.relationships_scanned);
-
-    println!("\n{BOLD}Results{RESET}");
-    println!("  Stale relationships:   {}", report.stale_relationships);
-    println!("  Dead relationships:    {}", report.dead_relationships);
-    println!("  Orphaned entities:     {}", report.orphaned_entities);
-
-    let verb = if report.dry_run {
-        "would remove"
-    } else {
-        "removed"
-    };
-    println!("  Total {verb}:         {}", report.total_removed);
-
-    // Details
-    if !report.actions.is_empty() {
-        println!("\n{BOLD}Actions{RESET}");
-        for action in &report.actions {
-            let icon = match action.kind {
-                GcActionKind::StaleRelationship => format!("{YELLOW}⚠{RESET}"),
-                GcActionKind::DeadRelationship => format!("{YELLOW}✗{RESET}"),
-                GcActionKind::OrphanedEntity => format!("{CYAN}○{RESET}"),
-            };
+    serve_client::exclusive(memory_dir, |gm| async move {
+        if stats_only {
+            let stats = gm.gc_stats().await?;
+            println!("{BOLD}Graph Health{RESET}");
+            println!("  Entities:              {}", stats.total_entities);
+            println!("  Relationships:         {}", stats.total_relationships);
             println!(
-                "  {icon} [{kind}] {name}",
-                kind = action.kind,
-                name = action.target_name,
+                "  Pipeline entities:     {} {DIM}(protected){RESET}",
+                stats.pipeline_entities
             );
-            println!("    {DIM}{reason}{RESET}", reason = action.reason);
+            println!("  Zero-access entities:  {}", stats.zero_access_entities);
+            println!(
+                "  Low confidence rels:   {} {DIM}(< 0.5){RESET}",
+                stats.low_confidence_rels
+            );
+            println!(
+                "  Very low conf. rels:   {} {DIM}(< 0.2){RESET}",
+                stats.very_low_confidence_rels
+            );
+            println!("  Superseded rels:       {}", stats.superseded_rels);
+            return Ok(());
         }
-    }
 
-    if !report.errors.is_empty() {
-        println!("\n{BOLD}Errors{RESET}");
-        for err in &report.errors {
-            println!("  \x1b[31m✗\x1b[0m {err}");
+        let config = GcConfig {
+            stale_days,
+            stale_confidence,
+            dead_confidence,
+            dead_min_age_days,
+            dry_run: !execute,
+            protect_pipeline: true,
+        };
+
+        let report = gm.run_gc(&config).await?;
+
+        // Header
+        if report.dry_run {
+            println!(
+                "{BOLD}{YELLOW}GC Dry Run{RESET} {DIM}(pass --execute to actually delete){RESET}"
+            );
+        } else {
+            println!("{BOLD}{GREEN}GC Executed{RESET}");
         }
-    }
 
-    Ok(())
+        println!("\n{BOLD}Scan{RESET}");
+        println!("  Entities scanned:      {}", report.entities_scanned);
+        println!("  Relationships scanned: {}", report.relationships_scanned);
+
+        println!("\n{BOLD}Results{RESET}");
+        println!("  Stale relationships:   {}", report.stale_relationships);
+        println!("  Dead relationships:    {}", report.dead_relationships);
+        println!("  Orphaned entities:     {}", report.orphaned_entities);
+
+        let verb = if report.dry_run {
+            "would remove"
+        } else {
+            "removed"
+        };
+        println!("  Total {verb}:         {}", report.total_removed);
+
+        // Details
+        if !report.actions.is_empty() {
+            println!("\n{BOLD}Actions{RESET}");
+            for action in &report.actions {
+                let icon = match action.kind {
+                    GcActionKind::StaleRelationship => format!("{YELLOW}⚠{RESET}"),
+                    GcActionKind::DeadRelationship => format!("{YELLOW}✗{RESET}"),
+                    GcActionKind::OrphanedEntity => format!("{CYAN}○{RESET}"),
+                };
+                println!(
+                    "  {icon} [{kind}] {name}",
+                    kind = action.kind,
+                    name = action.target_name,
+                );
+                println!("    {DIM}{reason}{RESET}", reason = action.reason);
+            }
+        }
+
+        if !report.errors.is_empty() {
+            println!("\n{BOLD}Errors{RESET}");
+            for err in &report.errors {
+                println!("  \x1b[31m✗\x1b[0m {err}");
+            }
+        }
+
+        Ok(())
+    })
+    .await
 }
 
 /// Show relationship decay report — lists all relationships with their stored vs effective confidence.
@@ -1044,87 +1101,88 @@ pub async fn decay_report(
         ));
     }
 
-    let gm = GraphMemory::open(&graph_dir).await?;
+    serve_client::exclusive(memory_dir, |gm| async move {
+        let now = chrono::Utc::now();
 
-    let now = chrono::Utc::now();
-
-    let rels = if let Some(name) = entity_name {
-        gm.get_relationships(name, Direction::Both).await?
-    } else {
-        crate::graph::crud::list_all_relationships(gm.db()).await?
-    };
-
-    if rels.is_empty() {
-        println!("{YELLOW}No relationships found.{RESET}");
-        return Ok(());
-    }
-
-    println!(
-        "{BOLD}Decay Report{RESET} ({} relationships, half-life: {} days)\n",
-        rels.len(),
-        confidence::DEFAULT_HALF_LIFE_DAYS
-    );
-
-    let mut decayed_count = 0u32;
-    let mut total_decay = 0.0_f64;
-
-    for rel in &rels {
-        let effective = confidence::effective_confidence(
-            rel.confidence,
-            rel.last_reinforced.as_ref(),
-            &rel.valid_from,
-            &now,
-        );
-
-        let decay_amount = rel.confidence - effective;
-        if decay_amount > 0.001 {
-            decayed_count += 1;
-        }
-        total_decay += decay_amount;
-
-        if !show_all && decay_amount < 0.001 {
-            continue;
-        }
-
-        let from_short = match &rel.from_id {
-            serde_json::Value::String(s) => s.split(':').next_back().unwrap_or(s).to_string(),
-            other => other.to_string(),
-        };
-        let to_short = match &rel.to_id {
-            serde_json::Value::String(s) => s.split(':').next_back().unwrap_or(s).to_string(),
-            other => other.to_string(),
-        };
-
-        let reinforced_tag = match &rel.last_reinforced {
-            Some(serde_json::Value::String(s)) => format!(" {DIM}(reinforced: {s}){RESET}"),
-            _ => String::new(),
-        };
-
-        let decay_indicator = if decay_amount > 0.2 {
-            format!("\x1b[31m↓{:.0}%\x1b[0m", decay_amount * 100.0)
-        } else if decay_amount > 0.05 {
-            format!("{YELLOW}↓{:.0}%{RESET}", decay_amount * 100.0)
+        let rels = if let Some(name) = entity_name {
+            gm.get_relationships(name, Direction::Both).await?
         } else {
-            format!("{DIM}≈{RESET}")
+            crate::graph::crud::list_all_relationships(gm.db()).await?
         };
+
+        if rels.is_empty() {
+            println!("{YELLOW}No relationships found.{RESET}");
+            return Ok(());
+        }
 
         println!(
-            "  {from_short} {CYAN}—[{}]→{RESET} {to_short}  stored:{:.2} effective:{:.2} {decay_indicator}{reinforced_tag}",
-            rel.rel_type, rel.confidence, effective,
+            "{BOLD}Decay Report{RESET} ({} relationships, half-life: {} days)\n",
+            rels.len(),
+            confidence::DEFAULT_HALF_LIFE_DAYS
         );
-    }
 
-    println!(
-        "\n{BOLD}Summary{RESET}: {decayed_count}/{} relationships decayed, avg decay: {:.3}",
-        rels.len(),
-        if rels.is_empty() {
-            0.0
-        } else {
-            total_decay / rels.len() as f64
+        let mut decayed_count = 0u32;
+        let mut total_decay = 0.0_f64;
+
+        for rel in &rels {
+            let effective = confidence::effective_confidence(
+                rel.confidence,
+                rel.last_reinforced.as_ref(),
+                &rel.valid_from,
+                &now,
+            );
+
+            let decay_amount = rel.confidence - effective;
+            if decay_amount > 0.001 {
+                decayed_count += 1;
+            }
+            total_decay += decay_amount;
+
+            if !show_all && decay_amount < 0.001 {
+                continue;
+            }
+
+            let from_short = match &rel.from_id {
+                serde_json::Value::String(s) => s.split(':').next_back().unwrap_or(s).to_string(),
+                other => other.to_string(),
+            };
+            let to_short = match &rel.to_id {
+                serde_json::Value::String(s) => s.split(':').next_back().unwrap_or(s).to_string(),
+                other => other.to_string(),
+            };
+
+            let reinforced_tag = match &rel.last_reinforced {
+                Some(serde_json::Value::String(s)) => format!(" {DIM}(reinforced: {s}){RESET}"),
+                _ => String::new(),
+            };
+
+            let decay_indicator = if decay_amount > 0.2 {
+                format!("\x1b[31m↓{:.0}%\x1b[0m", decay_amount * 100.0)
+            } else if decay_amount > 0.05 {
+                format!("{YELLOW}↓{:.0}%{RESET}", decay_amount * 100.0)
+            } else {
+                format!("{DIM}≈{RESET}")
+            };
+
+            println!(
+                "  {from_short} {CYAN}—[{}]→{RESET} {to_short}  stored:{:.2} effective:{:.2} {decay_indicator}{reinforced_tag}",
+                rel.rel_type, rel.confidence, effective,
+            );
         }
-    );
 
-    Ok(())
+        println!(
+            "\n{BOLD}Summary{RESET}: {decayed_count}/{} relationships decayed, avg decay: {:.3}",
+            rels.len(),
+            if rels.is_empty() {
+                0.0
+            } else {
+                total_decay / rels.len() as f64
+            }
+        );
+
+        Ok(())
+    })
+    .await
 }
 
 /// Find the archive file for a given log number.

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -770,35 +770,30 @@ pub async fn pipeline_sync(
     // Read pipeline documents
     let docs = read_pipeline_docs(&docs_dir)?;
 
-    serve_client::exclusive(memory_dir, |gm| async move {
-        let report = gm.sync_pipeline(&docs).await?;
+    let report = crate::graph_bridge::sync_pipeline_into_graph(memory_dir, docs).await?;
 
-        println!("{BOLD}Pipeline Sync{RESET}");
-        println!("  Created:      {}", report.entities_created);
-        println!("  Updated:      {}", report.entities_updated);
-        println!("  Archived:     {}", report.entities_archived);
-        println!(
-            "  Relationships: +{} / ~{} skipped",
-            report.relationships_created, report.relationships_skipped
-        );
+    println!("{BOLD}Pipeline Sync{RESET}");
+    println!("  Created:      {}", report.entities_created);
+    println!("  Updated:      {}", report.entities_updated);
+    println!("  Archived:     {}", report.entities_archived);
+    println!(
+        "  Relationships: +{} / ~{} skipped",
+        report.relationships_created, report.relationships_skipped
+    );
 
-        if !report.errors.is_empty() {
-            println!("\n  {YELLOW}Warnings:{RESET}");
-            for err in &report.errors {
-                println!("    {DIM}{err}{RESET}");
-            }
+    if !report.errors.is_empty() {
+        println!("\n  {YELLOW}Warnings:{RESET}");
+        for err in &report.errors {
+            println!("    {DIM}{err}{RESET}");
         }
+    }
 
-        if report.entities_created == 0
-            && report.entities_updated == 0
-            && report.entities_archived == 0
-        {
-            println!("\n  {DIM}No changes — graph is in sync.{RESET}");
-        }
+    if report.entities_created == 0 && report.entities_updated == 0 && report.entities_archived == 0
+    {
+        println!("\n  {DIM}No changes — graph is in sync.{RESET}");
+    }
 
-        Ok(())
-    })
-    .await
+    Ok(())
 }
 
 /// Show pipeline health stats.

--- a/src/init.rs
+++ b/src/init.rs
@@ -181,7 +181,10 @@ fn init_graph(memory_dir: &Path) {
         return;
     }
 
-    match tokio::runtime::Runtime::new() {
+    let runtime = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build();
+    match runtime {
         Ok(rt) => match rt.block_on(crate::graph::GraphMemory::open(&graph_dir)) {
             Ok(_) => print_status(
                 Status::Created,

--- a/src/init.rs
+++ b/src/init.rs
@@ -183,7 +183,10 @@ fn init_graph(memory_dir: &Path) {
 
     match tokio::runtime::Runtime::new() {
         Ok(rt) => match rt.block_on(crate::graph::GraphMemory::open(&graph_dir)) {
-            Ok(_) => print_status(Status::Created, "Created graph/ (SurrealDB + fastembed)"),
+            Ok(_) => print_status(
+                Status::Created,
+                "Created graph/ (SurrealDB; embedding model downloads on first use)",
+            ),
             Err(e) => print_status(Status::Error, &format!("Failed to init graph: {e}")),
         },
         Err(e) => print_status(Status::Error, &format!("Failed to start runtime: {e}")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ pub mod paths;
 pub mod search;
 pub mod serve;
 pub mod serve_client;
+mod serve_security;
 pub mod status;
 pub mod summarize;
 pub mod tags;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,8 @@ pub mod init;
 pub mod jsonl;
 pub mod paths;
 pub mod search;
+pub mod serve;
+pub mod serve_client;
 pub mod status;
 pub mod summarize;
 pub mod tags;

--- a/src/main.rs
+++ b/src/main.rs
@@ -451,7 +451,7 @@ fn main() {
         }) => {
             let root = resolve_entity_root(entity_root);
             let memory_dir = root.join("memory");
-            tokio::runtime::Runtime::new()
+            client_runtime()
                 .map_err(recall_echo::error::RecallError::from)
                 .and_then(|rt| {
                     rt.block_on(async {
@@ -628,6 +628,15 @@ fn main() {
         eprintln!("\x1b[31m\u{2717}\x1b[0m {e}");
         std::process::exit(1);
     }
+}
+
+/// A runtime for a command that talks to the graph daemon: mostly socket
+/// round-trips, so one thread is enough. Only the daemon itself, which serves
+/// concurrent connections, needs the multi-thread runtime.
+fn client_runtime() -> std::io::Result<tokio::runtime::Runtime> {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
 }
 
 /// Run the graph daemon for a memory directory until it stops.

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,16 @@ enum Commands {
         #[arg(long)]
         entity_root: Option<PathBuf>,
     },
+    /// Run the graph daemon (started automatically by graph commands and hooks)
+    Serve {
+        /// Memory directory to serve (defaults to {entity_root}/memory)
+        #[arg(long)]
+        dir: Option<PathBuf>,
+        /// Stay in the foreground: log to stderr and never idle-shut-down
+        /// (for systemd units and debugging)
+        #[arg(long)]
+        foreground: bool,
+    },
     /// Knowledge graph operations
     Graph {
         #[command(subcommand)]
@@ -316,6 +326,11 @@ enum GraphCommands {
         #[arg(long)]
         outcomes_path: Option<PathBuf>,
     },
+    /// Inspect or stop the graph daemon
+    Daemon {
+        #[command(subcommand)]
+        command: DaemonCommands,
+    },
     /// Show relationship decay report — stored vs effective confidence
     DecayReport {
         /// Show only relationships for a specific entity
@@ -325,6 +340,14 @@ enum GraphCommands {
         #[arg(long)]
         all: bool,
     },
+}
+
+#[derive(Subcommand)]
+enum DaemonCommands {
+    /// Show the daemon's socket, pid, version and uptime
+    Status,
+    /// Stop the daemon serving this graph
+    Stop,
 }
 
 #[derive(Subcommand)]
@@ -418,6 +441,10 @@ fn main() {
         }
         #[cfg(feature = "bench")]
         Some(Commands::Bench { command }) => run_bench(command),
+        Some(Commands::Serve { dir, foreground }) => {
+            let memory_dir = dir.unwrap_or_else(|| resolve_entity_root(None).join("memory"));
+            run_serve(&memory_dir, foreground)
+        }
         Some(Commands::Graph {
             command,
             entity_root,
@@ -568,6 +595,12 @@ fn main() {
                                 )
                                 .await
                             }
+                            GraphCommands::Daemon { command } => match command {
+                                DaemonCommands::Status => {
+                                    graph_cli::daemon_status(&memory_dir).await
+                                }
+                                DaemonCommands::Stop => graph_cli::daemon_stop(&memory_dir).await,
+                            },
                             GraphCommands::DecayReport { entity, all } => {
                                 graph_cli::decay_report(&memory_dir, entity.as_deref(), all).await
                             }
@@ -595,6 +628,19 @@ fn main() {
         eprintln!("\x1b[31m\u{2717}\x1b[0m {e}");
         std::process::exit(1);
     }
+}
+
+/// Run the graph daemon for a memory directory until it stops.
+fn run_serve(
+    memory_dir: &std::path::Path,
+    foreground: bool,
+) -> Result<(), recall_echo::error::RecallError> {
+    use recall_echo::serve::{run, ServeOptions};
+
+    let options = ServeOptions::from_config(memory_dir, foreground)?;
+    tokio::runtime::Runtime::new()
+        .map_err(recall_echo::error::RecallError::from)
+        .and_then(|rt| rt.block_on(run(options)))
 }
 
 fn resolve_entity_root(explicit: Option<PathBuf>) -> PathBuf {

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -56,6 +56,17 @@ pub fn claude_dir() -> Result<PathBuf, RecallError> {
     Ok(home.join(".claude"))
 }
 
+/// Expand a leading `~/` to the home directory. Other paths pass through.
+#[must_use]
+pub fn expand_tilde(path: &str) -> String {
+    if let Some(rest) = path.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(rest).to_string_lossy().to_string();
+        }
+    }
+    path.to_string()
+}
+
 /// Detect Claude Code installation.
 /// Returns Some(~/.claude/) if it exists, None otherwise.
 #[must_use]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,0 +1,1017 @@
+//! `recall-echo serve` — the graph daemon.
+//!
+//! One daemon per memory directory owns the embedded graph store and answers
+//! command-level requests over a unix socket, one JSON object per line:
+//!
+//! ```text
+//! → {"op":"search","args":{"query":"rust","limit":5}}
+//! ← {"ok":true,"data":[ ... ]}
+//! ```
+//!
+//! The daemon is *crash-only*: it keeps no state outside the database, so it
+//! can be killed at any instant. Clients ([`crate::serve_client`]) detect the
+//! dead socket, clean it up and start a fresh daemon.
+//!
+//! Unix only — the socket is a plain `UnixListener`, with no transport
+//! abstraction (see RE-29 decisions log).
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use serde::{Deserialize, Serialize};
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::{UnixListener, UnixStream};
+use tokio::sync::Notify;
+
+use crate::error::RecallError;
+use crate::graph::error::GraphError;
+use crate::graph::types::{EntityType, NewEntity, NewRelationship, QueryOptions, SearchOptions};
+use crate::graph::GraphMemory;
+
+/// Longest idle-poll interval; keeps a long-lived daemon from spinning.
+const MAX_IDLE_POLL: Duration = Duration::from_secs(30);
+/// Shortest idle-poll interval; keeps short test timeouts responsive.
+const MIN_IDLE_POLL: Duration = Duration::from_millis(100);
+
+// ── Protocol ─────────────────────────────────────────────────────────────
+
+/// A client request. Wire form is `{"op": "...", "args": {...}}`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "op", content = "args", rename_all = "snake_case")]
+pub enum Request {
+    /// Version handshake — returns [`DaemonInfo`].
+    Hello,
+    /// Graph counts.
+    Status,
+    /// Semantic entity search.
+    Search(SearchArgs),
+    /// Semantic episode search.
+    SearchEpisodes(SearchEpisodesArgs),
+    /// Hybrid query: semantic + graph expansion + optional episodes.
+    Query(QueryArgs),
+    /// Traverse relationships from a named entity.
+    Traverse(TraverseArgs),
+    /// Create an entity.
+    AddEntity(AddEntityArgs),
+    /// Create a relationship between two named entities.
+    Relate(RelateArgs),
+    /// Ingest a conversation archive (episodes only, no LLM extraction).
+    IngestArchive(IngestArchiveArgs),
+    /// Ask the daemon to exit.
+    Shutdown,
+}
+
+impl Request {
+    /// Short name of the operation, for logs.
+    #[must_use]
+    pub fn op_name(&self) -> &'static str {
+        match self {
+            Request::Hello => "hello",
+            Request::Status => "status",
+            Request::Search(_) => "search",
+            Request::SearchEpisodes(_) => "search_episodes",
+            Request::Query(_) => "query",
+            Request::Traverse(_) => "traverse",
+            Request::AddEntity(_) => "add_entity",
+            Request::Relate(_) => "relate",
+            Request::IngestArchive(_) => "ingest_archive",
+            Request::Shutdown => "shutdown",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchArgs {
+    pub query: String,
+    pub limit: usize,
+    #[serde(default)]
+    pub entity_type: Option<String>,
+    #[serde(default)]
+    pub keyword: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchEpisodesArgs {
+    pub query: String,
+    pub limit: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct QueryArgs {
+    pub query: String,
+    pub limit: usize,
+    #[serde(default)]
+    pub entity_type: Option<String>,
+    #[serde(default)]
+    pub keyword: Option<String>,
+    pub depth: u32,
+    pub episodes: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TraverseArgs {
+    pub entity: String,
+    pub depth: u32,
+    #[serde(default)]
+    pub type_filter: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AddEntityArgs {
+    pub name: String,
+    pub entity_type: String,
+    pub abstract_text: String,
+    #[serde(default)]
+    pub overview: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct RelateArgs {
+    pub from: String,
+    pub rel_type: String,
+    pub to: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct IngestArchiveArgs {
+    pub content: String,
+    pub session_id: String,
+    #[serde(default)]
+    pub log_number: Option<u32>,
+}
+
+/// A daemon response. Wire form is `{"ok": true, "data": ...}` or
+/// `{"ok": false, "error": {"code": "...", "message": "..."}}`.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Response {
+    pub ok: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<ResponseError>,
+}
+
+/// A named failure. `code` is stable and machine-readable; `message` is the
+/// human-readable text (already prefixed by the error kind, e.g. `store locked`).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct ResponseError {
+    pub code: String,
+    pub message: String,
+}
+
+impl Response {
+    /// A successful response carrying `data`.
+    #[must_use]
+    pub fn success(data: serde_json::Value) -> Self {
+        Self {
+            ok: true,
+            data: Some(data),
+            error: None,
+        }
+    }
+
+    /// A failed response with a stable `code` and human-readable `message`.
+    #[must_use]
+    pub fn failure(code: impl Into<String>, message: impl Into<String>) -> Self {
+        Self {
+            ok: false,
+            data: None,
+            error: Some(ResponseError {
+                code: code.into(),
+                message: message.into(),
+            }),
+        }
+    }
+
+    /// Convert a graph error into a coded failure response.
+    #[must_use]
+    pub fn from_graph_error(err: &GraphError) -> Self {
+        Self::failure(error_code(err), err.to_string())
+    }
+
+    /// Unwrap into the client-side result: data on success, a named
+    /// [`RecallError::Remote`] on failure.
+    pub fn into_result(self) -> Result<serde_json::Value, RecallError> {
+        if self.ok {
+            return Ok(self.data.unwrap_or(serde_json::Value::Null));
+        }
+        let error = self.error.unwrap_or(ResponseError {
+            code: "unknown".into(),
+            message: "daemon reported failure without a message".into(),
+        });
+        Err(RecallError::Remote {
+            code: error.code,
+            message: error.message,
+        })
+    }
+}
+
+/// Stable machine-readable code for a graph error.
+fn error_code(err: &GraphError) -> &'static str {
+    match err {
+        GraphError::Db(_) => "db",
+        GraphError::Locked(_) => "locked",
+        GraphError::Embed(_) => "embedding",
+        GraphError::NotFound(_) => "not_found",
+        GraphError::Extraction(_) => "extraction",
+        GraphError::Dedup(_) => "dedup",
+        GraphError::Llm(_) => "llm",
+        GraphError::Parse(_) => "parse",
+        GraphError::Io(_) => "io",
+        GraphError::Json(_) => "json",
+        GraphError::ImmutableMerge(_) => "immutable_merge",
+    }
+}
+
+/// Identity of a running daemon, returned by [`Request::Hello`].
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct DaemonInfo {
+    pub version: String,
+    pub pid: u32,
+    pub memory_dir: String,
+    pub socket_path: String,
+    pub uptime_secs: u64,
+}
+
+// ── Dispatch ─────────────────────────────────────────────────────────────
+
+/// Execute a graph operation against an open store.
+///
+/// Control operations ([`Request::Hello`], [`Request::Shutdown`]) are owned by
+/// the connection loop and reported as `unsupported` here.
+pub async fn dispatch_graph(graph: &GraphMemory, request: &Request) -> Response {
+    match execute_graph(graph, request).await {
+        Ok(Some(data)) => Response::success(data),
+        Ok(None) => Response::failure(
+            "unsupported",
+            format!(
+                "`{}` is a control operation, not a graph operation",
+                request.op_name()
+            ),
+        ),
+        Err(err) => Response::from_graph_error(&err),
+    }
+}
+
+/// `Ok(None)` means "not a graph operation".
+async fn execute_graph(
+    graph: &GraphMemory,
+    request: &Request,
+) -> Result<Option<serde_json::Value>, GraphError> {
+    let data = match request {
+        Request::Hello | Request::Shutdown => return Ok(None),
+        Request::Status => serde_json::to_value(graph.stats().await?)?,
+        Request::Search(args) => {
+            let options = SearchOptions {
+                limit: args.limit,
+                entity_type: args.entity_type.clone(),
+                keyword: args.keyword.clone(),
+            };
+            serde_json::to_value(graph.search_with_options(&args.query, &options).await?)?
+        }
+        Request::SearchEpisodes(args) => {
+            serde_json::to_value(graph.search_episodes(&args.query, args.limit).await?)?
+        }
+        Request::Query(args) => {
+            let options = QueryOptions {
+                limit: args.limit,
+                entity_type: args.entity_type.clone(),
+                keyword: args.keyword.clone(),
+                graph_depth: args.depth,
+                include_episodes: args.episodes,
+            };
+            serde_json::to_value(graph.query(&args.query, &options).await?)?
+        }
+        Request::Traverse(args) => serde_json::to_value(
+            graph
+                .traverse_filtered(&args.entity, args.depth, args.type_filter.as_deref())
+                .await?,
+        )?,
+        Request::AddEntity(args) => {
+            let entity_type: EntityType = args
+                .entity_type
+                .parse()
+                .map_err(|e: String| GraphError::Parse(e))?;
+            let entity = graph
+                .add_entity(NewEntity {
+                    name: args.name.clone(),
+                    entity_type,
+                    abstract_text: args.abstract_text.clone(),
+                    overview: args.overview.clone(),
+                    content: None,
+                    attributes: None,
+                    source: args.source.clone(),
+                })
+                .await?;
+            serde_json::to_value(entity)?
+        }
+        Request::Relate(args) => {
+            let relationship = graph
+                .add_relationship(NewRelationship {
+                    from_entity: args.from.clone(),
+                    to_entity: args.to.clone(),
+                    rel_type: args.rel_type.clone(),
+                    description: args.description.clone(),
+                    confidence: None,
+                    source: args.source.clone(),
+                })
+                .await?;
+            serde_json::to_value(relationship)?
+        }
+        Request::IngestArchive(args) => {
+            let report = graph
+                .ingest_archive(&args.content, &args.session_id, args.log_number, None)
+                .await?;
+            serde_json::to_value(report)?
+        }
+    };
+    Ok(Some(data))
+}
+
+// ── Idle tracking ────────────────────────────────────────────────────────
+
+/// Tracks daemon activity so an unused daemon shuts itself down.
+///
+/// A daemon is idle when no connection is open *and* the last completed
+/// request is older than the configured timeout. `None` disables idle
+/// shutdown entirely (`--foreground`, or `idle_timeout_secs = 0`).
+#[derive(Debug)]
+pub struct IdleTracker {
+    timeout: Option<Duration>,
+    active: AtomicUsize,
+    last_activity: Mutex<Instant>,
+}
+
+impl IdleTracker {
+    #[must_use]
+    pub fn new(timeout: Option<Duration>) -> Self {
+        Self::new_at(timeout, Instant::now())
+    }
+
+    /// Construct with an explicit start instant (used by tests).
+    #[must_use]
+    pub fn new_at(timeout: Option<Duration>, start: Instant) -> Self {
+        Self {
+            timeout,
+            active: AtomicUsize::new(0),
+            last_activity: Mutex::new(start),
+        }
+    }
+
+    /// Register a connection as open.
+    pub fn begin(&self) {
+        self.active.fetch_add(1, Ordering::SeqCst);
+        self.touch_at(Instant::now());
+    }
+
+    /// Register a connection as closed.
+    pub fn end(&self) {
+        let previous = self.active.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(previous > 0, "IdleTracker::end without begin");
+        self.touch_at(Instant::now());
+    }
+
+    /// Record activity at `now`.
+    pub fn touch_at(&self, now: Instant) {
+        let mut last = self
+            .last_activity
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        *last = now;
+    }
+
+    /// True when the daemon has been unused for longer than the timeout.
+    #[must_use]
+    pub fn is_idle_at(&self, now: Instant) -> bool {
+        let Some(timeout) = self.timeout else {
+            return false;
+        };
+        if self.active.load(Ordering::SeqCst) > 0 {
+            return false;
+        }
+        let last = *self
+            .last_activity
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        now.saturating_duration_since(last) >= timeout
+    }
+
+    /// How often the accept loop should re-check idleness.
+    #[must_use]
+    pub fn poll_interval(&self) -> Duration {
+        match self.timeout {
+            None => MAX_IDLE_POLL,
+            Some(timeout) => (timeout / 10).clamp(MIN_IDLE_POLL, MAX_IDLE_POLL),
+        }
+    }
+}
+
+/// RAII connection counter for [`IdleTracker`].
+struct ActivityGuard(Arc<DaemonContext>);
+
+impl ActivityGuard {
+    fn new(context: Arc<DaemonContext>) -> Self {
+        context.idle.begin();
+        Self(context)
+    }
+}
+
+impl Drop for ActivityGuard {
+    fn drop(&mut self) {
+        self.0.idle.end();
+    }
+}
+
+// ── Logging ──────────────────────────────────────────────────────────────
+
+/// Append-only daemon log at `<memory_dir>/graph/daemon.log`.
+///
+/// Never fails a request: if the file cannot be opened, lines go to stderr.
+pub struct DaemonLog {
+    file: Mutex<Option<std::fs::File>>,
+    echo_stderr: bool,
+}
+
+impl DaemonLog {
+    #[must_use]
+    pub fn open(path: &Path, echo_stderr: bool) -> Self {
+        let file = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .ok();
+        Self {
+            file: Mutex::new(file),
+            echo_stderr,
+        }
+    }
+
+    pub fn log(&self, message: &str) {
+        use std::io::Write as _;
+        let line = format!(
+            "[{}] pid={} {message}\n",
+            chrono::Utc::now().format("%Y-%m-%d %H:%M:%S"),
+            std::process::id(),
+        );
+        let mut guard = self
+            .file
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        match guard.as_mut() {
+            Some(file) => {
+                let _ = file.write_all(line.as_bytes());
+                let _ = file.flush();
+                if self.echo_stderr {
+                    eprint!("{line}");
+                }
+            }
+            None => eprint!("{line}"),
+        }
+    }
+}
+
+// ── Daemon ───────────────────────────────────────────────────────────────
+
+/// Everything `serve` needs to run.
+#[derive(Debug, Clone)]
+pub struct ServeOptions {
+    /// The memory directory whose `graph/` store this daemon owns.
+    pub memory_dir: PathBuf,
+    /// Unix socket to listen on.
+    pub socket_path: PathBuf,
+    /// Idle shutdown timeout; `None` never shuts down.
+    pub idle_timeout: Option<Duration>,
+    /// Mirror the daemon log to stderr (foreground / systemd mode).
+    pub log_to_stderr: bool,
+}
+
+impl ServeOptions {
+    /// Build options from `[serve]` in the memory directory's config.
+    ///
+    /// `foreground` (systemd) disables idle shutdown and mirrors the log to
+    /// stderr, leaving daemon lifetime to the supervisor.
+    pub fn from_config(memory_dir: &Path, foreground: bool) -> Result<Self, RecallError> {
+        let config = crate::config::load_from_dir(memory_dir);
+        let idle_timeout = match (foreground, config.serve.idle_timeout_secs) {
+            (true, _) | (_, 0) => None,
+            (false, secs) => Some(Duration::from_secs(secs)),
+        };
+        Ok(Self {
+            memory_dir: memory_dir.to_path_buf(),
+            socket_path: crate::serve_client::socket_path(memory_dir)?,
+            idle_timeout,
+            log_to_stderr: foreground,
+        })
+    }
+}
+
+/// Shared, immutable-ish daemon state.
+struct DaemonContext {
+    started: Instant,
+    memory_dir: PathBuf,
+    socket_path: PathBuf,
+    idle: IdleTracker,
+    shutdown: Notify,
+}
+
+impl DaemonContext {
+    fn info(&self) -> DaemonInfo {
+        DaemonInfo {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            pid: std::process::id(),
+            memory_dir: self.memory_dir.display().to_string(),
+            socket_path: self.socket_path.display().to_string(),
+            uptime_secs: self.started.elapsed().as_secs(),
+        }
+    }
+}
+
+/// Path of the pidfile that accompanies a socket.
+#[must_use]
+pub fn pidfile_path(socket_path: &Path) -> PathBuf {
+    let mut path = socket_path.as_os_str().to_os_string();
+    path.push(".pid");
+    PathBuf::from(path)
+}
+
+/// Run the daemon until it is asked to stop or goes idle.
+pub async fn run(options: ServeOptions) -> Result<(), RecallError> {
+    let graph_dir = options.memory_dir.join("graph");
+    std::fs::create_dir_all(&graph_dir)?;
+
+    let log = Arc::new(DaemonLog::open(
+        &graph_dir.join("daemon.log"),
+        options.log_to_stderr,
+    ));
+    log.log(&format!(
+        "starting v{} for {} on {}",
+        env!("CARGO_PKG_VERSION"),
+        options.memory_dir.display(),
+        options.socket_path.display()
+    ));
+
+    if crate::serve_client::graph_mode(&options.memory_dir) == "server" {
+        log.log("warning: [graph] mode = \"server\" — clients bypass the daemon");
+    }
+
+    // Own the store before advertising the socket: clients that connect only
+    // after a successful bind never see a half-initialized daemon.
+    let graph = match GraphMemory::open_embedded(&graph_dir).await {
+        Ok(graph) => Arc::new(graph),
+        Err(err) => {
+            log.log(&format!("failed to open graph store: {err}"));
+            return Err(err.into());
+        }
+    };
+
+    let listener = match bind_socket(&options.socket_path) {
+        Ok(listener) => listener,
+        Err(err) => {
+            log.log(&format!("failed to bind socket: {err}"));
+            return Err(err);
+        }
+    };
+    write_pidfile(&options.socket_path)?;
+
+    let context = Arc::new(DaemonContext {
+        started: Instant::now(),
+        memory_dir: options.memory_dir.clone(),
+        socket_path: options.socket_path.clone(),
+        idle: IdleTracker::new(options.idle_timeout),
+        shutdown: Notify::new(),
+    });
+    log.log("ready");
+
+    accept_loop(listener, graph, Arc::clone(&context), Arc::clone(&log)).await;
+
+    let _ = std::fs::remove_file(&options.socket_path);
+    let _ = std::fs::remove_file(pidfile_path(&options.socket_path));
+    log.log("stopped");
+    Ok(())
+}
+
+async fn accept_loop(
+    listener: UnixListener,
+    graph: Arc<GraphMemory>,
+    context: Arc<DaemonContext>,
+    log: Arc<DaemonLog>,
+) {
+    loop {
+        let poll = context.idle.poll_interval();
+        tokio::select! {
+            accepted = listener.accept() => match accepted {
+                Ok((stream, _)) => {
+                    let graph = Arc::clone(&graph);
+                    let context = Arc::clone(&context);
+                    let log = Arc::clone(&log);
+                    tokio::spawn(async move {
+                        handle_connection(stream, graph, context, log).await;
+                    });
+                }
+                Err(err) => log.log(&format!("accept error: {err}")),
+            },
+            () = context.shutdown.notified() => {
+                log.log("shutdown requested");
+                break;
+            }
+            () = tokio::time::sleep(poll) => {
+                if context.idle.is_idle_at(Instant::now()) {
+                    log.log("idle timeout — exiting");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn handle_connection(
+    stream: UnixStream,
+    graph: Arc<GraphMemory>,
+    context: Arc<DaemonContext>,
+    log: Arc<DaemonLog>,
+) {
+    let _activity = ActivityGuard::new(Arc::clone(&context));
+    let (reader, mut writer) = stream.into_split();
+    let mut lines = BufReader::new(reader).lines();
+
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            Ok(None) => break,
+            Err(err) => {
+                log.log(&format!("read error: {err}"));
+                break;
+            }
+        };
+        if line.trim().is_empty() {
+            continue;
+        }
+
+        let (response, stop) = match serde_json::from_str::<Request>(&line) {
+            Ok(Request::Hello) => (
+                Response::success(
+                    serde_json::to_value(context.info()).unwrap_or(serde_json::Value::Null),
+                ),
+                false,
+            ),
+            Ok(Request::Shutdown) => (
+                Response::success(serde_json::json!({ "stopping": true })),
+                true,
+            ),
+            Ok(request) => {
+                let started = Instant::now();
+                let response = dispatch_graph(&graph, &request).await;
+                log.log(&format!(
+                    "{} {} in {}ms",
+                    request.op_name(),
+                    if response.ok { "ok" } else { "failed" },
+                    started.elapsed().as_millis()
+                ));
+                (response, false)
+            }
+            Err(err) => (
+                Response::failure("bad_request", format!("malformed request: {err}")),
+                false,
+            ),
+        };
+
+        if let Err(err) = write_response(&mut writer, &response).await {
+            log.log(&format!("write error: {err}"));
+            break;
+        }
+        context.idle.touch_at(Instant::now());
+
+        if stop {
+            // `notify_one` stores a permit when the accept loop happens to be
+            // between `select!` iterations; `notify_waiters` would be lost
+            // there and the daemon would outlive the shutdown request.
+            context.shutdown.notify_one();
+            break;
+        }
+    }
+}
+
+async fn write_response(
+    writer: &mut tokio::net::unix::OwnedWriteHalf,
+    response: &Response,
+) -> Result<(), RecallError> {
+    let mut line = serde_json::to_vec(response)?;
+    line.push(b'\n');
+    writer.write_all(&line).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Bind the listening socket, clearing a stale socket left by a dead daemon.
+fn bind_socket(socket_path: &Path) -> Result<UnixListener, RecallError> {
+    if let Some(parent) = socket_path.parent() {
+        crate::serve_client::ensure_socket_dir(parent)?;
+    }
+
+    match UnixListener::bind(socket_path) {
+        Ok(listener) => Ok(listener),
+        Err(err) if err.kind() == std::io::ErrorKind::AddrInUse => {
+            if std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
+                return Err(RecallError::Daemon(format!(
+                    "another daemon is already listening on {}",
+                    socket_path.display()
+                )));
+            }
+            std::fs::remove_file(socket_path)?;
+            UnixListener::bind(socket_path).map_err(|err| {
+                RecallError::Daemon(format!("cannot listen on {}: {err}", socket_path.display()))
+            })
+        }
+        Err(err) => Err(RecallError::Daemon(format!(
+            "cannot listen on {}: {err}",
+            socket_path.display()
+        ))),
+    }
+}
+
+fn write_pidfile(socket_path: &Path) -> Result<(), RecallError> {
+    let contents = serde_json::json!({
+        "pid": std::process::id(),
+        "version": env!("CARGO_PKG_VERSION"),
+        "socket_path": socket_path.display().to_string(),
+    });
+    std::fs::write(pidfile_path(socket_path), format!("{contents}\n"))?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const fn assert_shareable<T: Send + Sync>() {}
+
+    #[test]
+    fn graph_memory_is_shareable_across_tasks() {
+        // The daemon hands one Arc<GraphMemory> to every connection task.
+        assert_shareable::<GraphMemory>();
+    }
+
+    #[test]
+    fn request_wire_format_is_op_and_args() {
+        let request = Request::Search(SearchArgs {
+            query: "rust".into(),
+            limit: 5,
+            entity_type: None,
+            keyword: None,
+        });
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["op"], "search");
+        assert_eq!(json["args"]["query"], "rust");
+        assert_eq!(json["args"]["limit"], 5);
+    }
+
+    #[test]
+    fn control_requests_serialize_without_args() {
+        assert_eq!(
+            serde_json::to_string(&Request::Hello).unwrap(),
+            r#"{"op":"hello"}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&Request::Shutdown).unwrap(),
+            r#"{"op":"shutdown"}"#
+        );
+    }
+
+    #[test]
+    fn request_round_trips_every_variant() {
+        let requests = vec![
+            Request::Hello,
+            Request::Status,
+            Request::Search(SearchArgs {
+                query: "q".into(),
+                limit: 3,
+                entity_type: Some("tool".into()),
+                keyword: Some("k".into()),
+            }),
+            Request::SearchEpisodes(SearchEpisodesArgs {
+                query: "q".into(),
+                limit: 2,
+            }),
+            Request::Query(QueryArgs {
+                query: "q".into(),
+                limit: 10,
+                entity_type: None,
+                keyword: None,
+                depth: 2,
+                episodes: true,
+            }),
+            Request::Traverse(TraverseArgs {
+                entity: "Rust".into(),
+                depth: 1,
+                type_filter: None,
+            }),
+            Request::AddEntity(AddEntityArgs {
+                name: "Rust".into(),
+                entity_type: "tool".into(),
+                abstract_text: "language".into(),
+                overview: None,
+                source: Some("test".into()),
+            }),
+            Request::Relate(RelateArgs {
+                from: "D".into(),
+                rel_type: "USES".into(),
+                to: "Rust".into(),
+                description: None,
+                source: None,
+            }),
+            Request::IngestArchive(IngestArchiveArgs {
+                content: "# log".into(),
+                session_id: "s1".into(),
+                log_number: Some(7),
+            }),
+            Request::Shutdown,
+        ];
+
+        for request in requests {
+            let line = serde_json::to_string(&request).unwrap();
+            let parsed: Request = serde_json::from_str(&line).unwrap();
+            assert_eq!(parsed, request, "round trip failed for {line}");
+        }
+    }
+
+    #[test]
+    fn optional_args_may_be_omitted_on_the_wire() {
+        let parsed: Request =
+            serde_json::from_str(r#"{"op":"search","args":{"query":"q","limit":1}}"#).unwrap();
+        assert_eq!(
+            parsed,
+            Request::Search(SearchArgs {
+                query: "q".into(),
+                limit: 1,
+                entity_type: None,
+                keyword: None,
+            })
+        );
+    }
+
+    #[test]
+    fn success_response_carries_data_only() {
+        let response = Response::success(serde_json::json!({"n": 1}));
+        let json = serde_json::to_value(&response).unwrap();
+        assert_eq!(json["ok"], true);
+        assert_eq!(json["data"]["n"], 1);
+        assert!(json.get("error").is_none());
+        assert_eq!(response.into_result().unwrap(), serde_json::json!({"n": 1}));
+    }
+
+    #[test]
+    fn failure_response_maps_to_named_remote_error() {
+        let response = Response::from_graph_error(&GraphError::Locked("store busy".into()));
+        assert_eq!(response.error.as_ref().unwrap().code, "locked");
+        let err = response.into_result().unwrap_err();
+        assert!(err.to_string().contains("store locked"));
+        assert!(matches!(err, RecallError::Remote { .. }));
+    }
+
+    #[test]
+    fn failure_response_round_trips() {
+        let response = Response::failure("bad_request", "malformed");
+        let line = serde_json::to_string(&response).unwrap();
+        let parsed: Response = serde_json::from_str(&line).unwrap();
+        assert_eq!(parsed, response);
+        assert!(!parsed.ok);
+    }
+
+    #[test]
+    fn error_codes_are_distinct_per_kind() {
+        assert_eq!(error_code(&GraphError::Locked(String::new())), "locked");
+        assert_eq!(
+            error_code(&GraphError::NotFound(String::new())),
+            "not_found"
+        );
+        assert_eq!(error_code(&GraphError::Embed(String::new())), "embedding");
+    }
+
+    #[test]
+    fn idle_timer_fires_after_timeout() {
+        let start = Instant::now();
+        let tracker = IdleTracker::new_at(Some(Duration::from_secs(60)), start);
+
+        assert!(!tracker.is_idle_at(start + Duration::from_secs(59)));
+        assert!(tracker.is_idle_at(start + Duration::from_secs(60)));
+    }
+
+    #[test]
+    fn idle_timer_never_fires_while_a_connection_is_open() {
+        let start = Instant::now();
+        let tracker = IdleTracker::new_at(Some(Duration::from_secs(1)), start);
+
+        tracker.begin();
+        assert!(!tracker.is_idle_at(start + Duration::from_secs(600)));
+        tracker.end();
+
+        tracker.touch_at(start);
+        assert!(tracker.is_idle_at(start + Duration::from_secs(600)));
+    }
+
+    #[test]
+    fn activity_resets_the_idle_timer() {
+        let start = Instant::now();
+        let tracker = IdleTracker::new_at(Some(Duration::from_secs(10)), start);
+
+        tracker.touch_at(start + Duration::from_secs(9));
+        assert!(!tracker.is_idle_at(start + Duration::from_secs(18)));
+        assert!(tracker.is_idle_at(start + Duration::from_secs(19)));
+    }
+
+    #[test]
+    fn idle_shutdown_disabled_without_timeout() {
+        let start = Instant::now();
+        let tracker = IdleTracker::new_at(None, start);
+        assert!(!tracker.is_idle_at(start + Duration::from_secs(86_400)));
+        assert_eq!(tracker.poll_interval(), MAX_IDLE_POLL);
+    }
+
+    #[test]
+    fn poll_interval_is_bounded() {
+        let now = Instant::now();
+        assert_eq!(
+            IdleTracker::new_at(Some(Duration::from_millis(10)), now).poll_interval(),
+            MIN_IDLE_POLL
+        );
+        assert_eq!(
+            IdleTracker::new_at(Some(Duration::from_secs(3600)), now).poll_interval(),
+            MAX_IDLE_POLL
+        );
+        assert_eq!(
+            IdleTracker::new_at(Some(Duration::from_secs(100)), now).poll_interval(),
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn pidfile_sits_beside_the_socket() {
+        assert_eq!(
+            pidfile_path(Path::new("/run/recall-echo/abc.sock")),
+            PathBuf::from("/run/recall-echo/abc.sock.pid")
+        );
+    }
+
+    #[test]
+    fn serve_options_from_config_uses_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".recall-echo.toml"),
+            format!(
+                "[serve]\nsocket_path = \"{}/graph.sock\"\n",
+                dir.path().display()
+            ),
+        )
+        .unwrap();
+
+        let options = ServeOptions::from_config(dir.path(), false).unwrap();
+        assert_eq!(options.idle_timeout, Some(Duration::from_secs(3600)));
+        assert!(!options.log_to_stderr);
+        assert_eq!(options.socket_path, dir.path().join("graph.sock"));
+    }
+
+    #[test]
+    fn foreground_disables_idle_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".recall-echo.toml"),
+            format!(
+                "[serve]\nsocket_path = \"{}/graph.sock\"\nidle_timeout_secs = 30\n",
+                dir.path().display()
+            ),
+        )
+        .unwrap();
+
+        let options = ServeOptions::from_config(dir.path(), true).unwrap();
+        assert_eq!(options.idle_timeout, None);
+        assert!(options.log_to_stderr);
+    }
+
+    #[test]
+    fn zero_idle_timeout_disables_idle_shutdown() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".recall-echo.toml"),
+            format!(
+                "[serve]\nsocket_path = \"{}/graph.sock\"\nidle_timeout_secs = 0\n",
+                dir.path().display()
+            ),
+        )
+        .unwrap();
+
+        assert_eq!(
+            ServeOptions::from_config(dir.path(), false)
+                .unwrap()
+                .idle_timeout,
+            None
+        );
+    }
+}

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -21,19 +21,40 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use serde::{Deserialize, Serialize};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Notify;
 
 use crate::error::RecallError;
 use crate::graph::error::GraphError;
-use crate::graph::types::{EntityType, NewEntity, NewRelationship, QueryOptions, SearchOptions};
+use crate::graph::types::{
+    EntityType, NewEntity, NewRelationship, PipelineDocuments, QueryOptions, SearchOptions,
+};
 use crate::graph::GraphMemory;
+use crate::serve_security::{
+    append_private_file, check_peer_uid, current_uid, unlink_socket, PRIVATE_FILE_MODE,
+};
 
 /// Longest idle-poll interval; keeps a long-lived daemon from spinning.
 const MAX_IDLE_POLL: Duration = Duration::from_secs(30);
 /// Shortest idle-poll interval; keeps short test timeouts responsive.
 const MIN_IDLE_POLL: Duration = Duration::from_millis(100);
+
+/// Largest request line the daemon will read. An archive ingest is the biggest
+/// legitimate request by far and stays far below this; anything larger is a
+/// buggy or hostile client trying to make the daemon buffer without bound.
+const MAX_REQUEST_BYTES: u64 = 8 * 1024 * 1024;
+/// Largest result set a request may ask for. Wire-supplied limits reach the
+/// HNSW KNN operator, where an unbounded value is an unbounded scan.
+const MAX_LIMIT: usize = 1000;
+/// Deepest graph expansion a request may ask for. Expansion is exponential in
+/// the branching factor.
+const MAX_DEPTH: u32 = 8;
+/// How long the daemon waits for its own store to close before giving up and
+/// unlinking the socket anyway.
+const STORE_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Polling interval while waiting for connection tasks to release the store.
+const STORE_RELEASE_POLL: Duration = Duration::from_millis(10);
 
 // ── Protocol ─────────────────────────────────────────────────────────────
 
@@ -59,6 +80,8 @@ pub enum Request {
     Relate(RelateArgs),
     /// Ingest a conversation archive (episodes only, no LLM extraction).
     IngestArchive(IngestArchiveArgs),
+    /// Sync the pipeline documents into the graph (no LLM extraction).
+    SyncPipeline(SyncPipelineArgs),
     /// Ask the daemon to exit.
     Shutdown,
 }
@@ -77,7 +100,30 @@ impl Request {
             Request::AddEntity(_) => "add_entity",
             Request::Relate(_) => "relate",
             Request::IngestArchive(_) => "ingest_archive",
+            Request::SyncPipeline(_) => "sync_pipeline",
             Request::Shutdown => "shutdown",
+        }
+    }
+
+    /// Whether repeating this request against a fresh daemon is safe.
+    ///
+    /// A connection that drops mid-request cannot tell us whether the daemon
+    /// applied it before dying, so only read-only or idempotent operations may
+    /// be retried. Repeating an archive ingest would duplicate its episodes —
+    /// a silently corrupted memory is worse than a reported failure.
+    #[must_use]
+    pub fn is_retryable(&self) -> bool {
+        match self {
+            Request::Hello
+            | Request::Status
+            | Request::Search(_)
+            | Request::SearchEpisodes(_)
+            | Request::Query(_)
+            | Request::Traverse(_)
+            // Pipeline sync diffs documents against the graph.
+            | Request::SyncPipeline(_)
+            | Request::Shutdown => true,
+            Request::AddEntity(_) | Request::Relate(_) | Request::IngestArchive(_) => false,
         }
     }
 }
@@ -146,6 +192,13 @@ pub struct IngestArchiveArgs {
     pub session_id: String,
     #[serde(default)]
     pub log_number: Option<u32>,
+}
+
+/// Pipeline sync needs no LLM provider, so it runs against the daemon like any
+/// other graph operation instead of taking the store exclusively.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SyncPipelineArgs {
+    pub docs: PipelineDocuments,
 }
 
 /// A daemon response. Wire form is `{"ok": true, "data": ...}` or
@@ -261,6 +314,16 @@ pub async fn dispatch_graph(graph: &GraphMemory, request: &Request) -> Response 
     }
 }
 
+/// Clamp a wire-supplied result limit into a range the store can serve.
+fn clamp_limit(limit: usize) -> usize {
+    limit.clamp(1, MAX_LIMIT)
+}
+
+/// Clamp a wire-supplied expansion depth.
+fn clamp_depth(depth: u32) -> u32 {
+    depth.clamp(1, MAX_DEPTH)
+}
+
 /// `Ok(None)` means "not a graph operation".
 async fn execute_graph(
     graph: &GraphMemory,
@@ -271,28 +334,42 @@ async fn execute_graph(
         Request::Status => serde_json::to_value(graph.stats().await?)?,
         Request::Search(args) => {
             let options = SearchOptions {
-                limit: args.limit,
+                limit: clamp_limit(args.limit),
                 entity_type: args.entity_type.clone(),
                 keyword: args.keyword.clone(),
             };
             serde_json::to_value(graph.search_with_options(&args.query, &options).await?)?
         }
         Request::SearchEpisodes(args) => {
-            serde_json::to_value(graph.search_episodes(&args.query, args.limit).await?)?
+            let mut episodes = graph
+                .search_episodes(&args.query, clamp_limit(args.limit))
+                .await?;
+            for result in &mut episodes {
+                result.episode.embedding = None;
+            }
+            serde_json::to_value(episodes)?
         }
         Request::Query(args) => {
             let options = QueryOptions {
-                limit: args.limit,
+                limit: clamp_limit(args.limit),
                 entity_type: args.entity_type.clone(),
                 keyword: args.keyword.clone(),
-                graph_depth: args.depth,
+                graph_depth: clamp_depth(args.depth),
                 include_episodes: args.episodes,
             };
-            serde_json::to_value(graph.query(&args.query, &options).await?)?
+            let mut result = graph.query(&args.query, &options).await?;
+            for episode in &mut result.episodes {
+                episode.episode.embedding = None;
+            }
+            serde_json::to_value(result)?
         }
         Request::Traverse(args) => serde_json::to_value(
             graph
-                .traverse_filtered(&args.entity, args.depth, args.type_filter.as_deref())
+                .traverse_filtered(
+                    &args.entity,
+                    clamp_depth(args.depth),
+                    args.type_filter.as_deref(),
+                )
                 .await?,
         )?,
         Request::AddEntity(args) => {
@@ -300,7 +377,7 @@ async fn execute_graph(
                 .entity_type
                 .parse()
                 .map_err(|e: String| GraphError::Parse(e))?;
-            let entity = graph
+            let mut entity = graph
                 .add_entity(NewEntity {
                     name: args.name.clone(),
                     entity_type,
@@ -311,6 +388,8 @@ async fn execute_graph(
                     source: args.source.clone(),
                 })
                 .await?;
+            // 384 floats of JSON text no client has ever read.
+            entity.embedding = None;
             serde_json::to_value(entity)?
         }
         Request::Relate(args) => {
@@ -331,6 +410,9 @@ async fn execute_graph(
                 .ingest_archive(&args.content, &args.session_id, args.log_number, None)
                 .await?;
             serde_json::to_value(report)?
+        }
+        Request::SyncPipeline(args) => {
+            serde_json::to_value(graph.sync_pipeline(&args.docs).await?)?
         }
     };
     Ok(Some(data))
@@ -443,11 +525,7 @@ pub struct DaemonLog {
 impl DaemonLog {
     #[must_use]
     pub fn open(path: &Path, echo_stderr: bool) -> Self {
-        let file = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .ok();
+        let file = append_private_file().open(path).ok();
         Self {
             file: Mutex::new(file),
             echo_stderr,
@@ -518,6 +596,8 @@ struct DaemonContext {
     started: Instant,
     memory_dir: PathBuf,
     socket_path: PathBuf,
+    /// Only this uid may use the socket.
+    owner_uid: u32,
     idle: IdleTracker,
     shutdown: Notify,
 }
@@ -562,15 +642,11 @@ pub async fn run(options: ServeOptions) -> Result<(), RecallError> {
         log.log("warning: [graph] mode = \"server\" — clients bypass the daemon");
     }
 
+    let owner_uid = current_uid()?;
+
     // Own the store before advertising the socket: clients that connect only
     // after a successful bind never see a half-initialized daemon.
-    let graph = match GraphMemory::open_embedded(&graph_dir).await {
-        Ok(graph) => Arc::new(graph),
-        Err(err) => {
-            log.log(&format!("failed to open graph store: {err}"));
-            return Err(err.into());
-        }
-    };
+    let graph = open_store(&graph_dir, &options.socket_path, &log).await?;
 
     let listener = match bind_socket(&options.socket_path) {
         Ok(listener) => listener,
@@ -585,17 +661,105 @@ pub async fn run(options: ServeOptions) -> Result<(), RecallError> {
         started: Instant::now(),
         memory_dir: options.memory_dir.clone(),
         socket_path: options.socket_path.clone(),
+        owner_uid,
         idle: IdleTracker::new(options.idle_timeout),
         shutdown: Notify::new(),
     });
+    warm_embedder(Arc::clone(&graph), Arc::clone(&log));
     log.log("ready");
 
-    accept_loop(listener, graph, Arc::clone(&context), Arc::clone(&log)).await;
+    accept_loop(
+        listener,
+        Arc::clone(&graph),
+        Arc::clone(&context),
+        Arc::clone(&log),
+    )
+    .await;
 
-    let _ = std::fs::remove_file(&options.socket_path);
+    // Close the store *before* the socket disappears: a client waiting for the
+    // socket to go treats that as "the store is free", and would otherwise
+    // race the SurrealKV file lock we have not released yet.
+    release_store(graph, &log).await;
+    if let Err(err) = unlink_socket(&options.socket_path) {
+        log.log(&format!("socket cleanup: {err}"));
+    }
     let _ = std::fs::remove_file(pidfile_path(&options.socket_path));
     log.log("stopped");
     Ok(())
+}
+
+/// Open the store, waiting out an admin operation that currently owns it.
+async fn open_store(
+    graph_dir: &Path,
+    socket_path: &Path,
+    log: &DaemonLog,
+) -> Result<Arc<GraphMemory>, RecallError> {
+    let deadline = Instant::now() + crate::serve_client::ADMIN_WAIT_TIMEOUT;
+    loop {
+        crate::serve_client::wait_for_admin_lock(socket_path, deadline).await?;
+        match GraphMemory::open_embedded(graph_dir).await {
+            Ok(graph) => return Ok(Arc::new(graph)),
+            Err(GraphError::Locked(message))
+                if Instant::now() < deadline
+                    && crate::serve_client::admin_lock_is_held(socket_path) =>
+            {
+                log.log(&format!("waiting for an admin operation: {message}"));
+            }
+            Err(err) => {
+                log.log(&format!("failed to open graph store: {err}"));
+                return Err(err.into());
+            }
+        }
+    }
+}
+
+/// Drop the store once every in-flight connection has let go of it.
+async fn release_store(graph: Arc<GraphMemory>, log: &DaemonLog) {
+    let deadline = Instant::now() + STORE_RELEASE_TIMEOUT;
+    let mut graph = graph;
+    loop {
+        match Arc::try_unwrap(graph) {
+            Ok(store) => {
+                drop(store);
+                return;
+            }
+            Err(shared) => {
+                if Instant::now() >= deadline {
+                    log.log("gave up waiting for in-flight requests to release the store");
+                    return;
+                }
+                graph = shared;
+                tokio::time::sleep(STORE_RELEASE_POLL).await;
+            }
+        }
+    }
+}
+
+/// Load the ONNX embedding model in the background, so the first request that
+/// needs an embedding does not pay for it inline.
+///
+/// Skipped while the model cache is empty: warming a cold cache downloads the
+/// model, which must stay tied to a request that actually needs it rather than
+/// happening on every daemon start.
+fn warm_embedder(graph: Arc<GraphMemory>, log: Arc<DaemonLog>) {
+    let models_dir = graph.path().join("models");
+    if !has_cached_model(&models_dir) {
+        return;
+    }
+    tokio::task::spawn_blocking(move || {
+        let started = Instant::now();
+        match graph.embedder() {
+            Ok(_) => log.log(&format!(
+                "embedder warm in {}ms",
+                started.elapsed().as_millis()
+            )),
+            Err(err) => log.log(&format!("embedder warm-up failed: {err}")),
+        }
+    });
+}
+
+fn has_cached_model(models_dir: &Path) -> bool {
+    std::fs::read_dir(models_dir).is_ok_and(|mut entries| entries.next().is_some())
 }
 
 async fn accept_loop(
@@ -639,18 +803,36 @@ async fn handle_connection(
     log: Arc<DaemonLog>,
 ) {
     let _activity = ActivityGuard::new(Arc::clone(&context));
+    if let Err(err) = authorize_peer(&stream, context.owner_uid) {
+        log.log(&format!("rejected connection: {err}"));
+        return;
+    }
+
     let (reader, mut writer) = stream.into_split();
-    let mut lines = BufReader::new(reader).lines();
+    let mut lines = BufReader::new(reader.take(MAX_REQUEST_BYTES)).lines();
 
     loop {
         let line = match lines.next_line().await {
             Ok(Some(line)) => line,
-            Ok(None) => break,
+            Ok(None) => {
+                // The reader stopped at the byte cap instead of at a newline:
+                // the client is sending a request larger than we will read.
+                if request_cap_reached(&mut lines) {
+                    let response = Response::failure(
+                        "bad_request",
+                        format!("request exceeds the {MAX_REQUEST_BYTES}-byte limit"),
+                    );
+                    log.log("rejected an oversized request");
+                    let _ = write_response(&mut writer, &response).await;
+                }
+                break;
+            }
             Err(err) => {
                 log.log(&format!("read error: {err}"));
                 break;
             }
         };
+        recharge_request_cap(&mut lines);
         if line.trim().is_empty() {
             continue;
         }
@@ -699,6 +881,28 @@ async fn handle_connection(
     }
 }
 
+/// A connection's request reader, capped at [`MAX_REQUEST_BYTES`] per request.
+type RequestLines = tokio::io::Lines<BufReader<tokio::io::Take<tokio::net::unix::OwnedReadHalf>>>;
+
+/// True when the reader stopped because the request hit the byte cap.
+fn request_cap_reached(lines: &mut RequestLines) -> bool {
+    lines.get_mut().get_mut().limit() == 0
+}
+
+/// Give the next request on this connection its own full byte budget.
+fn recharge_request_cap(lines: &mut RequestLines) {
+    lines.get_mut().get_mut().set_limit(MAX_REQUEST_BYTES);
+}
+
+/// The socket has no authentication of its own: anyone who can open it can
+/// read every ingest payload and forge every answer. Only our own uid may.
+fn authorize_peer(stream: &UnixStream, owner_uid: u32) -> Result<(), RecallError> {
+    let peer = stream.peer_cred().map_err(|err| {
+        RecallError::Daemon(format!("cannot read socket peer credentials: {err}"))
+    })?;
+    check_peer_uid(peer.uid(), owner_uid)
+}
+
 async fn write_response(
     writer: &mut tokio::net::unix::OwnedWriteHalf,
     response: &Response,
@@ -710,40 +914,70 @@ async fn write_response(
     Ok(())
 }
 
+/// Path the socket is bound to before it is published under its real name.
+fn staging_path(socket_path: &Path) -> PathBuf {
+    let mut path = socket_path.as_os_str().to_os_string();
+    path.push(".new");
+    PathBuf::from(path)
+}
+
 /// Bind the listening socket, clearing a stale socket left by a dead daemon.
+///
+/// The socket is bound under a temporary name in the same directory, made
+/// owner-only, and only then renamed into place: `bind` applies the process
+/// umask, so publishing first would leave a world-reachable socket for as long
+/// as it takes to chmod it.
 fn bind_socket(socket_path: &Path) -> Result<UnixListener, RecallError> {
+    use std::os::unix::fs::PermissionsExt;
+
     if let Some(parent) = socket_path.parent() {
         crate::serve_client::ensure_socket_dir(parent)?;
     }
-
-    match UnixListener::bind(socket_path) {
-        Ok(listener) => Ok(listener),
-        Err(err) if err.kind() == std::io::ErrorKind::AddrInUse => {
-            if std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
-                return Err(RecallError::Daemon(format!(
-                    "another daemon is already listening on {}",
-                    socket_path.display()
-                )));
-            }
-            std::fs::remove_file(socket_path)?;
-            UnixListener::bind(socket_path).map_err(|err| {
-                RecallError::Daemon(format!("cannot listen on {}: {err}", socket_path.display()))
-            })
-        }
-        Err(err) => Err(RecallError::Daemon(format!(
-            "cannot listen on {}: {err}",
+    if std::os::unix::net::UnixStream::connect(socket_path).is_ok() {
+        return Err(RecallError::Daemon(format!(
+            "another daemon is already listening on {}",
             socket_path.display()
-        ))),
+        )));
     }
+
+    let staged = staging_path(socket_path);
+    unlink_socket(&staged)?;
+    let listener = UnixListener::bind(&staged).map_err(|err| {
+        RecallError::Daemon(format!("cannot listen on {}: {err}", staged.display()))
+    })?;
+    std::fs::set_permissions(&staged, std::fs::Permissions::from_mode(PRIVATE_FILE_MODE)).map_err(
+        |err| {
+            RecallError::Daemon(format!(
+                "cannot restrict the daemon socket {}: {err}",
+                staged.display()
+            ))
+        },
+    )?;
+
+    // Whatever sits at the published path is a socket a dead daemon left.
+    unlink_socket(socket_path)?;
+    std::fs::rename(&staged, socket_path).map_err(|err| {
+        let _ = std::fs::remove_file(&staged);
+        RecallError::Daemon(format!(
+            "cannot publish the daemon socket at {}: {err}",
+            socket_path.display()
+        ))
+    })?;
+    Ok(listener)
 }
 
 fn write_pidfile(socket_path: &Path) -> Result<(), RecallError> {
+    use std::io::Write as _;
+
     let contents = serde_json::json!({
         "pid": std::process::id(),
         "version": env!("CARGO_PKG_VERSION"),
         "socket_path": socket_path.display().to_string(),
     });
-    std::fs::write(pidfile_path(socket_path), format!("{contents}\n"))?;
+    let path = pidfile_path(socket_path);
+    let _ = std::fs::remove_file(&path);
+    let mut file = crate::serve_security::create_new_private_file().open(&path)?;
+    writeln!(file, "{contents}")?;
     Ok(())
 }
 
@@ -831,6 +1065,12 @@ mod tests {
                 content: "# log".into(),
                 session_id: "s1".into(),
                 log_number: Some(7),
+            }),
+            Request::SyncPipeline(SyncPipelineArgs {
+                docs: PipelineDocuments {
+                    learning: "# learning".into(),
+                    ..PipelineDocuments::default()
+                },
             }),
             Request::Shutdown,
         ];
@@ -950,6 +1190,62 @@ mod tests {
             IdleTracker::new_at(Some(Duration::from_secs(100)), now).poll_interval(),
             Duration::from_secs(10)
         );
+    }
+
+    #[test]
+    fn only_repeatable_operations_are_retryable() {
+        assert!(Request::Status.is_retryable());
+        assert!(Request::Traverse(TraverseArgs {
+            entity: "Rust".into(),
+            depth: 1,
+            type_filter: None,
+        })
+        .is_retryable());
+
+        // Replaying this one would duplicate every episode of a conversation.
+        assert!(!Request::IngestArchive(IngestArchiveArgs {
+            content: "# log".into(),
+            session_id: "s1".into(),
+            log_number: Some(1),
+        })
+        .is_retryable());
+        assert!(!Request::AddEntity(AddEntityArgs {
+            name: "Rust".into(),
+            entity_type: "tool".into(),
+            abstract_text: "language".into(),
+            overview: None,
+            source: None,
+        })
+        .is_retryable());
+    }
+
+    #[test]
+    fn wire_limits_are_clamped_into_a_servable_range() {
+        assert_eq!(clamp_limit(10), 10);
+        assert_eq!(clamp_limit(MAX_LIMIT), MAX_LIMIT);
+        // A limit this large overflows the `limit * 4` KNN `ef` computation
+        // and asks SurrealDB for an unbounded scan.
+        assert_eq!(clamp_limit(usize::MAX), MAX_LIMIT);
+        assert_eq!(clamp_limit(0), 1);
+    }
+
+    #[test]
+    fn wire_depths_are_clamped_into_a_servable_range() {
+        assert_eq!(clamp_depth(2), 2);
+        assert_eq!(clamp_depth(MAX_DEPTH), MAX_DEPTH);
+        assert_eq!(clamp_depth(u32::MAX), MAX_DEPTH);
+        assert_eq!(clamp_depth(0), 1);
+    }
+
+    #[test]
+    fn the_staged_socket_sits_beside_the_published_one() {
+        let socket = Path::new("/run/recall-echo/abc.sock");
+        let staged = staging_path(socket);
+        assert_eq!(staged.parent(), socket.parent());
+        assert_ne!(staged, socket);
+        // `sockaddr_un.sun_path` is 108 bytes and the published path is capped
+        // at 100, so the staging name must stay within the remainder.
+        assert!(staged.as_os_str().len() - socket.as_os_str().len() <= 7);
     }
 
     #[test]

--- a/src/serve_client.rs
+++ b/src/serve_client.rs
@@ -1,0 +1,653 @@
+//! Client side of the graph daemon — connect, or start one and connect.
+//!
+//! Every hot graph operation (search, query, traverse, status, ingest, entity
+//! and relationship writes) goes through here. There is no embedded fallback:
+//! when the daemon cannot be reached *and* cannot be started, that is a named
+//! [`RecallError::Daemon`] error, never a silent degradation.
+//!
+//! Two escapes exist:
+//!
+//! - `[graph] mode = "server"` (advanced): the store is an external SurrealDB
+//!   server, so there is nothing to serialize — requests run in-process.
+//! - [`exclusive`]: admin operations (init, gc, extraction, bulk ingest, …)
+//!   stop the daemon and take the store for themselves; the next hot operation
+//!   starts a fresh daemon.
+
+use std::io::ErrorKind;
+use std::os::unix::ffi::OsStrExt;
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::UnixStream;
+
+use crate::error::RecallError;
+use crate::graph::GraphMemory;
+use crate::serve::{DaemonInfo, Request, Response};
+
+/// Environment override for the binary used to start the daemon.
+/// Defaults to the running executable; tests and wrappers set it explicitly.
+pub const DAEMON_BIN_ENV: &str = "RECALL_ECHO_BIN";
+
+/// `sockaddr_un.sun_path` is 108 bytes on Linux; stay well inside it.
+const MAX_SOCKET_PATH_LEN: usize = 100;
+/// How long to wait for a freshly spawned daemon to accept connections.
+const START_TIMEOUT: Duration = Duration::from_secs(30);
+/// Polling interval while waiting for a socket to appear or disappear.
+const POLL_INTERVAL: Duration = Duration::from_millis(25);
+/// A spawn lockfile older than this belongs to a client that died mid-spawn.
+const STALE_LOCK_AGE: Duration = Duration::from_secs(30);
+/// How long to wait for a daemon to answer the version handshake.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Upper bound on connect → spawn → reconnect rounds.
+const MAX_CONNECT_ROUNDS: u32 = 3;
+
+// ── Socket location ──────────────────────────────────────────────────────
+
+/// Socket path for a memory directory.
+///
+/// `$XDG_RUNTIME_DIR/recall-echo/<hash>.sock`, falling back to
+/// `/tmp/recall-echo-<uid>/<hash>.sock`, unless `[serve] socket_path`
+/// overrides it. The hash is taken over the canonical memory directory, so
+/// every graph gets its own daemon and symlinked paths share one.
+pub fn socket_path(memory_dir: &Path) -> Result<PathBuf, RecallError> {
+    let config = crate::config::load_from_dir(memory_dir);
+    let path = match config.serve.socket_path.as_deref() {
+        Some(configured) if !configured.trim().is_empty() => {
+            PathBuf::from(crate::paths::expand_tilde(configured.trim()))
+        }
+        _ => runtime_dir().join(format!("{}.sock", path_hash(&canonical(memory_dir)))),
+    };
+
+    if path.as_os_str().as_bytes().len() > MAX_SOCKET_PATH_LEN {
+        return Err(RecallError::Daemon(format!(
+            "daemon socket path is too long ({} bytes, max {MAX_SOCKET_PATH_LEN}): {}. \
+             Set `[serve] socket_path` in .recall-echo.toml to a shorter path.",
+            path.as_os_str().as_bytes().len(),
+            path.display()
+        )));
+    }
+    Ok(path)
+}
+
+fn runtime_dir() -> PathBuf {
+    match std::env::var_os("XDG_RUNTIME_DIR") {
+        Some(dir) if !dir.is_empty() => PathBuf::from(dir).join("recall-echo"),
+        _ => PathBuf::from(format!("/tmp/recall-echo-{}", current_uid())),
+    }
+}
+
+/// Owner uid, read from the filesystem so no libc dependency is needed.
+fn current_uid() -> u32 {
+    use std::os::unix::fs::MetadataExt;
+    std::fs::metadata("/proc/self")
+        .or_else(|_| std::fs::metadata(dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"))))
+        .map(|meta| meta.uid())
+        .unwrap_or(0)
+}
+
+fn canonical(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// FNV-1a 64 of a path — stable across processes and releases, unlike
+/// `DefaultHasher`, which is what a socket name needs.
+fn path_hash(path: &Path) -> String {
+    let mut hash: u64 = 0xcbf2_9ce4_8422_2325;
+    for byte in path.as_os_str().as_bytes() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    format!("{hash:016x}")
+}
+
+/// Create the socket directory, owner-only.
+pub(crate) fn ensure_socket_dir(dir: &Path) -> Result<(), RecallError> {
+    use std::os::unix::fs::PermissionsExt;
+
+    std::fs::create_dir_all(dir).map_err(|err| {
+        RecallError::Daemon(format!(
+            "cannot create daemon socket directory {}: {err}",
+            dir.display()
+        ))
+    })?;
+    let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
+    Ok(())
+}
+
+// ── Public entry points ──────────────────────────────────────────────────
+
+/// Backend mode from `[graph] mode` — `embedded` (daemon) or `server` (direct).
+#[must_use]
+pub fn graph_mode(memory_dir: &Path) -> String {
+    crate::config::load_from_dir(memory_dir)
+        .graph
+        .map_or_else(|| "embedded".to_string(), |graph| graph.mode)
+}
+
+fn uses_daemon(memory_dir: &Path) -> bool {
+    graph_mode(memory_dir) != "server"
+}
+
+/// Run a hot graph operation, starting the daemon if necessary.
+///
+/// In `mode = "server"` the request runs in-process against the external
+/// SurrealDB server; the result is identical either way.
+pub async fn execute(
+    memory_dir: &Path,
+    request: &Request,
+) -> Result<serde_json::Value, RecallError> {
+    if !uses_daemon(memory_dir) {
+        return execute_direct(memory_dir, request).await;
+    }
+
+    let socket = socket_path(memory_dir)?;
+    let mut connection = connect_or_spawn(memory_dir, &socket).await?;
+    connection.call(request).await?.into_result()
+}
+
+async fn execute_direct(
+    memory_dir: &Path,
+    request: &Request,
+) -> Result<serde_json::Value, RecallError> {
+    let graph = GraphMemory::open(&memory_dir.join("graph")).await?;
+    crate::serve::dispatch_graph(&graph, request)
+        .await
+        .into_result()
+}
+
+/// Take exclusive ownership of the store for an admin operation.
+///
+/// Stops a running daemon, opens the store in-process, and runs `operation`.
+/// The daemon is not restarted here — the next hot operation starts a fresh
+/// one, so the store has exactly one owner at every instant.
+pub async fn exclusive<T, F, Fut>(memory_dir: &Path, operation: F) -> Result<T, RecallError>
+where
+    F: FnOnce(GraphMemory) -> Fut,
+    Fut: std::future::Future<Output = Result<T, RecallError>>,
+{
+    let graph_dir = memory_dir.join("graph");
+    if !uses_daemon(memory_dir) {
+        return operation(GraphMemory::open(&graph_dir).await?).await;
+    }
+
+    stop_daemon(memory_dir).await?;
+    let graph = GraphMemory::open_embedded(&graph_dir).await?;
+    operation(graph).await
+}
+
+/// Identity of the running daemon, or `None` when none is running (or when
+/// the store is an external server). Never starts a daemon.
+pub async fn daemon_info(memory_dir: &Path) -> Result<Option<DaemonInfo>, RecallError> {
+    if !uses_daemon(memory_dir) {
+        return Ok(None);
+    }
+    let socket = socket_path(memory_dir)?;
+    let Some(mut connection) = Connection::try_connect(&socket).await else {
+        return Ok(None);
+    };
+    match connection.hello().await {
+        Ok(info) => Ok(Some(info)),
+        Err(_) => Ok(None),
+    }
+}
+
+/// Stop the daemon for this memory directory. Returns whether one was running.
+pub async fn stop_daemon(memory_dir: &Path) -> Result<bool, RecallError> {
+    if !uses_daemon(memory_dir) {
+        return Ok(false);
+    }
+    let socket = socket_path(memory_dir)?;
+    let Some(mut connection) = Connection::try_connect(&socket).await else {
+        // Nothing listening — clear a stale socket so the next start is clean.
+        let _ = std::fs::remove_file(&socket);
+        return Ok(false);
+    };
+
+    connection.call(&Request::Shutdown).await?.into_result()?;
+    drop(connection);
+    wait_for_socket_gone(&socket, Instant::now() + START_TIMEOUT).await?;
+    Ok(true)
+}
+
+// ── Connection ───────────────────────────────────────────────────────────
+
+/// One JSON-line conversation with a daemon.
+struct Connection {
+    reader: BufReader<tokio::net::unix::OwnedReadHalf>,
+    writer: tokio::net::unix::OwnedWriteHalf,
+}
+
+impl Connection {
+    async fn connect(socket: &Path) -> std::io::Result<Self> {
+        let stream = UnixStream::connect(socket).await?;
+        let (reader, writer) = stream.into_split();
+        Ok(Self {
+            reader: BufReader::new(reader),
+            writer,
+        })
+    }
+
+    /// Connect, treating every failure as "no daemon there".
+    async fn try_connect(socket: &Path) -> Option<Self> {
+        Self::connect(socket).await.ok()
+    }
+
+    async fn call(&mut self, request: &Request) -> Result<Response, RecallError> {
+        let mut line = serde_json::to_vec(request)?;
+        line.push(b'\n');
+        self.writer.write_all(&line).await?;
+        self.writer.flush().await?;
+
+        let mut response_line = String::new();
+        let read = self.reader.read_line(&mut response_line).await?;
+        if read == 0 {
+            return Err(RecallError::Daemon(format!(
+                "daemon closed the connection while handling `{}` — see the daemon log",
+                request.op_name()
+            )));
+        }
+        Ok(serde_json::from_str(&response_line)?)
+    }
+
+    async fn hello(&mut self) -> Result<DaemonInfo, RecallError> {
+        let response = tokio::time::timeout(HANDSHAKE_TIMEOUT, self.call(&Request::Hello))
+            .await
+            .map_err(|_| {
+                RecallError::Daemon("daemon did not answer the version handshake within 10s".into())
+            })??;
+        let data = response.into_result()?;
+        Ok(serde_json::from_value(data)?)
+    }
+}
+
+/// Connect to the daemon for `socket`, starting one if needed.
+async fn connect_or_spawn(memory_dir: &Path, socket: &Path) -> Result<Connection, RecallError> {
+    let deadline = Instant::now() + START_TIMEOUT;
+
+    for _ in 0..MAX_CONNECT_ROUNDS {
+        match Connection::connect(socket).await {
+            Ok(mut connection) => {
+                let info = connection.hello().await?;
+                if info.version == env!("CARGO_PKG_VERSION") {
+                    return Ok(connection);
+                }
+                // Upgraded binary, stale daemon: ask it to go, then respawn.
+                let _ = connection.call(&Request::Shutdown).await;
+                drop(connection);
+                wait_for_socket_gone(socket, deadline).await?;
+            }
+            Err(err) if err.kind() == ErrorKind::PermissionDenied => {
+                return Err(RecallError::Daemon(format!(
+                    "permission denied opening the daemon socket {}: {err}. \
+                     Check ownership of the socket directory, or set \
+                     `[serve] socket_path` in .recall-echo.toml.",
+                    socket.display()
+                )));
+            }
+            Err(err) if err.kind() == ErrorKind::NotFound => {}
+            Err(_) => {
+                // Socket file exists but nothing is listening (crashed daemon).
+                let _ = std::fs::remove_file(socket);
+            }
+        }
+
+        start_daemon(memory_dir, socket, deadline).await?;
+    }
+
+    Err(RecallError::Daemon(format!(
+        "gave up connecting to the graph daemon on {} after {MAX_CONNECT_ROUNDS} attempts",
+        socket.display()
+    )))
+}
+
+/// Start a daemon — exactly one client wins the race; the rest wait.
+async fn start_daemon(
+    memory_dir: &Path,
+    socket: &Path,
+    deadline: Instant,
+) -> Result<(), RecallError> {
+    match acquire_spawn_lock(socket)? {
+        Some(lock) => {
+            let result = match spawn_daemon(memory_dir, socket) {
+                Ok(mut child) => {
+                    wait_for_socket(socket, memory_dir, deadline, Some(&mut child)).await
+                }
+                Err(err) => Err(err),
+            };
+            drop(lock);
+            result
+        }
+        None => wait_for_socket(socket, memory_dir, deadline, None).await,
+    }
+}
+
+/// Holds the `O_EXCL` spawn lockfile; removes it on drop.
+struct SpawnLock(PathBuf);
+
+impl Drop for SpawnLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.0);
+    }
+}
+
+fn lock_path(socket: &Path) -> PathBuf {
+    let mut path = socket.as_os_str().to_os_string();
+    path.push(".lock");
+    PathBuf::from(path)
+}
+
+/// `Some(lock)` — this client spawns the daemon. `None` — another client is
+/// already spawning one; wait for its socket.
+fn acquire_spawn_lock(socket: &Path) -> Result<Option<SpawnLock>, RecallError> {
+    if let Some(parent) = socket.parent() {
+        ensure_socket_dir(parent)?;
+    }
+    let path = lock_path(socket);
+
+    match create_lock_file(&path) {
+        Ok(()) => Ok(Some(SpawnLock(path))),
+        Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+            if lock_is_stale(&path) {
+                let _ = std::fs::remove_file(&path);
+                return match create_lock_file(&path) {
+                    Ok(()) => Ok(Some(SpawnLock(path))),
+                    Err(_) => Ok(None),
+                };
+            }
+            Ok(None)
+        }
+        Err(err) => Err(RecallError::Daemon(format!(
+            "cannot create the daemon spawn lock {}: {err}",
+            path.display()
+        ))),
+    }
+}
+
+fn create_lock_file(path: &Path) -> std::io::Result<()> {
+    use std::io::Write as _;
+    let mut file = std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)?;
+    writeln!(file, "{}", std::process::id())
+}
+
+fn lock_is_stale(path: &Path) -> bool {
+    std::fs::metadata(path)
+        .and_then(|meta| meta.modified())
+        .map(|modified| modified.elapsed().unwrap_or_default() > STALE_LOCK_AGE)
+        .unwrap_or(true)
+}
+
+fn daemon_binary() -> Result<PathBuf, RecallError> {
+    if let Some(binary) = std::env::var_os(DAEMON_BIN_ENV) {
+        return Ok(PathBuf::from(binary));
+    }
+    std::env::current_exe().map_err(|err| {
+        RecallError::Daemon(format!(
+            "cannot locate the recall-echo binary to start the graph daemon: {err}. \
+             Set {DAEMON_BIN_ENV} to its path."
+        ))
+    })
+}
+
+/// Spawn `recall-echo serve --dir <memory_dir>` detached, with stdio going to
+/// the daemon log so panics and native-library output are captured.
+fn spawn_daemon(memory_dir: &Path, socket: &Path) -> Result<std::process::Child, RecallError> {
+    use std::os::unix::process::CommandExt as _;
+
+    let binary = daemon_binary()?;
+    let log_path = daemon_log_path(memory_dir);
+    if let Some(parent) = log_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let log = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|err| {
+            RecallError::Daemon(format!(
+                "cannot open the daemon log {}: {err}",
+                log_path.display()
+            ))
+        })?;
+
+    let mut command = std::process::Command::new(&binary);
+    command
+        .arg("serve")
+        .arg("--dir")
+        .arg(memory_dir)
+        .stdin(std::process::Stdio::null())
+        .stdout(std::process::Stdio::from(log.try_clone()?))
+        .stderr(std::process::Stdio::from(log))
+        // Own process group: terminal signals aimed at the client never reach
+        // the daemon, and the daemon outlives the shell that started it.
+        .process_group(0);
+
+    command.spawn().map_err(|err| {
+        RecallError::Daemon(format!(
+            "cannot start the graph daemon ({} serve --dir {}): {err}. \
+             Socket: {}",
+            binary.display(),
+            memory_dir.display(),
+            socket.display()
+        ))
+    })
+}
+
+/// Daemon log path for a memory directory.
+#[must_use]
+pub fn daemon_log_path(memory_dir: &Path) -> PathBuf {
+    memory_dir.join("graph").join("daemon.log")
+}
+
+/// Wait until the daemon accepts connections.
+///
+/// When `child` is the daemon this client just spawned, its early exit (a
+/// locked store, a failed bind) is reported immediately instead of after the
+/// full start timeout.
+async fn wait_for_socket(
+    socket: &Path,
+    memory_dir: &Path,
+    deadline: Instant,
+    mut child: Option<&mut std::process::Child>,
+) -> Result<(), RecallError> {
+    while Instant::now() < deadline {
+        if Connection::try_connect(socket).await.is_some() {
+            return Ok(());
+        }
+        if let Some(child) = child.as_mut() {
+            if let Ok(Some(status)) = child.try_wait() {
+                return Err(RecallError::Daemon(format!(
+                    "the graph daemon exited immediately ({status}). Last daemon log lines:\n{}",
+                    log_tail(&daemon_log_path(memory_dir), 5)
+                )));
+            }
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Err(RecallError::Daemon(format!(
+        "the graph daemon did not start within {}s (socket {} never accepted a connection). \
+         Last daemon log lines:\n{}",
+        START_TIMEOUT.as_secs(),
+        socket.display(),
+        log_tail(&daemon_log_path(memory_dir), 5)
+    )))
+}
+
+async fn wait_for_socket_gone(socket: &Path, deadline: Instant) -> Result<(), RecallError> {
+    while Instant::now() < deadline {
+        if Connection::try_connect(socket).await.is_none() {
+            let _ = std::fs::remove_file(socket);
+            return Ok(());
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Err(RecallError::Daemon(format!(
+        "the graph daemon on {} did not stop when asked",
+        socket.display()
+    )))
+}
+
+/// Last `lines` lines of the daemon log, for error messages.
+fn log_tail(path: &Path, lines: usize) -> String {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            let tail: Vec<&str> = contents
+                .lines()
+                .rev()
+                .take(lines)
+                .collect::<Vec<_>>()
+                .into_iter()
+                .rev()
+                .collect();
+            if tail.is_empty() {
+                "  (daemon log is empty)".to_string()
+            } else {
+                tail.iter()
+                    .map(|line| format!("  {line}"))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            }
+        }
+        Err(err) => format!("  (no daemon log at {}: {err})", path.display()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_hash_is_stable_and_distinct() {
+        let first = path_hash(Path::new("/home/echo/memory"));
+        assert_eq!(first, path_hash(Path::new("/home/echo/memory")));
+        assert_ne!(first, path_hash(Path::new("/home/echo/memory2")));
+        assert_eq!(first.len(), 16);
+    }
+
+    #[test]
+    fn socket_path_is_per_memory_dir() {
+        let first = tempfile::tempdir().unwrap();
+        let second = tempfile::tempdir().unwrap();
+        assert_ne!(
+            socket_path(first.path()).unwrap(),
+            socket_path(second.path()).unwrap()
+        );
+    }
+
+    #[test]
+    fn socket_path_honors_config_override() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".recall-echo.toml"),
+            "[serve]\nsocket_path = \"/tmp/re-test.sock\"\n",
+        )
+        .unwrap();
+        assert_eq!(
+            socket_path(dir.path()).unwrap(),
+            PathBuf::from("/tmp/re-test.sock")
+        );
+    }
+
+    #[test]
+    fn socket_path_rejects_paths_over_the_unix_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let long = format!("/tmp/{}.sock", "x".repeat(MAX_SOCKET_PATH_LEN));
+        std::fs::write(
+            dir.path().join(".recall-echo.toml"),
+            format!("[serve]\nsocket_path = \"{long}\"\n"),
+        )
+        .unwrap();
+
+        let err = socket_path(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("too long"), "{err}");
+    }
+
+    #[test]
+    fn spawn_lock_admits_one_winner_and_frees_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("graph.sock");
+
+        let winner = acquire_spawn_lock(&socket).unwrap();
+        assert!(winner.is_some());
+        assert!(acquire_spawn_lock(&socket).unwrap().is_none());
+
+        drop(winner);
+        assert!(acquire_spawn_lock(&socket).unwrap().is_some());
+    }
+
+    #[test]
+    fn stale_spawn_lock_is_reclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("graph.sock");
+        let lock = lock_path(&socket);
+
+        std::fs::write(&lock, "1\n").unwrap();
+        assert!(!lock_is_stale(&lock));
+
+        let old = std::time::SystemTime::now() - STALE_LOCK_AGE - Duration::from_secs(60);
+        set_mtime(&lock, old);
+        assert!(lock_is_stale(&lock));
+        assert!(acquire_spawn_lock(&socket).unwrap().is_some());
+    }
+
+    #[test]
+    fn graph_mode_defaults_to_embedded_and_reads_server() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(graph_mode(dir.path()), "embedded");
+        assert!(uses_daemon(dir.path()));
+
+        std::fs::write(
+            dir.path().join(".recall-echo.toml"),
+            "[graph]\nmode = \"server\"\n",
+        )
+        .unwrap();
+        assert_eq!(graph_mode(dir.path()), "server");
+        assert!(!uses_daemon(dir.path()));
+    }
+
+    #[test]
+    fn log_tail_reports_missing_and_present_logs() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.log");
+        assert!(log_tail(&path, 5).contains("no daemon log"));
+
+        std::fs::write(&path, "one\ntwo\nthree\n").unwrap();
+        let tail = log_tail(&path, 2);
+        assert!(tail.contains("two") && tail.contains("three"));
+        assert!(!tail.contains("one"));
+    }
+
+    #[test]
+    fn socket_dir_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let socket_dir = dir.path().join("run");
+        ensure_socket_dir(&socket_dir).unwrap();
+
+        let mode = std::fs::metadata(&socket_dir).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o700);
+    }
+
+    #[test]
+    fn socket_dir_failure_is_a_named_daemon_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"not a directory").unwrap();
+
+        let err = ensure_socket_dir(&blocker.join("run")).unwrap_err();
+        assert!(matches!(err, RecallError::Daemon(_)), "{err}");
+        assert!(err.to_string().contains("socket directory"), "{err}");
+    }
+
+    /// Backdate a file's mtime without a libc dependency: rewrite it through a
+    /// `File` whose times we set via `filetime`-free `set_times`.
+    fn set_mtime(path: &Path, when: std::time::SystemTime) {
+        let file = std::fs::OpenOptions::new().write(true).open(path).unwrap();
+        file.set_times(std::fs::FileTimes::new().set_modified(when))
+            .unwrap();
+    }
+}

--- a/src/serve_client.rs
+++ b/src/serve_client.rs
@@ -10,8 +10,13 @@
 //! - `[graph] mode = "server"` (advanced): the store is an external SurrealDB
 //!   server, so there is nothing to serialize — requests run in-process.
 //! - [`exclusive`]: admin operations (init, gc, extraction, bulk ingest, …)
-//!   stop the daemon and take the store for themselves; the next hot operation
-//!   starts a fresh daemon.
+//!   take an admin lock, stop the daemon and keep the store for themselves;
+//!   hot operations that arrive meanwhile wait for the lock, and the next one
+//!   after it is released starts a fresh daemon.
+//!
+//! Both ends of the socket check the peer's uid, and the socket, its
+//! directory, the pidfile and the daemon log are all owner-only — see
+//! [`crate::serve_security`].
 
 use std::io::ErrorKind;
 use std::os::unix::ffi::OsStrExt;
@@ -24,10 +29,34 @@ use tokio::net::UnixStream;
 use crate::error::RecallError;
 use crate::graph::GraphMemory;
 use crate::serve::{DaemonInfo, Request, Response};
+use crate::serve_security::{
+    append_private_file, check_peer_uid, create_new_private_file, create_private_dir, current_uid,
+    require_owned_dir, unlink_socket,
+};
 
 /// Environment override for the binary used to start the daemon.
 /// Defaults to the running executable; tests and wrappers set it explicitly.
 pub const DAEMON_BIN_ENV: &str = "RECALL_ECHO_BIN";
+
+/// Environment the detached daemon inherits. Everything else is dropped: the
+/// daemon outlives the command that started it by up to an hour, and hook
+/// contexts hand their process API credentials to every child they spawn.
+const DAEMON_ENV_ALLOWLIST: &[&str] = &[
+    "PATH",
+    "HOME",
+    "XDG_RUNTIME_DIR",
+    "RECALL_ECHO_HOME",
+    DAEMON_BIN_ENV,
+    // fastembed downloads the ONNX model over TLS on first use.
+    "SSL_CERT_FILE",
+    "SSL_CERT_DIR",
+    "HTTPS_PROXY",
+    "HTTP_PROXY",
+    "NO_PROXY",
+    "https_proxy",
+    "http_proxy",
+    "no_proxy",
+];
 
 /// `sockaddr_un.sun_path` is 108 bytes on Linux; stay well inside it.
 const MAX_SOCKET_PATH_LEN: usize = 100;
@@ -39,8 +68,20 @@ const POLL_INTERVAL: Duration = Duration::from_millis(25);
 const STALE_LOCK_AGE: Duration = Duration::from_secs(30);
 /// How long to wait for a daemon to answer the version handshake.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+/// Upper bound on a single request/response exchange with the daemon. Long
+/// enough for an ingest of a large archive, short enough that a wedged daemon
+/// cannot hang a session hook forever.
+const CALL_TIMEOUT: Duration = Duration::from_secs(300);
 /// Upper bound on connect → spawn → reconnect rounds.
 const MAX_CONNECT_ROUNDS: u32 = 3;
+/// How long a hot operation waits for an admin operation to release the store
+/// before failing with a named error.
+pub(crate) const ADMIN_WAIT_TIMEOUT: Duration = Duration::from_secs(300);
+/// An admin lock whose owner cannot be found in `/proc` is stale immediately;
+/// where process liveness is unknowable, it is stale after this long.
+const ADMIN_LOCK_STALE_AGE: Duration = Duration::from_secs(900);
+/// How many times `exclusive` re-stops a daemon that raced in behind it.
+const MAX_STOP_ROUNDS: u32 = 3;
 
 // ── Socket location ──────────────────────────────────────────────────────
 
@@ -56,7 +97,7 @@ pub fn socket_path(memory_dir: &Path) -> Result<PathBuf, RecallError> {
         Some(configured) if !configured.trim().is_empty() => {
             PathBuf::from(crate::paths::expand_tilde(configured.trim()))
         }
-        _ => runtime_dir().join(format!("{}.sock", path_hash(&canonical(memory_dir)))),
+        _ => runtime_dir()?.join(format!("{}.sock", path_hash(&canonical(memory_dir)))),
     };
 
     if path.as_os_str().as_bytes().len() > MAX_SOCKET_PATH_LEN {
@@ -70,20 +111,15 @@ pub fn socket_path(memory_dir: &Path) -> Result<PathBuf, RecallError> {
     Ok(path)
 }
 
-fn runtime_dir() -> PathBuf {
+/// The directory recall-echo derives its own sockets in.
+fn runtime_dir() -> Result<PathBuf, RecallError> {
     match std::env::var_os("XDG_RUNTIME_DIR") {
-        Some(dir) if !dir.is_empty() => PathBuf::from(dir).join("recall-echo"),
-        _ => PathBuf::from(format!("/tmp/recall-echo-{}", current_uid())),
+        Some(dir) if !dir.is_empty() => Ok(PathBuf::from(dir).join("recall-echo")),
+        _ => Ok(PathBuf::from(format!(
+            "/tmp/recall-echo-{}",
+            current_uid()?
+        ))),
     }
-}
-
-/// Owner uid, read from the filesystem so no libc dependency is needed.
-fn current_uid() -> u32 {
-    use std::os::unix::fs::MetadataExt;
-    std::fs::metadata("/proc/self")
-        .or_else(|_| std::fs::metadata(dirs::home_dir().unwrap_or_else(|| PathBuf::from("/tmp"))))
-        .map(|meta| meta.uid())
-        .unwrap_or(0)
 }
 
 fn canonical(path: &Path) -> PathBuf {
@@ -101,18 +137,19 @@ fn path_hash(path: &Path) -> String {
     format!("{hash:016x}")
 }
 
-/// Create the socket directory, owner-only.
+/// Make sure the socket directory exists and only this user can write into it.
+///
+/// recall-echo creates (and then validates as `0o700`) the runtime directory
+/// it derives itself. Any other directory comes from `[serve] socket_path`,
+/// i.e. from a config file that may not be trustworthy — it is validated but
+/// never created and never chmod-ed, so a config file cannot make the tool
+/// mutate an arbitrary directory.
 pub(crate) fn ensure_socket_dir(dir: &Path) -> Result<(), RecallError> {
-    use std::os::unix::fs::PermissionsExt;
-
-    std::fs::create_dir_all(dir).map_err(|err| {
-        RecallError::Daemon(format!(
-            "cannot create daemon socket directory {}: {err}",
-            dir.display()
-        ))
-    })?;
-    let _ = std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700));
-    Ok(())
+    if runtime_dir().is_ok_and(|derived| derived == dir) {
+        create_private_dir(dir)
+    } else {
+        require_owned_dir(dir)
+    }
 }
 
 // ── Public entry points ──────────────────────────────────────────────────
@@ -143,7 +180,17 @@ pub async fn execute(
 
     let socket = socket_path(memory_dir)?;
     let mut connection = connect_or_spawn(memory_dir, &socket).await?;
-    connection.call(request).await?.into_result()
+    match connection.call(request).await {
+        Ok(response) => response.into_result(),
+        // The daemon went away between the handshake and its answer (a crash,
+        // or an `exclusive` operation racing us). One fresh daemon, one retry —
+        // but only for a request that is safe to apply twice.
+        Err(CallError::Disconnected(_)) if request.is_retryable() => {
+            let mut connection = connect_or_spawn(memory_dir, &socket).await?;
+            connection.call(request).await?.into_result()
+        }
+        Err(err) => Err(err.into()),
+    }
 }
 
 async fn execute_direct(
@@ -158,9 +205,14 @@ async fn execute_direct(
 
 /// Take exclusive ownership of the store for an admin operation.
 ///
-/// Stops a running daemon, opens the store in-process, and runs `operation`.
-/// The daemon is not restarted here — the next hot operation starts a fresh
-/// one, so the store has exactly one owner at every instant.
+/// Takes the admin lock, stops a running daemon, opens the store in-process
+/// and runs `operation`. Hot clients that arrive while the lock is held wait
+/// for it instead of starting a daemon, so the store has exactly one owner at
+/// every instant. The daemon is not restarted here — the next hot operation
+/// starts a fresh one.
+///
+/// The lock is released only after the store has been closed, so the client
+/// that wakes up next never races the admin operation for the file lock.
 pub async fn exclusive<T, F, Fut>(memory_dir: &Path, operation: F) -> Result<T, RecallError>
 where
     F: FnOnce(GraphMemory) -> Fut,
@@ -171,9 +223,27 @@ where
         return operation(GraphMemory::open(&graph_dir).await?).await;
     }
 
-    stop_daemon(memory_dir).await?;
+    let socket = socket_path(memory_dir)?;
+    let admin = acquire_admin_lock(&socket, Instant::now() + ADMIN_WAIT_TIMEOUT).await?;
+    stop_daemon_for_admin(memory_dir).await?;
+
     let graph = GraphMemory::open_embedded(&graph_dir).await?;
-    operation(graph).await
+    let result = operation(graph).await;
+    drop(admin);
+    result
+}
+
+/// Stop the daemon, and any daemon that races in behind it.
+async fn stop_daemon_for_admin(memory_dir: &Path) -> Result<(), RecallError> {
+    for _ in 0..MAX_STOP_ROUNDS {
+        if !stop_daemon(memory_dir).await? {
+            return Ok(());
+        }
+    }
+    Err(RecallError::Daemon(format!(
+        "a graph daemon for {} keeps restarting; cannot take the store exclusively",
+        memory_dir.display()
+    )))
 }
 
 /// Identity of the running daemon, or `None` when none is running (or when
@@ -200,17 +270,57 @@ pub async fn stop_daemon(memory_dir: &Path) -> Result<bool, RecallError> {
     let socket = socket_path(memory_dir)?;
     let Some(mut connection) = Connection::try_connect(&socket).await else {
         // Nothing listening — clear a stale socket so the next start is clean.
-        let _ = std::fs::remove_file(&socket);
+        unlink_socket(&socket)?;
         return Ok(false);
     };
 
-    connection.call(&Request::Shutdown).await?.into_result()?;
+    match connection.call(&Request::Shutdown).await {
+        Ok(response) => {
+            response.into_result()?;
+        }
+        // The daemon died (or shut itself down) before it could answer: the
+        // end state we asked for is the one we got.
+        Err(CallError::Disconnected(_)) => {}
+        Err(err) => return Err(err.into()),
+    }
     drop(connection);
     wait_for_socket_gone(&socket, Instant::now() + START_TIMEOUT).await?;
     Ok(true)
 }
 
 // ── Connection ───────────────────────────────────────────────────────────
+
+/// Why a request over the daemon socket failed.
+///
+/// The distinction matters on the hook path: a dead daemon is recoverable by
+/// starting a fresh one, while a protocol or timeout failure is not and must
+/// surface as-is.
+enum CallError {
+    /// The daemon closed the connection: idle timeout, shutdown, or a crash.
+    Disconnected(RecallError),
+    /// Anything else — retrying will not help.
+    Fatal(RecallError),
+}
+
+impl From<CallError> for RecallError {
+    fn from(err: CallError) -> Self {
+        match err {
+            CallError::Disconnected(err) | CallError::Fatal(err) => err,
+        }
+    }
+}
+
+/// A broken pipe or reset means the daemon went away mid-request.
+fn classify_io(err: std::io::Error) -> CallError {
+    match err.kind() {
+        ErrorKind::BrokenPipe
+        | ErrorKind::ConnectionReset
+        | ErrorKind::ConnectionAborted
+        | ErrorKind::UnexpectedEof
+        | ErrorKind::NotConnected => CallError::Disconnected(err.into()),
+        _ => CallError::Fatal(err.into()),
+    }
+}
 
 /// One JSON-line conversation with a daemon.
 struct Connection {
@@ -221,6 +331,7 @@ struct Connection {
 impl Connection {
     async fn connect(socket: &Path) -> std::io::Result<Self> {
         let stream = UnixStream::connect(socket).await?;
+        verify_daemon_peer(&stream)?;
         let (reader, writer) = stream.into_split();
         Ok(Self {
             reader: BufReader::new(reader),
@@ -233,50 +344,95 @@ impl Connection {
         Self::connect(socket).await.ok()
     }
 
-    async fn call(&mut self, request: &Request) -> Result<Response, RecallError> {
-        let mut line = serde_json::to_vec(request)?;
+    /// Send one request and read its response, bounded by [`CALL_TIMEOUT`].
+    async fn call(&mut self, request: &Request) -> Result<Response, CallError> {
+        match tokio::time::timeout(CALL_TIMEOUT, self.exchange(request)).await {
+            Ok(result) => result,
+            Err(_) => Err(CallError::Fatal(RecallError::Daemon(format!(
+                "the graph daemon did not answer `{}` within {}s — see the daemon log",
+                request.op_name(),
+                CALL_TIMEOUT.as_secs()
+            )))),
+        }
+    }
+
+    async fn exchange(&mut self, request: &Request) -> Result<Response, CallError> {
+        let mut line = serde_json::to_vec(request).map_err(|err| CallError::Fatal(err.into()))?;
         line.push(b'\n');
-        self.writer.write_all(&line).await?;
-        self.writer.flush().await?;
+        self.writer.write_all(&line).await.map_err(classify_io)?;
+        self.writer.flush().await.map_err(classify_io)?;
 
         let mut response_line = String::new();
-        let read = self.reader.read_line(&mut response_line).await?;
+        let read = self
+            .reader
+            .read_line(&mut response_line)
+            .await
+            .map_err(classify_io)?;
         if read == 0 {
-            return Err(RecallError::Daemon(format!(
+            return Err(CallError::Disconnected(RecallError::Daemon(format!(
                 "daemon closed the connection while handling `{}` — see the daemon log",
                 request.op_name()
-            )));
+            ))));
         }
-        Ok(serde_json::from_str(&response_line)?)
+        serde_json::from_str(&response_line).map_err(|err| CallError::Fatal(err.into()))
     }
 
-    async fn hello(&mut self) -> Result<DaemonInfo, RecallError> {
-        let response = tokio::time::timeout(HANDSHAKE_TIMEOUT, self.call(&Request::Hello))
-            .await
-            .map_err(|_| {
-                RecallError::Daemon("daemon did not answer the version handshake within 10s".into())
-            })??;
-        let data = response.into_result()?;
-        Ok(serde_json::from_value(data)?)
+    async fn hello(&mut self) -> Result<DaemonInfo, CallError> {
+        let response =
+            match tokio::time::timeout(HANDSHAKE_TIMEOUT, self.exchange(&Request::Hello)).await {
+                Ok(result) => result?,
+                Err(_) => {
+                    return Err(CallError::Fatal(RecallError::Daemon(format!(
+                        "daemon did not answer the version handshake within {}s",
+                        HANDSHAKE_TIMEOUT.as_secs()
+                    ))))
+                }
+            };
+        let data = response.into_result().map_err(CallError::Fatal)?;
+        serde_json::from_value(data).map_err(|err| CallError::Fatal(err.into()))
     }
+}
+
+/// Refuse to talk to a daemon running as another user: it would see every
+/// ingest payload we send and could answer every query with anything it likes.
+fn verify_daemon_peer(stream: &UnixStream) -> std::io::Result<()> {
+    let peer = stream.peer_cred()?;
+    let owner = current_uid().map_err(permission_denied)?;
+    check_peer_uid(peer.uid(), owner).map_err(permission_denied)
+}
+
+fn permission_denied(err: RecallError) -> std::io::Error {
+    std::io::Error::new(ErrorKind::PermissionDenied, err.to_string())
 }
 
 /// Connect to the daemon for `socket`, starting one if needed.
 async fn connect_or_spawn(memory_dir: &Path, socket: &Path) -> Result<Connection, RecallError> {
+    // Establish that the socket lives somewhere only we can write *before*
+    // touching anything in it, so an unusable location is reported as such
+    // rather than as a puzzling connect failure.
+    if let Some(parent) = socket.parent() {
+        ensure_socket_dir(parent)?;
+    }
     let deadline = Instant::now() + START_TIMEOUT;
 
     for _ in 0..MAX_CONNECT_ROUNDS {
         match Connection::connect(socket).await {
-            Ok(mut connection) => {
-                let info = connection.hello().await?;
-                if info.version == env!("CARGO_PKG_VERSION") {
-                    return Ok(connection);
+            Ok(mut connection) => match connection.hello().await {
+                Ok(info) if info.version == env!("CARGO_PKG_VERSION") => return Ok(connection),
+                Ok(_) => {
+                    // Upgraded binary, stale daemon: ask it to go, then respawn.
+                    let _ = connection.call(&Request::Shutdown).await;
+                    drop(connection);
+                    wait_for_socket_gone(socket, deadline).await?;
                 }
-                // Upgraded binary, stale daemon: ask it to go, then respawn.
-                let _ = connection.call(&Request::Shutdown).await;
-                drop(connection);
-                wait_for_socket_gone(socket, deadline).await?;
-            }
+                // The daemon closed the socket mid-handshake — it went idle or
+                // an admin operation stopped it. Clean up and start a fresh one.
+                Err(CallError::Disconnected(_)) => {
+                    drop(connection);
+                    unlink_socket(socket)?;
+                }
+                Err(CallError::Fatal(err)) => return Err(err),
+            },
             Err(err) if err.kind() == ErrorKind::PermissionDenied => {
                 return Err(RecallError::Daemon(format!(
                     "permission denied opening the daemon socket {}: {err}. \
@@ -288,11 +444,11 @@ async fn connect_or_spawn(memory_dir: &Path, socket: &Path) -> Result<Connection
             Err(err) if err.kind() == ErrorKind::NotFound => {}
             Err(_) => {
                 // Socket file exists but nothing is listening (crashed daemon).
-                let _ = std::fs::remove_file(socket);
+                unlink_socket(socket)?;
             }
         }
 
-        start_daemon(memory_dir, socket, deadline).await?;
+        start_daemon(memory_dir, socket, Instant::now() + START_TIMEOUT).await?;
     }
 
     Err(RecallError::Daemon(format!(
@@ -302,11 +458,16 @@ async fn connect_or_spawn(memory_dir: &Path, socket: &Path) -> Result<Connection
 }
 
 /// Start a daemon — exactly one client wins the race; the rest wait.
+///
+/// An admin operation ([`exclusive`]) owns the store while its lock is held,
+/// so a daemon started now would collide with it: wait for the lock first.
 async fn start_daemon(
     memory_dir: &Path,
     socket: &Path,
     deadline: Instant,
 ) -> Result<(), RecallError> {
+    wait_for_admin_lock(socket, Instant::now() + ADMIN_WAIT_TIMEOUT).await?;
+
     match acquire_spawn_lock(socket)? {
         Some(lock) => {
             let result = match spawn_daemon(memory_dir, socket) {
@@ -366,10 +527,7 @@ fn acquire_spawn_lock(socket: &Path) -> Result<Option<SpawnLock>, RecallError> {
 
 fn create_lock_file(path: &Path) -> std::io::Result<()> {
     use std::io::Write as _;
-    let mut file = std::fs::OpenOptions::new()
-        .write(true)
-        .create_new(true)
-        .open(path)?;
+    let mut file = create_new_private_file().open(path)?;
     writeln!(file, "{}", std::process::id())
 }
 
@@ -378,6 +536,130 @@ fn lock_is_stale(path: &Path) -> bool {
         .and_then(|meta| meta.modified())
         .map(|modified| modified.elapsed().unwrap_or_default() > STALE_LOCK_AGE)
         .unwrap_or(true)
+}
+
+// ── Admin lock ───────────────────────────────────────────────────────────
+
+/// Exclusive ownership of a store by an admin operation.
+///
+/// Held for the whole operation — which can run for minutes — and released
+/// only after the store has been closed. Hot clients wait for it instead of
+/// starting a daemon that would collide with the operation.
+///
+/// Crash safety comes from the owning pid rather than from a heartbeat: an
+/// admin operation blocks its thread inside the ONNX embedder for long
+/// stretches, so a timer-based heartbeat would report a healthy operation as
+/// dead. Where process liveness cannot be read (`/proc` absent), the lock's
+/// mtime bounds how long a crashed holder can block others.
+#[derive(Debug)]
+struct AdminLock {
+    path: PathBuf,
+}
+
+impl Drop for AdminLock {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+/// Path of the admin lockfile that accompanies a socket.
+fn admin_lock_path(socket: &Path) -> PathBuf {
+    let mut path = socket.as_os_str().to_os_string();
+    path.push(".admin");
+    PathBuf::from(path)
+}
+
+/// Take the admin lock, waiting for another admin operation to finish.
+async fn acquire_admin_lock(socket: &Path, deadline: Instant) -> Result<AdminLock, RecallError> {
+    if let Some(parent) = socket.parent() {
+        ensure_socket_dir(parent)?;
+    }
+    let path = admin_lock_path(socket);
+
+    loop {
+        match create_lock_file(&path) {
+            Ok(()) => return Ok(AdminLock { path }),
+            Err(err) if err.kind() == ErrorKind::AlreadyExists => {
+                if !admin_lock_is_live(&path) {
+                    let _ = std::fs::remove_file(&path);
+                } else if Instant::now() >= deadline {
+                    return Err(admin_wait_timeout(&path));
+                }
+                tokio::time::sleep(POLL_INTERVAL).await;
+                if Instant::now() >= deadline {
+                    return Err(admin_wait_timeout(&path));
+                }
+            }
+            Err(err) => {
+                return Err(RecallError::Daemon(format!(
+                    "cannot create the admin lock {}: {err}",
+                    path.display()
+                )))
+            }
+        }
+    }
+}
+
+/// Wait until no admin operation owns the store for `socket`.
+pub(crate) async fn wait_for_admin_lock(
+    socket: &Path,
+    deadline: Instant,
+) -> Result<(), RecallError> {
+    let path = admin_lock_path(socket);
+    while admin_lock_is_live(&path) {
+        if Instant::now() >= deadline {
+            return Err(admin_wait_timeout(&path));
+        }
+        tokio::time::sleep(POLL_INTERVAL).await;
+    }
+    Ok(())
+}
+
+fn admin_wait_timeout(path: &Path) -> RecallError {
+    RecallError::Daemon(format!(
+        "a recall-echo admin operation has owned the graph store for more than {}s \
+         (lock {}). Wait for it to finish, or remove the lock if its process is gone.",
+        ADMIN_WAIT_TIMEOUT.as_secs(),
+        path.display()
+    ))
+}
+
+/// True when an admin lockfile belongs to a live admin operation.
+pub(crate) fn admin_lock_is_held(socket: &Path) -> bool {
+    admin_lock_is_live(&admin_lock_path(socket))
+}
+
+fn admin_lock_is_live(path: &Path) -> bool {
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    match lock_owner_pid(path).map(process_is_alive) {
+        Some(Some(alive)) => alive,
+        // Unreadable pid, or a platform without `/proc`: fall back to age.
+        _ => meta
+            .modified()
+            .map(|modified| modified.elapsed().unwrap_or_default() < ADMIN_LOCK_STALE_AGE)
+            .unwrap_or(false),
+    }
+}
+
+fn lock_owner_pid(path: &Path) -> Option<u32> {
+    std::fs::read_to_string(path)
+        .ok()?
+        .lines()
+        .next()?
+        .trim()
+        .parse()
+        .ok()
+}
+
+/// `Some(alive)` where process liveness can be read from `/proc` (Linux),
+/// `None` where it cannot.
+fn process_is_alive(pid: u32) -> Option<bool> {
+    if !Path::new("/proc/self").exists() {
+        return None;
+    }
+    Some(Path::new(&format!("/proc/{pid}")).exists())
 }
 
 fn daemon_binary() -> Result<PathBuf, RecallError> {
@@ -402,16 +684,12 @@ fn spawn_daemon(memory_dir: &Path, socket: &Path) -> Result<std::process::Child,
     if let Some(parent) = log_path.parent() {
         std::fs::create_dir_all(parent)?;
     }
-    let log = std::fs::OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .map_err(|err| {
-            RecallError::Daemon(format!(
-                "cannot open the daemon log {}: {err}",
-                log_path.display()
-            ))
-        })?;
+    let log = append_private_file().open(&log_path).map_err(|err| {
+        RecallError::Daemon(format!(
+            "cannot open the daemon log {}: {err}",
+            log_path.display()
+        ))
+    })?;
 
     let mut command = std::process::Command::new(&binary);
     command
@@ -424,6 +702,7 @@ fn spawn_daemon(memory_dir: &Path, socket: &Path) -> Result<std::process::Child,
         // Own process group: terminal signals aimed at the client never reach
         // the daemon, and the daemon outlives the shell that started it.
         .process_group(0);
+    apply_daemon_env(&mut command);
 
     command.spawn().map_err(|err| {
         RecallError::Daemon(format!(
@@ -434,6 +713,20 @@ fn spawn_daemon(memory_dir: &Path, socket: &Path) -> Result<std::process::Child,
             socket.display()
         ))
     })
+}
+
+/// Hand the daemon a minimal environment.
+///
+/// The daemon is detached and long-lived; inheriting the client's environment
+/// would hand it whatever credentials the calling context happens to export
+/// (a Claude Code hook exports API keys) for the rest of its hour-long life.
+fn apply_daemon_env(command: &mut std::process::Command) {
+    command.env_clear();
+    for key in DAEMON_ENV_ALLOWLIST {
+        if let Some(value) = std::env::var_os(key) {
+            command.env(key, value);
+        }
+    }
 }
 
 /// Daemon log path for a memory directory.
@@ -479,7 +772,7 @@ async fn wait_for_socket(
 async fn wait_for_socket_gone(socket: &Path, deadline: Instant) -> Result<(), RecallError> {
     while Instant::now() < deadline {
         if Connection::try_connect(socket).await.is_none() {
-            let _ = std::fs::remove_file(socket);
+            unlink_socket(socket)?;
             return Ok(());
         }
         tokio::time::sleep(POLL_INTERVAL).await;
@@ -621,15 +914,36 @@ mod tests {
     }
 
     #[test]
-    fn socket_dir_is_owner_only() {
+    fn the_derived_runtime_dir_is_created_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let derived = runtime_dir().unwrap();
+        ensure_socket_dir(&derived).unwrap();
+
+        let mode = std::fs::metadata(&derived).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o700);
+    }
+
+    /// A `[serve] socket_path` can point anywhere, so its directory is only
+    /// ever validated — never created, never chmod-ed.
+    #[test]
+    fn a_configured_socket_dir_is_validated_not_created() {
         use std::os::unix::fs::PermissionsExt;
 
         let dir = tempfile::tempdir().unwrap();
-        let socket_dir = dir.path().join("run");
-        ensure_socket_dir(&socket_dir).unwrap();
+        let missing = dir.path().join("run");
 
-        let mode = std::fs::metadata(&socket_dir).unwrap().permissions().mode();
-        assert_eq!(mode & 0o777, 0o700);
+        let err = ensure_socket_dir(&missing).unwrap_err();
+        assert!(matches!(err, RecallError::Daemon(_)), "{err}");
+        assert!(err.to_string().contains("socket directory"), "{err}");
+        assert!(!missing.exists(), "the directory must not be created");
+
+        // An existing directory only we can write into is accepted as-is.
+        std::fs::create_dir(&missing).unwrap();
+        std::fs::set_permissions(&missing, std::fs::Permissions::from_mode(0o755)).unwrap();
+        ensure_socket_dir(&missing).unwrap();
+        let mode = std::fs::metadata(&missing).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o755, "the directory must not be chmod-ed");
     }
 
     #[test]
@@ -641,6 +955,80 @@ mod tests {
         let err = ensure_socket_dir(&blocker.join("run")).unwrap_err();
         assert!(matches!(err, RecallError::Daemon(_)), "{err}");
         assert!(err.to_string().contains("socket directory"), "{err}");
+    }
+
+    #[tokio::test]
+    async fn admin_lock_admits_one_holder_and_frees_on_drop() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("graph.sock");
+
+        assert!(!admin_lock_is_held(&socket));
+        let held = acquire_admin_lock(&socket, Instant::now() + Duration::from_millis(50))
+            .await
+            .unwrap();
+        assert!(admin_lock_is_held(&socket));
+
+        let err = acquire_admin_lock(&socket, Instant::now() + Duration::from_millis(50))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("admin operation"), "{err}");
+
+        drop(held);
+        assert!(!admin_lock_is_held(&socket));
+        acquire_admin_lock(&socket, Instant::now() + Duration::from_millis(50))
+            .await
+            .unwrap();
+    }
+
+    /// A client that died mid-operation must not block the store forever.
+    #[tokio::test]
+    async fn an_admin_lock_owned_by_a_dead_process_is_reclaimed() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("graph.sock");
+        let path = admin_lock_path(&socket);
+
+        // pid 0 never names a live process, so `/proc/0` never exists.
+        std::fs::write(&path, "0\n").unwrap();
+        assert!(!admin_lock_is_held(&socket));
+        acquire_admin_lock(&socket, Instant::now() + Duration::from_millis(50))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_live_admin_lock_is_honored_by_waiters() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("graph.sock");
+        let path = admin_lock_path(&socket);
+
+        std::fs::write(&path, format!("{}\n", std::process::id())).unwrap();
+        assert!(admin_lock_is_held(&socket));
+
+        let err = wait_for_admin_lock(&socket, Instant::now() + Duration::from_millis(50))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, RecallError::Daemon(_)), "{err}");
+
+        std::fs::remove_file(&path).unwrap();
+        wait_for_admin_lock(&socket, Instant::now() + Duration::from_millis(50))
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn the_daemon_environment_is_an_allowlist() {
+        assert!(DAEMON_ENV_ALLOWLIST.contains(&"PATH"));
+        assert!(DAEMON_ENV_ALLOWLIST.contains(&DAEMON_BIN_ENV));
+        for secret in [
+            "ANTHROPIC_API_KEY",
+            "CLAUDE_CODE_OAUTH_TOKEN",
+            "AWS_SECRET_ACCESS_KEY",
+        ] {
+            assert!(
+                !DAEMON_ENV_ALLOWLIST.contains(&secret),
+                "{secret} must not reach the detached daemon"
+            );
+        }
     }
 
     /// Backdate a file's mtime without a libc dependency: rewrite it through a

--- a/src/serve_security.rs
+++ b/src/serve_security.rs
@@ -1,0 +1,435 @@
+//! Ownership checks for the daemon's filesystem surface and its socket peers.
+//!
+//! The daemon socket carries unauthenticated command access to a whole graph —
+//! including `ingest_archive` and `shutdown` — so both ends verify that the
+//! other side runs as the same uid, and every directory the socket lives in
+//! must be owner-only.
+//!
+//! Everything here **fails closed**: when ownership cannot be established the
+//! operation is refused with a named [`RecallError::Daemon`], never assumed
+//! safe. In particular the directory checks never *repair* a directory they
+//! did not create — chmod-ing a pre-existing directory is how a local user
+//! turns a symlink into a privilege escalation.
+
+use std::fs::DirBuilder;
+use std::io::ErrorKind;
+use std::os::unix::fs::{DirBuilderExt, FileTypeExt, MetadataExt, OpenOptionsExt, PermissionsExt};
+use std::path::Path;
+
+use crate::error::RecallError;
+
+/// Mode of every directory recall-echo creates at runtime: owner-only.
+pub(crate) const PRIVATE_DIR_MODE: u32 = 0o700;
+/// Mode of every runtime file recall-echo creates: owner-only.
+pub(crate) const PRIVATE_FILE_MODE: u32 = 0o600;
+
+/// Permission bits that must never be set on a directory recall-echo derives
+/// and creates itself.
+const FOREIGN_ACCESS: u32 = 0o077;
+/// Permission bits that let another user drop a socket of their own into a
+/// directory — the bits that actually enable a socket hijack.
+const FOREIGN_WRITE: u32 = 0o022;
+
+/// The uid recall-echo runs as.
+///
+/// Read from the filesystem (`/proc/self`, then the home directory) so no libc
+/// dependency is needed. An unknown uid is an error — never a silent `0`,
+/// which would make every ownership comparison pass for root-owned paths.
+pub(crate) fn current_uid() -> Result<u32, RecallError> {
+    std::fs::metadata("/proc/self")
+        .or_else(|_| {
+            let home = dirs::home_dir()
+                .ok_or_else(|| std::io::Error::new(ErrorKind::NotFound, "no home directory"))?;
+            std::fs::metadata(home)
+        })
+        .map(|meta| meta.uid())
+        .map_err(|err| {
+            RecallError::Daemon(format!(
+                "cannot determine the uid recall-echo runs as ({err}); \
+                 refusing to use the graph daemon socket"
+            ))
+        })
+}
+
+/// Options that create a file owner-only, failing if it already exists.
+pub(crate) fn create_new_private_file() -> std::fs::OpenOptions {
+    let mut options = std::fs::OpenOptions::new();
+    options.write(true).create_new(true).mode(PRIVATE_FILE_MODE);
+    options
+}
+
+/// Options that append to a file, creating it owner-only.
+pub(crate) fn append_private_file() -> std::fs::OpenOptions {
+    let mut options = std::fs::OpenOptions::new();
+    options.append(true).create(true).mode(PRIVATE_FILE_MODE);
+    options
+}
+
+/// Create `dir` (and any missing parents) owner-only, then verify it.
+///
+/// Only for directories recall-echo derives itself. Each component is created
+/// with mode `0o700` by the kernel, so there is no window where the directory
+/// exists with wider permissions; a component that already exists is validated,
+/// never chmod-ed.
+pub(crate) fn create_private_dir(dir: &Path) -> Result<(), RecallError> {
+    if let Some(parent) = dir.parent() {
+        require_safe_container(parent)?;
+    }
+    DirBuilder::new()
+        .mode(PRIVATE_DIR_MODE)
+        .recursive(true)
+        .create(dir)
+        .map_err(|err| {
+            RecallError::Daemon(format!(
+                "cannot create daemon socket directory {}: {err}",
+                dir.display()
+            ))
+        })?;
+    require_private_dir(dir)
+}
+
+/// Verify that `dir` is an owner-only directory belonging to this user.
+///
+/// The strict policy, for the runtime directory recall-echo derives and
+/// creates itself: anything looser than `0o700` there means somebody else
+/// created it first.
+pub(crate) fn require_private_dir(dir: &Path) -> Result<(), RecallError> {
+    let meta = inspect_dir(dir)?;
+    let mode = meta.permissions().mode();
+    if mode & FOREIGN_ACCESS != 0 {
+        return Err(refuse(
+            dir,
+            &format!(
+                "is accessible to other users (mode {:04o}, needs {PRIVATE_DIR_MODE:04o})",
+                mode & 0o7777
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Verify that `dir` is a directory only this user can write into.
+///
+/// The policy for a directory recall-echo does *not* own — one named by
+/// `[serve] socket_path`, which comes from a config file an untrusted checkout
+/// can supply. Such a directory is never created and never chmod-ed, only
+/// accepted or refused, and a conventional `0o755` home-relative directory is
+/// perfectly safe: what matters is that no other user can put their own socket
+/// there for us to talk to.
+pub(crate) fn require_owned_dir(dir: &Path) -> Result<(), RecallError> {
+    let meta = inspect_dir(dir)?;
+    let mode = meta.permissions().mode();
+    if mode & FOREIGN_WRITE != 0 && mode & 0o1000 == 0 {
+        return Err(refuse(
+            dir,
+            &format!("is writable by other users (mode {:04o})", mode & 0o7777),
+        ));
+    }
+    Ok(())
+}
+
+/// Shared checks: a real directory, not a symlink, owned by this user.
+fn inspect_dir(dir: &Path) -> Result<std::fs::Metadata, RecallError> {
+    let meta = std::fs::symlink_metadata(dir).map_err(|err| {
+        RecallError::Daemon(format!(
+            "cannot use daemon socket directory {}: {err}. \
+             Create it, or set `[serve] socket_path` in .recall-echo.toml.",
+            dir.display()
+        ))
+    })?;
+
+    if meta.file_type().is_symlink() {
+        return Err(refuse(dir, "is a symlink"));
+    }
+    if !meta.is_dir() {
+        return Err(refuse(dir, "is not a directory"));
+    }
+
+    let owner = current_uid()?;
+    if meta.uid() != owner {
+        return Err(refuse(
+            dir,
+            &format!("is owned by uid {}, not {owner}", meta.uid()),
+        ));
+    }
+    Ok(meta)
+}
+
+fn refuse(dir: &Path, reason: &str) -> RecallError {
+    RecallError::Daemon(format!(
+        "refusing to use daemon socket directory {}: it {reason}. \
+         Remove it, or set `[serve] socket_path` in .recall-echo.toml to a directory you own.",
+        dir.display()
+    ))
+}
+
+/// Verify that a directory recall-echo is about to create something inside is
+/// not a hijack point: it must belong to this user or to root, and if it is
+/// group- or world-writable it must carry the sticky bit (as `/tmp` does).
+/// Without that, another user could rename our socket directory away and put
+/// theirs in its place.
+fn require_safe_container(parent: &Path) -> Result<(), RecallError> {
+    let Ok(meta) = std::fs::metadata(parent) else {
+        // Missing or unreadable: the create call below reports it precisely.
+        return Ok(());
+    };
+    let mode = meta.permissions().mode();
+    let shared_writable = mode & 0o022 != 0;
+    let sticky = mode & 0o1000 != 0;
+    let owner = current_uid()?;
+
+    if meta.uid() != owner && meta.uid() != 0 {
+        return Err(refuse(
+            parent,
+            &format!(
+                "holds our socket directory but is owned by uid {}",
+                meta.uid()
+            ),
+        ));
+    }
+    if shared_writable && !sticky {
+        return Err(refuse(
+            parent,
+            &format!(
+                "holds our socket directory but is writable by other users without the sticky bit (mode {:04o})",
+                mode & 0o7777
+            ),
+        ));
+    }
+    Ok(())
+}
+
+/// Remove a unix socket, refusing to unlink anything else.
+///
+/// `bind` reports `EADDRINUSE` for a *regular* file too, so an unguarded
+/// "clear the stale socket" step turns a config-supplied `socket_path` into an
+/// arbitrary-file delete. Missing paths are not an error — the socket being
+/// gone is the desired end state.
+pub(crate) fn unlink_socket(path: &Path) -> Result<(), RecallError> {
+    let meta = match std::fs::symlink_metadata(path) {
+        Ok(meta) => meta,
+        Err(err) if err.kind() == ErrorKind::NotFound => return Ok(()),
+        Err(err) => {
+            return Err(RecallError::Daemon(format!(
+                "cannot inspect the daemon socket {}: {err}",
+                path.display()
+            )))
+        }
+    };
+
+    if !meta.file_type().is_socket() {
+        return Err(RecallError::Daemon(format!(
+            "refusing to remove {}: it is not a unix socket. \
+             Check `[serve] socket_path` in .recall-echo.toml.",
+            path.display()
+        )));
+    }
+    let owner = current_uid()?;
+    if meta.uid() != owner {
+        return Err(RecallError::Daemon(format!(
+            "refusing to remove the daemon socket {}: it is owned by uid {}, not {owner}",
+            path.display(),
+            meta.uid()
+        )));
+    }
+
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(RecallError::Daemon(format!(
+            "cannot remove the daemon socket {}: {err}",
+            path.display()
+        ))),
+    }
+}
+
+/// Accept a socket peer only when it runs as the daemon's own uid.
+///
+/// The unix socket has no other authentication: whoever connects can read
+/// every ingest payload and forge every query result.
+pub(crate) fn check_peer_uid(peer_uid: u32, owner_uid: u32) -> Result<(), RecallError> {
+    if peer_uid == owner_uid {
+        return Ok(());
+    }
+    Err(RecallError::Daemon(format!(
+        "graph daemon socket peer uid {peer_uid} does not match the owner uid {owner_uid}"
+    )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::symlink;
+
+    #[test]
+    fn current_uid_matches_a_file_we_just_created() {
+        let dir = tempfile::tempdir().unwrap();
+        let meta = std::fs::metadata(dir.path()).unwrap();
+        assert_eq!(current_uid().unwrap(), meta.uid());
+    }
+
+    #[test]
+    fn created_socket_dir_is_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket_dir = dir.path().join("run");
+        create_private_dir(&socket_dir).unwrap();
+
+        let mode = std::fs::metadata(&socket_dir).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, PRIVATE_DIR_MODE);
+    }
+
+    #[test]
+    fn nested_socket_dirs_are_each_created_owner_only() {
+        let dir = tempfile::tempdir().unwrap();
+        let nested = dir.path().join("a").join("b");
+        create_private_dir(&nested).unwrap();
+
+        for path in [dir.path().join("a"), nested] {
+            let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, PRIVATE_DIR_MODE, "{}", path.display());
+        }
+    }
+
+    /// The hijack: a local user pre-creates the socket directory world-writable
+    /// so they can drop their own socket in it.
+    #[test]
+    fn a_world_writable_socket_dir_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let hijacked = dir.path().join("run");
+        std::fs::create_dir(&hijacked).unwrap();
+        std::fs::set_permissions(&hijacked, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        for err in [
+            create_private_dir(&hijacked).unwrap_err(),
+            require_private_dir(&hijacked).unwrap_err(),
+            require_owned_dir(&hijacked).unwrap_err(),
+        ] {
+            assert!(matches!(err, RecallError::Daemon(_)), "{err}");
+        }
+
+        // The refusal must not have "repaired" the directory behind our back —
+        // chmod-ing a directory we did not create is the escalation itself.
+        let mode = std::fs::metadata(&hijacked).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, 0o777);
+    }
+
+    /// A conventional `0o755` directory cannot be hijacked (nobody else can
+    /// write in it), so a configured `socket_path` may live there — but the
+    /// runtime directory recall-echo creates itself must still be `0o700`.
+    #[test]
+    fn a_readable_but_unwritable_socket_dir_is_owner_only_enough() {
+        let dir = tempfile::tempdir().unwrap();
+        let conventional = dir.path().join("run");
+        std::fs::create_dir(&conventional).unwrap();
+        std::fs::set_permissions(&conventional, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        require_owned_dir(&conventional).unwrap();
+
+        let err = require_private_dir(&conventional).unwrap_err();
+        assert!(
+            err.to_string().contains("accessible to other users"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_symlinked_socket_dir_is_refused() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target");
+        std::fs::create_dir(&target).unwrap();
+        let link = dir.path().join("run");
+        symlink(&target, &link).unwrap();
+
+        for err in [
+            require_private_dir(&link).unwrap_err(),
+            require_owned_dir(&link).unwrap_err(),
+            // create_dir_all follows symlinks, so creating must refuse too.
+            create_private_dir(&link).unwrap_err(),
+        ] {
+            assert!(err.to_string().contains("is a symlink"), "{err}");
+        }
+    }
+
+    #[test]
+    fn a_regular_file_is_not_a_socket_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("run");
+        std::fs::write(&file, b"x").unwrap();
+
+        let err = require_owned_dir(&file).unwrap_err();
+        assert!(err.to_string().contains("socket directory"), "{err}");
+        assert!(err.to_string().contains("is not a directory"), "{err}");
+    }
+
+    #[test]
+    fn a_missing_socket_dir_is_a_named_daemon_error() {
+        let dir = tempfile::tempdir().unwrap();
+        let err = require_owned_dir(&dir.path().join("nope")).unwrap_err();
+        assert!(matches!(err, RecallError::Daemon(_)), "{err}");
+        assert!(err.to_string().contains("socket directory"), "{err}");
+    }
+
+    #[test]
+    fn unlink_socket_removes_only_sockets() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("g.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+        drop(listener);
+
+        unlink_socket(&socket).unwrap();
+        assert!(!socket.exists());
+        // Idempotent: a missing socket is the desired end state.
+        unlink_socket(&socket).unwrap();
+    }
+
+    #[test]
+    fn unlink_socket_refuses_a_regular_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = dir.path().join("precious.toml");
+        std::fs::write(&file, b"keep me").unwrap();
+
+        let err = unlink_socket(&file).unwrap_err();
+        assert!(err.to_string().contains("not a unix socket"), "{err}");
+        assert!(file.exists(), "the file must survive the refusal");
+    }
+
+    #[test]
+    fn unlink_socket_refuses_a_symlink_to_a_socket() {
+        let dir = tempfile::tempdir().unwrap();
+        let socket = dir.path().join("g.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket).unwrap();
+        let link = dir.path().join("link.sock");
+        symlink(&socket, &link).unwrap();
+
+        let err = unlink_socket(&link).unwrap_err();
+        assert!(err.to_string().contains("not a unix socket"), "{err}");
+        assert!(socket.exists(), "the target must survive");
+        drop(listener);
+    }
+
+    #[test]
+    fn peer_uid_must_match_the_owner() {
+        assert!(check_peer_uid(1000, 1000).is_ok());
+
+        let err = check_peer_uid(1001, 1000).unwrap_err();
+        assert!(matches!(err, RecallError::Daemon(_)), "{err}");
+        assert!(err.to_string().contains("1001"), "{err}");
+        assert!(err.to_string().contains("1000"), "{err}");
+    }
+
+    #[test]
+    fn private_file_options_create_owner_only_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("daemon.log");
+
+        drop(append_private_file().open(&path).unwrap());
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, PRIVATE_FILE_MODE);
+
+        let exclusive = dir.path().join("g.sock.lock");
+        drop(create_new_private_file().open(&exclusive).unwrap());
+        assert!(create_new_private_file().open(&exclusive).is_err());
+        let mode = std::fs::metadata(&exclusive).unwrap().permissions().mode();
+        assert_eq!(mode & 0o777, PRIVATE_FILE_MODE);
+    }
+}

--- a/tests/graph_lock.rs
+++ b/tests/graph_lock.rs
@@ -1,0 +1,46 @@
+//! The embedded store's process-exclusive lock, exercised for real.
+//!
+//! Everything the daemon exists for rests on one behavior: a second opener of
+//! an embedded store fails with [`GraphError::Locked`] rather than corrupting
+//! it or hanging. That detection is a match on SurrealKV's error *text*, so a
+//! dependency reword would silently turn the retry path into a raw `Db` error
+//! and the daemon hand-off into a hard failure. This test is the tripwire.
+
+use recall_echo::graph::error::GraphError;
+use recall_echo::graph::store;
+use recall_echo::graph::GraphMemory;
+use tempfile::TempDir;
+
+#[tokio::test]
+async fn a_second_opener_of_an_embedded_store_gets_a_named_lock_error() {
+    let dir = TempDir::new().expect("temp dir");
+    let held = GraphMemory::open_embedded(dir.path())
+        .await
+        .expect("first open owns the store");
+
+    let Err(err) = GraphMemory::open_embedded(dir.path()).await else {
+        panic!("a second opener must be refused while the store is held");
+    };
+    assert!(
+        matches!(err, GraphError::Locked(_)),
+        "expected GraphError::Locked, got {err:?} — SurrealKV's lock message \
+         probably changed, and store::is_lock_error no longer recognizes it"
+    );
+    assert!(
+        err.to_string().contains("locked by another process"),
+        "{err}"
+    );
+
+    drop(held);
+}
+
+/// Once the owner lets go, the store is openable again — the retry loop in
+/// `store::open` is waiting for exactly this.
+#[tokio::test]
+async fn the_store_reopens_after_the_owner_drops_it() {
+    let dir = TempDir::new().expect("temp dir");
+    let held = store::open(dir.path()).await.expect("first open");
+    drop(held);
+
+    store::open(dir.path()).await.expect("reopen after release");
+}

--- a/tests/query_golden.rs
+++ b/tests/query_golden.rs
@@ -1,0 +1,714 @@
+//! Golden-set integration tests for the hybrid recall path (`src/graph/query.rs`).
+//!
+//! The hybrid path is: semantic KNN (`limit * 2` candidates) → 1-hop expansion
+//! from the top 3 candidates scored `parent_score * effective_confidence` →
+//! merge/dedup → sort → truncate. This file pins the behaviors that Phase 2
+//! retrieval work must not silently change: recall@k membership, confidence
+//! weighting (including read-time decay and the `< 0.1` edge drop), scoring
+//! weight sensitivity, and expansion depth.
+//!
+//! These tests drive the graph layer one level below `GraphMemory` (raw
+//! `Surreal<Db>` + `query::query`) for two reasons the higher-level API cannot
+//! serve: scoring weights must be varied per call (`GraphMemory` binds them at
+//! open time from `.recall-echo.toml`), and edges must be backdated to exercise
+//! temporal decay.
+//!
+//! Semantic contrasts in the fixture are deliberately coarse (systems
+//! programming vs bread baking vs offshore sailing) so assertions survive
+//! embedding-model churn.
+
+use std::collections::BTreeSet;
+use std::path::Path;
+use std::sync::OnceLock;
+
+use recall_echo::config::GraphScoringConfig;
+use recall_echo::graph::embed::FastEmbedder;
+use recall_echo::graph::store::{self, Db};
+use recall_echo::graph::types::{
+    EntityType, MatchSource, NewEntity, NewEpisode, NewRelationship, QueryOptions, QueryResult,
+    ScoredEntity,
+};
+use recall_echo::graph::{crud, query};
+use surrealdb::Surreal;
+use tempfile::TempDir;
+
+// ── Entity names under assertion ─────────────────────────────────────
+
+const BORROW_CHECKER: &str = "Borrow Checker";
+const OWNERSHIP_MODEL: &str = "Ownership Model";
+const CARGO: &str = "Cargo";
+
+const SOURDOUGH_STARTER: &str = "Sourdough Starter";
+const BULK_FERMENTATION: &str = "Bulk Fermentation";
+const DUTCH_OVEN: &str = "Dutch Oven";
+
+const CELESTIAL_NAVIGATION: &str = "Celestial Navigation";
+const SPINNAKER: &str = "Spinnaker";
+
+/// Neighbor of [`BORROW_CHECKER`] via a fresh, high-confidence edge.
+const INES: &str = "Ines Marchetti";
+/// Neighbor of [`BORROW_CHECKER`] via a two-year-old, low-confidence edge.
+const OTTO: &str = "Otto Brenner";
+/// Neighbor of [`BORROW_CHECKER`] via a high-confidence but half-year-old edge.
+const LUCIA: &str = "Lucia Fontana";
+/// Two hops from [`BORROW_CHECKER`] (via [`INES`]).
+const ESTUDIO: &str = "Estudio Marchetti";
+/// Unconnected person — never reachable by expansion.
+const PRIYA: &str = "Priya Raghavan";
+const MIREIA: &str = "Mireia Costa";
+
+/// High similarity to [`SENSOR_QUERY`], utility pinned to 0.0.
+const KALMAN_FILTER: &str = "Kalman Filter";
+/// Low similarity to every fixture query, utility pinned to 1.0.
+const MUNICIPAL_BONDS: &str = "Municipal Bond Yields";
+
+const RUST_QUERY: &str = "Rust borrow checker ownership and lifetimes";
+const BAKING_QUERY: &str = "sourdough starter and bulk fermentation for artisan bread";
+const SENSOR_QUERY: &str = "Kalman filter sensor fusion state estimation";
+
+// ── Fixture ──────────────────────────────────────────────────────────
+
+/// One process-wide embedder. The ONNX model is downloaded and loaded once per
+/// test-binary run; `CARGO_TARGET_TMPDIR` keeps the cache out of the per-test
+/// temp dirs so re-runs are offline.
+fn embedder() -> &'static FastEmbedder {
+    static EMBEDDER: OnceLock<FastEmbedder> = OnceLock::new();
+    EMBEDDER.get_or_init(|| {
+        let cache_dir = Path::new(env!("CARGO_TARGET_TMPDIR")).join("fastembed-cache");
+        std::fs::create_dir_all(&cache_dir).expect("failed to create embedder cache dir");
+        FastEmbedder::new(&cache_dir).expect("failed to initialize embedder")
+    })
+}
+
+/// A freshly seeded golden graph in its own temp dir.
+///
+/// Each test gets its own store: semantic search mutates `access_count`, which
+/// feeds the hotness term, so a shared store would leak scoring state between
+/// tests.
+struct GoldenGraph {
+    db: Surreal<Db>,
+    _dir: TempDir,
+}
+
+impl GoldenGraph {
+    async fn seed() -> Self {
+        let dir = TempDir::new().expect("failed to create temp dir");
+        let graph_path = dir.path().join("graph");
+        std::fs::create_dir_all(&graph_path).expect("failed to create graph dir");
+
+        let db = store::open(&graph_path)
+            .await
+            .expect("failed to open store");
+        store::init_schema(&db)
+            .await
+            .expect("failed to init schema");
+
+        let graph = Self { db, _dir: dir };
+        graph.seed_entities().await;
+        graph.seed_relationships().await;
+        graph.seed_episodes().await;
+        graph
+    }
+
+    async fn seed_entities(&self) {
+        let entities = [
+            (
+                BORROW_CHECKER,
+                EntityType::Concept,
+                "The Rust borrow checker enforces ownership and lifetime rules at compile time, \
+                 rejecting programs that alias or free memory unsafely.",
+            ),
+            (
+                OWNERSHIP_MODEL,
+                EntityType::Concept,
+                "Rust ownership and move semantics decide when a value is dropped and its heap \
+                 memory is released.",
+            ),
+            (
+                CARGO,
+                EntityType::Tool,
+                "Cargo is the Rust build system and package manager that resolves crate \
+                 dependencies and runs the compiler.",
+            ),
+            (
+                SOURDOUGH_STARTER,
+                EntityType::Concept,
+                "A sourdough starter is a living culture of wild yeast and lactobacilli kept \
+                 alive by regular flour and water refreshments to leaven bread.",
+            ),
+            (
+                BULK_FERMENTATION,
+                EntityType::Concept,
+                "Bulk fermentation is the long first rise of bread dough after the levain is \
+                 mixed in, before the loaves are shaped.",
+            ),
+            (
+                DUTCH_OVEN,
+                EntityType::Tool,
+                "A cast iron dutch oven traps steam so an artisan loaf bakes with an open crumb \
+                 and a blistered crust.",
+            ),
+            (
+                CELESTIAL_NAVIGATION,
+                EntityType::Concept,
+                "Sailors fix their position offshore with a sextant, a nautical almanac and star \
+                 sights taken at dawn.",
+            ),
+            (
+                SPINNAKER,
+                EntityType::Tool,
+                "A spinnaker is the large downwind sail flown from the bow of a racing yacht.",
+            ),
+            (
+                INES,
+                EntityType::Person,
+                "Trail runner and amateur luthier who restores nineteenth century parlour \
+                 guitars in Lisbon.",
+            ),
+            (
+                OTTO,
+                EntityType::Person,
+                "Retired ferry captain who collects nautical charts of the Baltic coast.",
+            ),
+            (
+                LUCIA,
+                EntityType::Person,
+                "Watercolour painter who teaches botanical illustration classes in Bologna.",
+            ),
+            (
+                ESTUDIO,
+                EntityType::Project,
+                "A workshop in Alfama that rebuilds soundboards and necks for parlour guitars.",
+            ),
+            (
+                PRIYA,
+                EntityType::Person,
+                "Marine biologist studying coral bleaching on Red Sea reefs.",
+            ),
+            (
+                MIREIA,
+                EntityType::Person,
+                "Baker who runs a wood fired bakery in Girona and teaches weekend bread courses.",
+            ),
+            (
+                KALMAN_FILTER,
+                EntityType::Concept,
+                "The Kalman filter fuses noisy sensor measurements into a smoothed state estimate \
+                 for a moving vehicle.",
+            ),
+            (
+                MUNICIPAL_BONDS,
+                EntityType::Concept,
+                "Municipal bond yields slipped after the treasury auction repriced ten year notes.",
+            ),
+        ];
+
+        for (name, entity_type, abstract_text) in entities {
+            crud::add_entity(
+                &self.db,
+                embedder(),
+                NewEntity {
+                    name: name.to_string(),
+                    entity_type,
+                    abstract_text: abstract_text.to_string(),
+                    overview: None,
+                    content: None,
+                    attributes: None,
+                    source: Some("golden".to_string()),
+                },
+            )
+            .await
+            .unwrap_or_else(|e| panic!("failed to seed entity {name}: {e}"));
+        }
+    }
+
+    async fn seed_relationships(&self) {
+        // Fresh, high-confidence edge — effective confidence stays ~0.95.
+        self.relate(BORROW_CHECKER, INES, "MAINTAINED_BY", 0.95)
+            .await;
+
+        // Two years old and weak: 0.30 × 0.5^(730/90) hits the decay floor
+        // (0.05) and must be dropped by the `< 0.1` filter.
+        let stale = self
+            .relate(BORROW_CHECKER, OTTO, "DOCUMENTED_BY", 0.30)
+            .await;
+        self.age_edge(&stale, 730).await;
+
+        // Half a year old, never reinforced: 0.90 × 0.5^(180/90) ≈ 0.225 —
+        // survives the filter but is heavily discounted.
+        let aging = self
+            .relate(BORROW_CHECKER, LUCIA, "REVIEWED_BY", 0.90)
+            .await;
+        self.age_unreinforced_edge(&aging, 180).await;
+
+        // Second hop out of INES — must never surface from a query anchored on
+        // BORROW_CHECKER, because expansion is one hop.
+        self.relate(INES, ESTUDIO, "FOUNDED", 1.0).await;
+
+        self.relate(OWNERSHIP_MODEL, BORROW_CHECKER, "RELATED_TO", 1.0)
+            .await;
+        self.relate(SOURDOUGH_STARTER, MIREIA, "MAINTAINED_BY", 0.95)
+            .await;
+        self.relate(BULK_FERMENTATION, SOURDOUGH_STARTER, "REQUIRES", 1.0)
+            .await;
+        self.relate(DUTCH_OVEN, MIREIA, "USED_BY", 0.80).await;
+        self.relate(CELESTIAL_NAVIGATION, OTTO, "PRACTICED_BY", 0.90)
+            .await;
+    }
+
+    async fn seed_episodes(&self) {
+        let episodes = [
+            (
+                "s-rust",
+                "Debugged a lifetime error where a mutable borrow outlived the struct it pointed \
+                 at.",
+            ),
+            (
+                "s-bake",
+                "Refreshed the sourdough starter twice and shortened bulk fermentation because \
+                 the kitchen was warm.",
+            ),
+            (
+                "s-sail",
+                "Practised sextant sights at dawn and compared the fix against the chart plotter.",
+            ),
+        ];
+
+        for (session_id, abstract_text) in episodes {
+            crud::add_episode(
+                &self.db,
+                embedder(),
+                NewEpisode {
+                    session_id: session_id.to_string(),
+                    abstract_text: abstract_text.to_string(),
+                    overview: None,
+                    content: None,
+                    log_number: None,
+                },
+            )
+            .await
+            .unwrap_or_else(|e| panic!("failed to seed episode {session_id}: {e}"));
+        }
+    }
+
+    /// Create an edge and return its record id.
+    async fn relate(&self, from: &str, to: &str, rel_type: &str, confidence: f32) -> String {
+        crud::add_relationship(
+            &self.db,
+            NewRelationship {
+                from_entity: from.to_string(),
+                to_entity: to.to_string(),
+                rel_type: rel_type.to_string(),
+                description: None,
+                confidence: Some(confidence),
+                source: Some("golden".to_string()),
+            },
+        )
+        .await
+        .unwrap_or_else(|e| panic!("failed to relate {from} -> {to}: {e}"))
+        .id_string()
+    }
+
+    /// Backdate an edge that was reinforced when it was created.
+    async fn age_edge(&self, rel_id: &str, days: u32) {
+        self.db
+            .query(
+                "UPDATE type::record($id) SET
+                     valid_from = time::now() - type::duration($age),
+                     last_reinforced = time::now() - type::duration($age)",
+            )
+            .bind(("id", rel_id.to_string()))
+            .bind(("age", format!("{days}d")))
+            .await
+            .and_then(surrealdb::IndexedResults::check)
+            .unwrap_or_else(|e| panic!("failed to age edge {rel_id}: {e}"));
+    }
+
+    /// Backdate an edge that was never reinforced — decay anchors on `valid_from`.
+    async fn age_unreinforced_edge(&self, rel_id: &str, days: u32) {
+        self.db
+            .query(
+                "UPDATE type::record($id) SET
+                     valid_from = time::now() - type::duration($age),
+                     last_reinforced = NONE",
+            )
+            .bind(("id", rel_id.to_string()))
+            .bind(("age", format!("{days}d")))
+            .await
+            .and_then(surrealdb::IndexedResults::check)
+            .unwrap_or_else(|e| panic!("failed to age edge {rel_id}: {e}"));
+    }
+
+    async fn set_utility(&self, name: &str, utility: f64) {
+        self.db
+            .query("UPDATE entity SET utility_score = $utility WHERE name = $name")
+            .bind(("name", name.to_string()))
+            .bind(("utility", utility))
+            .await
+            .and_then(surrealdb::IndexedResults::check)
+            .unwrap_or_else(|e| panic!("failed to set utility for {name}: {e}"));
+    }
+
+    /// Run the hybrid query with default scoring weights.
+    async fn query(&self, text: &str, options: &QueryOptions) -> QueryResult {
+        self.query_scored(text, options, &GraphScoringConfig::default())
+            .await
+    }
+
+    async fn query_scored(
+        &self,
+        text: &str,
+        options: &QueryOptions,
+        scoring: &GraphScoringConfig,
+    ) -> QueryResult {
+        query::query(&self.db, embedder(), scoring, text, options)
+            .await
+            .unwrap_or_else(|e| panic!("query {text:?} failed: {e}"))
+    }
+}
+
+// ── Assertion helpers ────────────────────────────────────────────────
+
+fn names(results: &[ScoredEntity]) -> Vec<&str> {
+    results.iter().map(|r| r.entity.name.as_str()).collect()
+}
+
+fn name_set(results: &[ScoredEntity]) -> BTreeSet<&str> {
+    results.iter().map(|r| r.entity.name.as_str()).collect()
+}
+
+fn find<'a>(results: &'a [ScoredEntity], name: &str) -> Option<&'a ScoredEntity> {
+    results.iter().find(|r| r.entity.name == name)
+}
+
+/// Rank of `name`, or [`usize::MAX`] when it did not survive truncation.
+/// Lets rank comparisons stay meaningful when one side is ranked off the list.
+fn rank(results: &[ScoredEntity], name: &str) -> usize {
+    results
+        .iter()
+        .position(|r| r.entity.name == name)
+        .unwrap_or(usize::MAX)
+}
+
+fn graph_sourced(results: &[ScoredEntity]) -> BTreeSet<&str> {
+    results
+        .iter()
+        .filter(|r| matches!(r.source, MatchSource::Graph { .. }))
+        .map(|r| r.entity.name.as_str())
+        .collect()
+}
+
+fn assert_close(actual: f64, expected: f64, tolerance: f64, what: &str) {
+    assert!(
+        (actual - expected).abs() < tolerance,
+        "{what}: expected {expected} ± {tolerance}, got {actual}"
+    );
+}
+
+fn semantic_only() -> GraphScoringConfig {
+    GraphScoringConfig {
+        weight_semantic: 1.0,
+        weight_hotness: 0.0,
+        weight_utility: 0.0,
+    }
+}
+
+fn utility_only() -> GraphScoringConfig {
+    GraphScoringConfig {
+        weight_semantic: 0.0,
+        weight_hotness: 0.0,
+        weight_utility: 1.0,
+    }
+}
+
+/// A query anchored on exactly one semantic hit.
+///
+/// The keyword `"borrow checker"` matches a single entity's name/abstract, so
+/// the semantic phase yields one candidate and **every other result must have
+/// arrived through 1-hop graph expansion** — the keyword filter is applied in
+/// the semantic phase only, never to expanded neighbors. With no truncation
+/// pressure, the expansion ordering is visible in full.
+fn borrow_checker_anchor() -> QueryOptions {
+    QueryOptions {
+        limit: 5,
+        graph_depth: 1,
+        keyword: Some("borrow checker".to_string()),
+        ..Default::default()
+    }
+}
+
+// ── Golden set ───────────────────────────────────────────────────────
+
+/// recall@k: a query whose relevant set is unambiguous by construction (the
+/// three baking entities) must return exactly that set as its top 3, ahead of
+/// every systems-programming, sailing and finance entity in the graph.
+#[tokio::test]
+async fn golden_query_recall_at_k_ordering() {
+    let graph = GoldenGraph::seed().await;
+    let options = QueryOptions {
+        limit: 5,
+        graph_depth: 1,
+        ..Default::default()
+    };
+
+    let result = graph.query(BAKING_QUERY, &options).await;
+    let ranked = names(&result.entities);
+
+    assert_eq!(ranked.len(), 5, "limit honored: {ranked:?}");
+    let top3: BTreeSet<&str> = ranked[..3].iter().copied().collect();
+    let expected: BTreeSet<&str> = [SOURDOUGH_STARTER, BULK_FERMENTATION, DUTCH_OVEN]
+        .into_iter()
+        .collect();
+    assert_eq!(top3, expected, "recall@3 for {BAKING_QUERY:?}: {ranked:?}");
+}
+
+/// Confidence weighting: neighbors reached over a fresh high-confidence edge
+/// outrank neighbors reached over an old one, and the graph score is exactly
+/// `parent_score * effective_confidence` — decay included.
+#[tokio::test]
+async fn golden_query_confidence_weighting_orders_neighbors() {
+    let graph = GoldenGraph::seed().await;
+    let result = graph.query(RUST_QUERY, &borrow_checker_anchor()).await;
+    let ranked = names(&result.entities);
+
+    let parent = find(&result.entities, BORROW_CHECKER)
+        .unwrap_or_else(|| panic!("anchor missing: {ranked:?}"))
+        .score;
+    let fresh = find(&result.entities, INES)
+        .unwrap_or_else(|| panic!("fresh-edge neighbor missing: {ranked:?}"))
+        .score;
+    let decayed = find(&result.entities, LUCIA)
+        .unwrap_or_else(|| panic!("decayed-edge neighbor missing: {ranked:?}"))
+        .score;
+
+    // 0.95, reinforced at creation — no decay yet.
+    assert_close(fresh / parent, 0.95, 1e-6, "fresh edge multiplier");
+    // 0.90 stored, never reinforced, 180 days old: 0.90 x 0.5^(180/90).
+    assert_close(decayed / parent, 0.225, 1e-3, "decayed edge multiplier");
+
+    assert!(
+        rank(&result.entities, INES) < rank(&result.entities, LUCIA),
+        "fresh high-confidence neighbor must outrank the decayed one: {ranked:?}"
+    );
+}
+
+/// Confidence weighting: an edge whose effective confidence has decayed below
+/// `0.1` contributes nothing — its target is not reachable by expansion at all.
+#[tokio::test]
+async fn golden_query_confidence_weighting_drops_dead_edges() {
+    let graph = GoldenGraph::seed().await;
+    let result = graph.query(RUST_QUERY, &borrow_checker_anchor()).await;
+    let ranked = names(&result.entities);
+
+    assert!(
+        find(&result.entities, INES).is_some(),
+        "expansion did not run — the rest of this test would pass vacuously: {ranked:?}"
+    );
+    // 0.30 stored, 730 days old: decays to the 0.05 floor, below the 0.1 cutoff.
+    assert!(
+        find(&result.entities, OTTO).is_none(),
+        "target of a sub-0.1 effective-confidence edge must be dropped: {ranked:?}"
+    );
+}
+
+/// Scoring weights are live: the same graph and the same query produce a rank
+/// flip when the weight vector moves from similarity-only to utility-only.
+#[tokio::test]
+async fn golden_query_scoring_weights_flip_rank() {
+    let graph = GoldenGraph::seed().await;
+    graph.set_utility(KALMAN_FILTER, 0.0).await;
+    graph.set_utility(MUNICIPAL_BONDS, 1.0).await;
+
+    let options = QueryOptions {
+        limit: 10,
+        graph_depth: 0,
+        ..Default::default()
+    };
+
+    let by_similarity = graph
+        .query_scored(SENSOR_QUERY, &options, &semantic_only())
+        .await
+        .entities;
+    assert_eq!(
+        names(&by_similarity).first().copied(),
+        Some(KALMAN_FILTER),
+        "similarity-only must rank the on-topic entity first: {:?}",
+        names(&by_similarity)
+    );
+    assert!(
+        rank(&by_similarity, KALMAN_FILTER) < rank(&by_similarity, MUNICIPAL_BONDS),
+        "similarity-only ordering: {:?}",
+        names(&by_similarity)
+    );
+
+    let by_utility = graph
+        .query_scored(SENSOR_QUERY, &options, &utility_only())
+        .await
+        .entities;
+    assert_eq!(
+        names(&by_utility).first().copied(),
+        Some(MUNICIPAL_BONDS),
+        "utility-only must rank the high-utility entity first: {:?}",
+        names(&by_utility)
+    );
+    assert!(
+        rank(&by_utility, MUNICIPAL_BONDS) < rank(&by_utility, KALMAN_FILTER),
+        "utility-only ordering: {:?}",
+        names(&by_utility)
+    );
+}
+
+/// Expansion reaches every 1-hop neighbor of a semantic hit — in both edge
+/// directions — and stops there: no 2-hop entity and no unconnected entity is
+/// pulled in.
+#[tokio::test]
+async fn golden_query_expansion_pulls_one_hop_neighbors() {
+    let graph = GoldenGraph::seed().await;
+    let result = graph.query(RUST_QUERY, &borrow_checker_anchor()).await;
+    let ranked = names(&result.entities);
+
+    let expected: BTreeSet<&str> = [OWNERSHIP_MODEL, INES, LUCIA].into_iter().collect();
+    assert_eq!(
+        graph_sourced(&result.entities),
+        expected,
+        "1-hop neighborhood of {BORROW_CHECKER}: {ranked:?}"
+    );
+
+    // OWNERSHIP_MODEL is reached over an incoming edge — traversal is undirected.
+    let incoming = find(&result.entities, OWNERSHIP_MODEL).expect("incoming neighbor missing");
+    assert!(
+        matches!(&incoming.source, MatchSource::Graph { parent, rel_type }
+            if parent == BORROW_CHECKER && rel_type == "RELATED_TO"),
+        "incoming edge provenance: {:?}",
+        incoming.source
+    );
+
+    assert!(
+        find(&result.entities, ESTUDIO).is_none(),
+        "2-hop entity must not be expanded into: {ranked:?}"
+    );
+    assert!(
+        find(&result.entities, PRIYA).is_none(),
+        "unconnected entity must not appear: {ranked:?}"
+    );
+}
+
+/// `graph_depth = 0` turns the hybrid query into pure semantic search.
+#[tokio::test]
+async fn golden_query_graph_depth_zero_disables_expansion() {
+    let graph = GoldenGraph::seed().await;
+    let options = QueryOptions {
+        graph_depth: 0,
+        ..borrow_checker_anchor()
+    };
+
+    let result = graph.query(RUST_QUERY, &options).await;
+
+    assert_eq!(names(&result.entities), vec![BORROW_CHECKER]);
+    assert!(
+        graph_sourced(&result.entities).is_empty(),
+        "no expansion at depth 0"
+    );
+}
+
+/// `graph_depth` is currently a switch, not a depth: any value above zero
+/// expands exactly one hop. Pinned so a real multi-hop implementation has to
+/// change this test deliberately.
+#[tokio::test]
+async fn golden_query_graph_depth_above_one_is_still_one_hop() {
+    let graph = GoldenGraph::seed().await;
+    let one_hop = graph.query(RUST_QUERY, &borrow_checker_anchor()).await;
+    let deep = graph
+        .query(
+            RUST_QUERY,
+            &QueryOptions {
+                graph_depth: 5,
+                ..borrow_checker_anchor()
+            },
+        )
+        .await;
+
+    assert_eq!(
+        name_set(&deep.entities),
+        name_set(&one_hop.entities),
+        "depth 5 returned a different set than depth 1"
+    );
+    assert!(
+        find(&deep.entities, ESTUDIO).is_none(),
+        "depth 5 must still not reach the 2-hop entity: {:?}",
+        names(&deep.entities)
+    );
+}
+
+/// The entity-type filter is applied to graph-expanded neighbors too, not only
+/// to semantic hits.
+#[tokio::test]
+async fn golden_query_entity_type_filter_applies_to_expanded_neighbors() {
+    let graph = GoldenGraph::seed().await;
+    let options = QueryOptions {
+        entity_type: Some("concept".to_string()),
+        ..borrow_checker_anchor()
+    };
+
+    let result = graph.query(RUST_QUERY, &options).await;
+    let ranked = names(&result.entities);
+
+    assert!(
+        result
+            .entities
+            .iter()
+            .all(|r| r.entity.entity_type == EntityType::Concept),
+        "type filter leaked: {ranked:?}"
+    );
+    assert_eq!(
+        name_set(&result.entities),
+        [BORROW_CHECKER, OWNERSHIP_MODEL].into_iter().collect(),
+        "concept-typed 1-hop neighborhood: {ranked:?}"
+    );
+}
+
+/// Episode search is opt-in and ranks by its own semantic similarity.
+#[tokio::test]
+async fn golden_query_episodes_are_opt_in() {
+    let graph = GoldenGraph::seed().await;
+    let options = QueryOptions {
+        limit: 5,
+        ..Default::default()
+    };
+
+    let without = graph.query(BAKING_QUERY, &options).await;
+    assert!(
+        without.episodes.is_empty(),
+        "episodes must not be searched unless requested"
+    );
+
+    let with = graph
+        .query(
+            BAKING_QUERY,
+            &QueryOptions {
+                include_episodes: true,
+                ..options
+            },
+        )
+        .await;
+    let sessions: Vec<&str> = with
+        .episodes
+        .iter()
+        .map(|e| e.episode.session_id.as_str())
+        .collect();
+    assert_eq!(sessions.first().copied(), Some("s-bake"), "{sessions:?}");
+}
+
+/// `limit = 0` is not "no results" — it means the documented default of 10.
+#[tokio::test]
+async fn golden_query_zero_limit_defaults_to_ten() {
+    let graph = GoldenGraph::seed().await;
+    let options = QueryOptions {
+        limit: 0,
+        ..Default::default()
+    };
+
+    let result = graph.query(RUST_QUERY, &options).await;
+
+    assert_eq!(result.entities.len(), 10, "{:?}", names(&result.entities));
+}

--- a/tests/serve_client.rs
+++ b/tests/serve_client.rs
@@ -1,0 +1,320 @@
+//! Client ↔ daemon integration: auto-start, stale sockets, spawn races,
+//! version mismatch, and named failures.
+//!
+//! These tests start real daemons against throwaway temp directories. They
+//! only use operations that never embed (status, hello), so nothing here
+//! touches the network.
+
+use std::path::PathBuf;
+use std::sync::Once;
+use std::time::Duration;
+
+use recall_echo::error::RecallError;
+use recall_echo::serve::{DaemonInfo, Request, Response};
+use recall_echo::serve_client;
+use tempfile::TempDir;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+
+static BIN_ENV: Once = Once::new();
+
+/// Point the client at the binary cargo just built, instead of the test
+/// harness executable that `current_exe()` would return.
+fn use_test_binary() {
+    BIN_ENV.call_once(|| {
+        std::env::set_var(
+            serve_client::DAEMON_BIN_ENV,
+            env!("CARGO_BIN_EXE_recall-echo"),
+        );
+    });
+}
+
+struct Fixture {
+    _dir: TempDir,
+    entity_root: PathBuf,
+    memory_dir: PathBuf,
+    socket: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        Self::with_config("")
+    }
+
+    /// A memory directory with its own socket, plus optional extra config.
+    fn with_config(extra: &str) -> Self {
+        use_test_binary();
+
+        let dir = TempDir::new().expect("temp dir");
+        let entity_root = dir.path().join("e");
+        let memory_dir = entity_root.join("memory");
+        std::fs::create_dir_all(memory_dir.join("graph")).expect("memory dir");
+
+        let socket = dir.path().join("g.sock");
+        std::fs::write(
+            memory_dir.join(".recall-echo.toml"),
+            format!(
+                "[serve]\nsocket_path = \"{}\"\nidle_timeout_secs = 120\n{extra}",
+                socket.display()
+            ),
+        )
+        .expect("write config");
+
+        Self {
+            _dir: dir,
+            entity_root,
+            memory_dir,
+            socket,
+        }
+    }
+
+    async fn status(&self) -> Result<serde_json::Value, RecallError> {
+        serve_client::execute(&self.memory_dir, &Request::Status).await
+    }
+
+    async fn info(&self) -> Option<DaemonInfo> {
+        serve_client::daemon_info(&self.memory_dir).await.unwrap()
+    }
+
+    /// Stop the daemon, asserting the request was actually honored.
+    async fn stop(&self) {
+        serve_client::stop_daemon(&self.memory_dir)
+            .await
+            .expect("daemon stops when asked");
+    }
+
+    /// Run `recall-echo graph <args>` against this fixture's entity root.
+    fn graph_cli(&self, args: &[&str]) -> std::process::Child {
+        std::process::Command::new(env!("CARGO_BIN_EXE_recall-echo"))
+            .arg("graph")
+            .arg("--entity-root")
+            .arg(&self.entity_root)
+            .args(args)
+            .env(
+                serve_client::DAEMON_BIN_ENV,
+                env!("CARGO_BIN_EXE_recall-echo"),
+            )
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
+            .spawn()
+            .expect("spawn recall-echo")
+    }
+}
+
+#[tokio::test]
+async fn first_request_starts_a_daemon_and_completes() {
+    let fixture = Fixture::new();
+    assert!(fixture.info().await.is_none(), "no daemon before first use");
+
+    let stats = fixture.status().await.expect("status through daemon");
+    assert_eq!(stats["entity_count"], 0);
+    assert_eq!(stats["episode_count"], 0);
+
+    let info = fixture.info().await.expect("daemon running");
+    assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+    assert!(info.pid > 0);
+    assert!(fixture.socket.exists());
+
+    fixture.stop().await;
+    assert!(fixture.info().await.is_none(), "daemon stopped");
+}
+
+#[tokio::test]
+async fn shutdown_request_stops_the_daemon_promptly() {
+    let fixture = Fixture::new();
+    fixture.status().await.expect("start the daemon");
+
+    let started = std::time::Instant::now();
+    assert!(
+        serve_client::stop_daemon(&fixture.memory_dir)
+            .await
+            .expect("stop succeeds"),
+        "a daemon was running"
+    );
+
+    // Regression: a lost shutdown wakeup left the daemon alive until its idle
+    // timeout, and the client waited out the full stop timeout.
+    assert!(
+        started.elapsed() < Duration::from_secs(5),
+        "stopping took {:?}",
+        started.elapsed()
+    );
+    assert!(!fixture.socket.exists(), "socket cleaned up on exit");
+}
+
+#[tokio::test]
+async fn concurrent_spawn_race_has_a_single_winner() {
+    let fixture = Fixture::new();
+
+    let (a, b, c, d) = tokio::join!(
+        fixture.status(),
+        fixture.status(),
+        fixture.status(),
+        fixture.status()
+    );
+    for result in [a, b, c, d] {
+        result.expect("every racing client completes");
+    }
+
+    let info = fixture.info().await.expect("exactly one daemon survived");
+    assert!(info.uptime_secs < 120);
+
+    fixture.stop().await;
+}
+
+#[tokio::test]
+async fn client_cleans_stale_socket_and_respawns() {
+    let fixture = Fixture::new();
+
+    // A socket file with nobody listening — what a crashed daemon leaves behind.
+    let listener = std::os::unix::net::UnixListener::bind(&fixture.socket).expect("bind");
+    drop(listener);
+    assert!(fixture.socket.exists());
+
+    fixture.status().await.expect("stale socket is cleaned up");
+    assert!(fixture.info().await.is_some(), "fresh daemon took over");
+
+    fixture.stop().await;
+}
+
+#[tokio::test]
+async fn killed_daemon_is_replaced_on_the_next_request() {
+    let fixture = Fixture::new();
+    fixture.status().await.expect("first status");
+    let first = fixture.info().await.expect("daemon running");
+
+    let killed = std::process::Command::new("kill")
+        .args(["-9", &first.pid.to_string()])
+        .status()
+        .expect("kill");
+    assert!(killed.success());
+    wait_until_gone(&fixture.socket).await;
+
+    fixture.status().await.expect("status after kill -9");
+    let second = fixture.info().await.expect("replacement daemon");
+    assert_ne!(first.pid, second.pid);
+
+    fixture.stop().await;
+}
+
+#[tokio::test]
+async fn version_mismatch_replaces_the_running_daemon() {
+    let fixture = Fixture::new();
+    let socket = fixture.socket.clone();
+
+    // A daemon from an older build: answers Hello with a foreign version and
+    // exits when asked to shut down.
+    let listener = tokio::net::UnixListener::bind(&socket).expect("bind mock");
+    let mock_socket = socket.clone();
+    let mock = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept");
+        let (reader, mut writer) = stream.into_split();
+        let mut lines = BufReader::new(reader).lines();
+
+        while let Ok(Some(line)) = lines.next_line().await {
+            let request: Request = serde_json::from_str(&line).expect("parse request");
+            let response = match request {
+                Request::Hello => Response::success(serde_json::json!({
+                    "version": "0.0.0-ancient",
+                    "pid": 1,
+                    "memory_dir": "",
+                    "socket_path": "",
+                    "uptime_secs": 1,
+                })),
+                _ => Response::success(serde_json::json!({ "stopping": true })),
+            };
+            let mut bytes = serde_json::to_vec(&response).unwrap();
+            bytes.push(b'\n');
+            writer.write_all(&bytes).await.unwrap();
+            writer.flush().await.unwrap();
+            if !matches!(request, Request::Hello) {
+                break;
+            }
+        }
+        drop(listener);
+        let _ = std::fs::remove_file(&mock_socket);
+    });
+
+    let stats = fixture.status().await.expect("status after version swap");
+    assert_eq!(stats["entity_count"], 0);
+
+    let info = fixture
+        .info()
+        .await
+        .expect("current-version daemon running");
+    assert_eq!(info.version, env!("CARGO_PKG_VERSION"));
+
+    mock.await.expect("mock daemon exits");
+    fixture.stop().await;
+}
+
+#[tokio::test]
+async fn unstartable_daemon_reports_a_named_error() {
+    let dir = TempDir::new().expect("temp dir");
+    let memory_dir = dir.path().join("memory");
+    std::fs::create_dir_all(memory_dir.join("graph")).expect("memory dir");
+
+    // The socket's parent is a regular file, so the directory can never exist.
+    let blocker = dir.path().join("blocker");
+    std::fs::write(&blocker, b"x").expect("write blocker");
+    std::fs::write(
+        memory_dir.join(".recall-echo.toml"),
+        format!("[serve]\nsocket_path = \"{}/g.sock\"\n", blocker.display()),
+    )
+    .expect("write config");
+    use_test_binary();
+
+    let err = serve_client::execute(&memory_dir, &Request::Status)
+        .await
+        .expect_err("daemon cannot start");
+    assert!(matches!(err, RecallError::Daemon(_)), "{err}");
+    assert!(err.to_string().contains("socket directory"), "{err}");
+}
+
+#[tokio::test]
+async fn server_mode_bypasses_the_daemon() {
+    let fixture = Fixture::with_config("\n[graph]\nmode = \"server\"\n");
+
+    assert_eq!(serve_client::graph_mode(&fixture.memory_dir), "server");
+    assert!(
+        fixture.info().await.is_none(),
+        "server mode never consults a daemon"
+    );
+    assert!(!serve_client::stop_daemon(&fixture.memory_dir)
+        .await
+        .expect("stop is a no-op in server mode"),);
+    assert!(!fixture.socket.exists(), "no socket is created");
+}
+
+#[tokio::test]
+async fn two_concurrent_cli_invocations_share_one_daemon() {
+    let fixture = Fixture::new();
+
+    let first = fixture.graph_cli(&["status"]);
+    let second = fixture.graph_cli(&["status"]);
+
+    for child in [first, second] {
+        let output = child.wait_with_output().expect("cli finished");
+        assert!(
+            output.status.success(),
+            "concurrent `graph status` failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    assert!(
+        fixture.info().await.is_some(),
+        "one shared daemon is still serving"
+    );
+    fixture.stop().await;
+}
+
+/// Poll until nothing is listening on `socket`.
+async fn wait_until_gone(socket: &std::path::Path) {
+    for _ in 0..200 {
+        if tokio::net::UnixStream::connect(socket).await.is_err() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("socket {} still accepting connections", socket.display());
+}

--- a/tests/serve_client.rs
+++ b/tests/serve_client.rs
@@ -308,6 +308,187 @@ async fn two_concurrent_cli_invocations_share_one_daemon() {
     fixture.stop().await;
 }
 
+/// `exclusive` must actually be exclusive: the daemon that owned the store is
+/// gone for the whole operation, and the next hot operation starts a new one.
+#[tokio::test]
+async fn exclusive_takes_the_store_from_the_daemon_and_hands_it_back() {
+    let fixture = Fixture::new();
+    fixture.status().await.expect("start the daemon");
+    let before = fixture.info().await.expect("daemon running").pid;
+
+    let seen_inside = serve_client::exclusive(&fixture.memory_dir, |_graph| async {
+        // No daemon may be serving while an admin operation owns the store.
+        Ok(serve_client::daemon_info(&fixture.memory_dir)
+            .await
+            .unwrap())
+    })
+    .await
+    .expect("exclusive operation runs");
+    assert!(seen_inside.is_none(), "the daemon must be stopped");
+    assert!(!fixture.socket.exists(), "the socket is gone with it");
+
+    fixture.status().await.expect("hot op respawns the daemon");
+    let after = fixture.info().await.expect("replacement daemon").pid;
+    assert_ne!(before, after);
+
+    fixture.stop().await;
+}
+
+/// A hot operation that arrives while an admin operation owns the store waits
+/// for it instead of starting a daemon that would collide with it.
+#[tokio::test]
+async fn a_hot_operation_waits_for_a_running_admin_operation() {
+    let fixture = Fixture::new();
+
+    let memory_dir = fixture.memory_dir.clone();
+    let admin = tokio::spawn(async move {
+        serve_client::exclusive(&memory_dir, |_graph| async {
+            tokio::time::sleep(Duration::from_millis(750)).await;
+            Ok(())
+        })
+        .await
+    });
+
+    // Give the admin operation time to take the lock, then race it.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    let started = std::time::Instant::now();
+    fixture
+        .status()
+        .await
+        .expect("hot op completes after waiting");
+
+    admin.await.expect("join").expect("admin operation");
+    assert!(
+        started.elapsed() >= Duration::from_millis(400),
+        "the hot operation did not wait for the admin lock ({:?})",
+        started.elapsed()
+    );
+
+    fixture.stop().await;
+}
+
+/// A daemon that goes away between `connect` and the handshake — an idle
+/// timeout, or another process's `exclusive` — must not fail the caller. On
+/// the SessionEnd hook path that would silently lose a conversation ingest.
+#[tokio::test]
+async fn a_daemon_that_dies_mid_handshake_is_replaced() {
+    let fixture = Fixture::new();
+
+    let listener = tokio::net::UnixListener::bind(&fixture.socket).expect("bind mock");
+    let mock = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept");
+        // Closing without answering is exactly what an exiting daemon looks like.
+        drop(stream);
+        drop(listener);
+    });
+
+    let stats = fixture
+        .status()
+        .await
+        .expect("status despite the dead daemon");
+    assert_eq!(stats["entity_count"], 0);
+    assert!(fixture.info().await.is_some(), "a fresh daemon took over");
+
+    mock.await.expect("mock daemon exits");
+    fixture.stop().await;
+}
+
+/// An oversized request is rejected by code, and the daemon keeps serving.
+#[tokio::test]
+async fn an_oversized_request_is_refused_and_the_daemon_survives() {
+    let fixture = Fixture::new();
+    fixture.status().await.expect("start the daemon");
+    let before = fixture.info().await.expect("daemon running").pid;
+
+    let stream = tokio::net::UnixStream::connect(&fixture.socket)
+        .await
+        .expect("connect");
+    let (reader, mut writer) = stream.into_split();
+
+    // 9 MiB of a syntactically valid request, one MiB past the cap.
+    let opening = br#"{"op":"search","args":{"limit":1,"query":""#;
+    writer.write_all(opening).await.expect("write opening");
+    let chunk = vec![b'x'; 64 * 1024];
+    for _ in 0..(9 * 16) {
+        if writer.write_all(&chunk).await.is_err() {
+            break;
+        }
+    }
+    let _ = writer.write_all(b"\"}}\n").await;
+    let _ = writer.flush().await;
+
+    let mut response = String::new();
+    BufReader::new(reader)
+        .read_line(&mut response)
+        .await
+        .expect("read response");
+    let parsed: Response = serde_json::from_str(&response).expect("parse response");
+    assert!(!parsed.ok, "{response}");
+    assert_eq!(parsed.error.expect("error").code, "bad_request");
+
+    let after = fixture.info().await.expect("daemon still serving").pid;
+    assert_eq!(
+        before, after,
+        "the daemon must survive an oversized request"
+    );
+    fixture.status().await.expect("still answering requests");
+
+    fixture.stop().await;
+}
+
+/// The daemon socket is owner-only and only the owning uid may use it.
+#[tokio::test]
+async fn the_socket_is_owner_only() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let fixture = Fixture::new();
+    fixture.status().await.expect("start the daemon");
+
+    let mode = std::fs::metadata(&fixture.socket)
+        .expect("socket exists")
+        .permissions()
+        .mode();
+    assert_eq!(mode & 0o777, 0o600, "socket mode {mode:o}");
+
+    let pidfile = PathBuf::from(format!("{}.pid", fixture.socket.display()));
+    let mode = std::fs::metadata(&pidfile)
+        .expect("pidfile exists")
+        .permissions()
+        .mode();
+    assert_eq!(mode & 0o777, 0o600, "pidfile mode {mode:o}");
+
+    fixture.stop().await;
+}
+
+/// A `[serve] socket_path` must not make recall-echo unlink arbitrary files.
+#[tokio::test]
+async fn a_configured_socket_path_pointing_at_a_regular_file_is_refused() {
+    use_test_binary();
+
+    let dir = TempDir::new().expect("temp dir");
+    let memory_dir = dir.path().join("memory");
+    std::fs::create_dir_all(memory_dir.join("graph")).expect("memory dir");
+
+    let precious = dir.path().join("precious.toml");
+    std::fs::write(&precious, b"keep me").expect("write file");
+    std::fs::write(
+        memory_dir.join(".recall-echo.toml"),
+        format!("[serve]\nsocket_path = \"{}\"\n", precious.display()),
+    )
+    .expect("write config");
+
+    let err = serve_client::execute(&memory_dir, &Request::Status)
+        .await
+        .expect_err("daemon cannot use a regular file as its socket");
+    assert!(matches!(err, RecallError::Daemon(_)), "{err}");
+    assert!(precious.exists(), "the file must survive");
+    assert_eq!(
+        std::fs::read_to_string(&precious).unwrap(),
+        "keep me",
+        "the file must be untouched"
+    );
+}
+
 /// Poll until nothing is listening on `socket`.
 async fn wait_until_gone(socket: &std::path::Path) {
     for _ in 0..200 {


### PR DESCRIPTION
Closes the Phase 0 blockers so recall-echo can produce measured claims. RE-31 (Phase 1) is stacked on this branch.

## What's here

**Runtime backend** — embedded vs server is now a config choice (`[graph] mode`, previously a dead key) via `surrealdb::engine::any`; both backends compile in. Lock collisions became a named `GraphError::Locked` with bounded retry instead of a raw SurrealKV panic.

**Serve daemon** — every graph command and hook goes through a per-memory-dir unix-socket daemon that auto-starts on first use (no opt-in, no fallback paths, per design decision). It holds the one embedded store and the lazily-loaded embedder, idles out after `[serve] idle_timeout_secs`, and is crash-only. Admin ops take exclusive ownership via an enforced admin lock. This unblocks concurrent access — the failure that killed the benchmark pilot in June.

**LazyEmbedder** — the ONNX model loads on first embedding op, not on every graph open. Also fixed a test hang (untimeouted HuggingFace download during `init`).

**Golden retrieval tests** (`tests/query_golden.rs`) — 10 tests pinning recall@k ordering, confidence weighting, decay-floor edge exclusion, scoring-weight sensitivity and 1-hop expansion semantics, so Phase 2's retrieval work cannot silently regress them.

v3.11.1 (SessionEnd hook fix + the repo's first CI test job) shipped separately from this branch and is already on crates.io.

## Audit remediation

Three parallel auditors (quality / performance / security) reviewed the branch before this PR; 16 findings fixed in a92a64b — socket-directory hijack, peer authentication, config-driven filesystem mutation, protocol bounds, real mutual exclusion for admin ops, dead-daemon retry, and hook-path daemon reuse. Details in that commit message.

## Not here

The LongMemEval baseline report (`docs/benchmarks/baseline-2026-08.md`) lands as the final commit before merge — the run is in progress. AC4 stays open until then.

Refs #29