### PR TITLE
Phase 1: truth layer — stateful, provenance-aware confidence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,16 +19,18 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "affinitypool"
-version = "0.4.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a58b64a64aecad4ba7f2ccf0f79115f5d2d184b1e55307f78c20be07adc6633"
+checksum = "c4a46f56d354df11b6bcd8ca4f84fa03ac816cc41c72568a1b337d8f7e5af90e"
 dependencies = [
- "crossbeam",
+ "arc-swap",
+ "async-task",
+ "crossbeam-deque",
+ "crossbeam-utils",
  "libc",
  "num_cpus",
  "parking_lot",
  "thiserror",
- "tokio",
  "winapi",
 ]
 
@@ -281,6 +283,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -610,6 +618,20 @@ name = "bytemuck"
 version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+dependencies = [
+ "bytemuck_derive",
+]
+
+[[package]]
+name = "bytemuck_derive"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f65693059b6b9c588b9f62fed1cedbf0a8b805631457ea162d68f0de186f3de5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "byteorder"
@@ -744,7 +766,7 @@ version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
- "heck",
+ "heck 0.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -875,28 +897,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
-name = "crossbeam"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1137cd7e7fc0fb5d3c5a8678be38ec56e819125d8d7907411fe24ccb943faca8"
-dependencies = [
- "crossbeam-channel",
- "crossbeam-deque",
- "crossbeam-epoch",
- "crossbeam-queue",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-channel"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -911,15 +911,6 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-queue"
-version = "0.3.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1173,6 +1164,64 @@ dependencies = [
 ]
 
 [[package]]
+name = "diskann"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421c6cf955c6cb1451d36c8a3740ab2a22880265d0fa93d8ea22cbc425c90479"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "diskann-utils",
+ "diskann-vector",
+ "diskann-wide",
+ "futures-util",
+ "half",
+ "hashbrown 0.16.1",
+ "num-traits",
+ "rand 0.9.5",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
+name = "diskann-utils"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cdf7d491910fbff13338e07460c9197a3c172268cfd4d8f8e69e5cec5a256d9"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "diskann-vector",
+ "diskann-wide",
+ "half",
+ "rand 0.9.5",
+ "rand_distr",
+ "rayon",
+ "thiserror",
+]
+
+[[package]]
+name = "diskann-vector"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de1643bbece645f03527ef120bc7dd5e4e40557980dbe52ee51129adfb58a851"
+dependencies = [
+ "cfg-if",
+ "diskann-wide",
+ "half",
+]
+
+[[package]]
+name = "diskann-wide"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421f02c42e57a2153dc65b66b4b95fe2be56e14bf9f95253b663abcac8521166"
+dependencies = [
+ "cfg-if",
+ "half",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1303,12 +1352,6 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
-
-[[package]]
-name = "endian-type"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "869b0adbda23651a9c5c0c3d270aac9fcb52e8622a8f2b17e57802d7791962f2"
 
 [[package]]
 name = "equator"
@@ -1661,12 +1704,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
-name = "futures-timer"
-version = "3.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
-
-[[package]]
 name = "futures-util"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1723,25 +1760,6 @@ dependencies = [
 
 [[package]]
 name = "geo"
-version = "0.31.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc1a1678e54befc9b4bcab6cd43b8e7f834ae8ea121118b0fd8c42747675b4a"
-dependencies = [
- "earcutr",
- "float_next_after",
- "geo-types",
- "geographiclib-rs",
- "i_overlay",
- "log",
- "num-traits",
- "robust",
- "rstar 0.12.2",
- "serde",
- "spade",
-]
-
-[[package]]
-name = "geo"
 version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f3901269ec6d4f6068d3f09e5f02f995bd076398dcd1dfec407cd230b02d11b"
@@ -1763,9 +1781,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.18"
+version = "0.7.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24f8647af4005fa11da47cd56252c6ef030be8fa97bdbf355e7dfb6348f0a82c"
+checksum = "777d18aa0f12f8b285331cd867133ee14422b3f023f6d388034c47d43e28786a"
 dependencies = [
  "approx",
  "num-traits",
@@ -1773,9 +1791,11 @@ dependencies = [
  "rstar 0.10.0",
  "rstar 0.11.0",
  "rstar 0.12.2",
+ "rstar 0.13.0",
  "rstar 0.8.4",
  "rstar 0.9.3",
  "serde",
+ "thiserror",
 ]
 
 [[package]]
@@ -1838,12 +1858,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1885,8 +1899,12 @@ version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
 dependencies = [
+ "bytemuck",
  "cfg-if",
  "crunchy",
+ "num-traits",
+ "rand 0.9.5",
+ "rand_distr",
  "zerocopy",
 ]
 
@@ -1953,6 +1971,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
 name = "headers"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2013,6 +2037,12 @@ dependencies = [
 
 [[package]]
 name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
+name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2040,7 +2070,7 @@ dependencies = [
  "indicatif",
  "libc",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "reqwest",
  "serde",
  "serde_json",
@@ -2428,12 +2458,12 @@ checksum = "e7c5cedc30da3a610cac6b4ba17597bdf7152cf974e8aab3afb3d54455e371c8"
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2610,9 +2640,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -2900,15 +2930,6 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
-
-[[package]]
-name = "nibble_vec"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
-dependencies = [
- "smallvec",
-]
 
 [[package]]
 name = "noisy_float"
@@ -3712,7 +3733,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.5",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3766,17 +3787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "radix_trie"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4431027dcd37fc2a73ef740b5f233aa805897935b8bce0195e41bbf9a3289a"
-dependencies = [
- "endian-type",
- "nibble_vec",
- "serde",
-]
-
-[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3789,9 +3799,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "b9ef1d0d795eb7d84685bca4f72f3649f064e6641543d3a8c415898726a57b41"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3836,6 +3846,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8615d50dcf34fa31f7ab52692afec947c4dd0ab803cc87cb3b0b4570ff7463"
+dependencies = [
+ "num-traits",
+ "rand 0.9.5",
+]
+
+[[package]]
 name = "rav1e"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3862,7 +3882,7 @@ dependencies = [
  "num-traits",
  "paste",
  "profiling",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rand_chacha 0.9.0",
  "simd_helpers",
  "thiserror",
@@ -3893,9 +3913,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -4009,12 +4029,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
-name = "relative-path"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
-
-[[package]]
 name = "rend"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4069,13 +4083,13 @@ dependencies = [
 
 [[package]]
 name = "revision"
-version = "0.17.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11c3c8ec8b2be254beb5f8acdd80cdd57b7b5d40988c2ec3d0b7cdb6f7c2829b"
+checksum = "13b48b66c1cd4bf814516ea48f727d4b3697e3fa8841be99a7d9cbb8c9ac1666"
 dependencies = [
  "bytes",
  "chrono",
- "geo 0.31.0",
+ "geo",
  "regex",
  "revision-derive",
  "roaring",
@@ -4085,9 +4099,9 @@ dependencies = [
 
 [[package]]
 name = "revision-derive"
-version = "0.17.0"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76be63634a8b1809e663bc0b975d78f6883c0fadbcce9c52e19b9e421f423357"
+checksum = "3d266d798eaaa2921e14188dfe998bb7cc0528ec26e894b4be0e35fe2b19c89d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4174,9 +4188,9 @@ dependencies = [
 
 [[package]]
 name = "roaring"
-version = "0.11.3"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ba9ce64a8f45d7fc86358410bb1a82e8c987504c0d4900e9141d69a9f26c885"
+checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
@@ -4271,32 +4285,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "rstest"
-version = "0.26.1"
+name = "rstar"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
+checksum = "5912b862fa5ffb462607bfd1e35036c458c537921f508c8235a83d5f3987edfe"
 dependencies = [
- "futures-timer",
- "futures-util",
- "rstest_macros",
-]
-
-[[package]]
-name = "rstest_macros"
-version = "0.26.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c845311f0ff7951c5506121a9ad75aec44d083c31583b2ea5a30bcb0b0abba0"
-dependencies = [
- "cfg-if",
- "glob",
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "regex",
- "relative-path",
- "rustc_version",
- "syn 2.0.117",
- "unicode-ident",
+ "heapless 0.8.0",
+ "num-traits",
+ "serde",
+ "smallvec",
 ]
 
 [[package]]
@@ -4311,9 +4308,9 @@ dependencies = [
 
 [[package]]
 name = "rust_decimal"
-version = "1.41.0"
+version = "1.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+checksum = "be2a24f50780bc85f09cc6ac299bdf1424302742d77221106859c9d8b102126a"
 dependencies = [
  "arrayvec",
  "borsh",
@@ -4790,9 +4787,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "surrealdb"
-version = "3.0.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a96b55e86ef8653a03b6b97e771f49c954e26bcc0308160b0134d94f334fd"
+checksum = "01fef5cc04dd6cb042391d48c0f78a586c56042e999f8cb17f0b97b0a147e2c0"
 dependencies = [
  "anyhow",
  "async-channel",
@@ -4825,10 +4822,20 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-core"
-version = "3.0.5"
+name = "surrealdb-collections"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3e6a7f248c958fd5000c4fab5759503663bf93c622be10a6d7bf7d2d676b8fc"
+checksum = "ca3472955f9692427583e78476d5b03c6f750bf11dc8a04383e0d365d7bd5d99"
+dependencies = [
+ "revision",
+ "storekey",
+]
+
+[[package]]
+name = "surrealdb-core"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cd76c36f8b545a9371eec050bb2ae83750a6f60bae8c6d92d06956943348f4c"
 dependencies = [
  "addr",
  "affinitypool",
@@ -4838,7 +4845,6 @@ dependencies = [
  "argon2",
  "async-channel",
  "async-stream",
- "async-trait",
  "base64 0.22.1",
  "bcrypt",
  "blake3",
@@ -4847,15 +4853,19 @@ dependencies = [
  "ciborium",
  "dashmap",
  "deunicode",
+ "diskann",
+ "diskann-utils",
+ "diskann-vector",
  "dmp",
  "ext-sort",
  "fastnum",
  "fst",
  "futures",
  "fuzzy-matcher",
- "geo 0.32.0",
+ "geo",
  "geo-types",
  "getrandom 0.3.4",
+ "half",
  "headers",
  "hex",
  "http",
@@ -4864,6 +4874,7 @@ dependencies = [
  "jsonwebtoken",
  "lexicmp",
  "md-5",
+ "memchr",
  "mime",
  "ndarray 0.17.2",
  "ndarray-stats",
@@ -4876,8 +4887,8 @@ dependencies = [
  "phf 0.13.1",
  "pin-project-lite",
  "quick_cache",
- "radix_trie",
- "rand 0.8.5",
+ "rand 0.9.5",
+ "rand_core 0.6.4",
  "rayon",
  "reblessive",
  "regex",
@@ -4895,7 +4906,9 @@ dependencies = [
  "storekey",
  "strsim",
  "subtle",
+ "surrealdb-collections",
  "surrealdb-protocol",
+ "surrealdb-strand",
  "surrealdb-types",
  "surrealkv",
  "sysinfo",
@@ -4916,9 +4929,9 @@ dependencies = [
 
 [[package]]
 name = "surrealdb-protocol"
-version = "0.8.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb37698e0493bcfac3229ecb6ec6894a3ad705a3a2087b1562eeb881b3db19d4"
+checksum = "3f4e06f586c9179a02349b88b0c18e3a0850c55431aa513e0cd66529c00da1af"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4926,7 +4939,7 @@ dependencies = [
  "chrono",
  "flatbuffers",
  "futures",
- "geo 0.32.0",
+ "geo",
  "prost",
  "prost-types",
  "rust_decimal",
@@ -4939,37 +4952,53 @@ dependencies = [
 ]
 
 [[package]]
-name = "surrealdb-types"
-version = "3.0.5"
+name = "surrealdb-strand"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c79e71d035367b933cf528c09b7ed186bc17dea58c66a1bca84d22f9abf167db"
+checksum = "a86f53e307b6b8275b15eaff2b718add63605cb804395d156589770c3bf38e56"
+dependencies = [
+ "revision",
+ "serde",
+ "storekey",
+]
+
+[[package]]
+name = "surrealdb-types"
+version = "3.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d70c7f4dbf1198521282a171a03f2f77f38a1225a149f7c0175e758f773b8a"
 dependencies = [
  "anyhow",
+ "async-channel",
  "bytes",
+ "castaway",
  "chrono",
  "flatbuffers",
- "geo 0.32.0",
+ "geo",
  "hex",
  "http",
  "papaya",
- "rand 0.8.5",
+ "rand 0.9.5",
  "regex",
- "rstest",
  "rust_decimal",
+ "semver",
  "serde",
  "serde_json",
  "surrealdb-protocol",
  "surrealdb-types-derive",
+ "tracing",
  "ulid",
+ "url",
  "uuid",
 ]
 
 [[package]]
 name = "surrealdb-types-derive"
-version = "3.0.5"
+version = "3.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a76abdbfc597e062daae5269251e18a84553f9090cfff423591f57c8c6765aa8"
+checksum = "dc11310bfc0ae3e546cd14788f8d36e7616dbe41fa68b4b265b29fea34a7d7e1"
 dependencies = [
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -4977,9 +5006,9 @@ dependencies = [
 
 [[package]]
 name = "surrealkv"
-version = "0.21.0"
+version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "485ec2c4bbb6c0a708e1fb8c439cbc9e69d400899a8f7bde2ee56b91c0a713f3"
+checksum = "741f90582eb840b8639def097626b21a920266594f24544ff061a429124260b9"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -4996,11 +5025,12 @@ dependencies = [
  "lz4_flex",
  "parking_lot",
  "quick_cache",
- "rand 0.9.2",
+ "rand 0.9.5",
  "scopeguard",
  "sha2",
  "snap",
  "tokio",
+ "xxhash-rust",
 ]
 
 [[package]]
@@ -5019,6 +5049,17 @@ name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5102,22 +5143,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -5218,7 +5259,7 @@ dependencies = [
  "monostate",
  "onig",
  "paste",
- "rand 0.9.2",
+ "rand 0.9.5",
  "rayon",
  "rayon-cond",
  "regex",
@@ -5234,9 +5275,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "202caea871b69668250d242070849eb495be178ed697a3e98aebce5bc81a0bed"
 dependencies = [
  "bytes",
  "libc",
@@ -5544,7 +5585,7 @@ dependencies = [
  "http",
  "httparse",
  "log",
- "rand 0.9.2",
+ "rand 0.9.5",
  "sha1",
  "thiserror",
  "url",
@@ -5569,7 +5610,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
 dependencies = [
- "rand 0.9.2",
+ "rand 0.9.5",
  "serde",
  "web-time",
 ]
@@ -5688,9 +5729,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "bf3923a6f5c4c6382e0b653c4117f48d631ea17f38ed86e2a828e6f7412f5239"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -6314,7 +6355,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "wit-parser",
 ]
 
@@ -6325,7 +6366,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck",
+ "heck 0.5.0",
  "indexmap",
  "prettyplease",
  "syn 2.0.117",
@@ -6410,6 +6451,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "y4m"

--- a/README.md
+++ b/README.md
@@ -58,15 +58,17 @@ The knowledge graph is the structural foundation of recall-echo. It turns conver
 **Why Bayesian confidence.** Traditional knowledge graphs store facts as absolutes — "Dani uses NeoVim" is either true or not. But memories aren't binary. Things change, context matters, and some things are more certain than others. recall-echo uses a Beta-Binomial Bayesian confidence model on every relationship edge:
 
 - Each relationship starts with a confidence prior based on how it was established: authoritative (1.0), explicit (0.9), inferred (0.6), or speculative (0.3)
-- When new evidence corroborates a relationship, confidence increases. When evidence contradicts it, confidence decreases
-- Updates are gradual — it takes ~10 observations to overwhelm the prior, so a single contradictory mention doesn't erase established knowledge
+- Evidence is **persisted on the edge** as Beta pseudo-counts (`alpha` for corroboration, `beta` for contradiction). Corroboration adds to α, contradiction adds to β, and the stored confidence is the posterior mean `α / (α + β)`
+- Because the counts accumulate, the graph distinguishes "believed at 0.9" from "believed at 0.9 for good reason" — the posterior variance narrows as evidence builds, and a prior's initial skepticism persists rather than being recomputed away
+- Updates are gradual — a prior is worth ~10 observations, so a single contradictory mention doesn't erase established knowledge
+- **Observations are weighted by provenance.** Every episode is stamped at ingestion with who authored it, and an observation contributes evidence accordingly: an independent external source counts fully (1.0), the human nearly fully (0.8), the agent restating its own belief almost not at all (0.05, configurable via `[graph.provenance]`). Self-corroboration is also tallied separately on the edge, so coherence never passes for evidence
 - Multi-hop queries compound confidence along the path, naturally preferring shorter, higher-confidence routes
 
 This means the graph handles contradictions, reinforces patterns over time, and lets uncertain or stale knowledge fade gracefully — instead of requiring manual cleanup or producing false-positive retrievals.
 
 **Entity types:** person, project, tool, service, preference, decision, event, concept, case, pattern, thread, thought, question, observation, policy, measurement, outcome. Mutable types (person, project, tool, etc.) can be updated; immutable types (decision, event, case, etc.) are append-only.
 
-**Extraction pipeline:** When conversations are archived, an LLM-powered pipeline chunks the text (~500 tokens), extracts entities and relationships in parallel (up to 10 concurrent), then deduplicates sequentially with LLM-assisted skip/create/merge decisions. Re-extracted relationships receive Bayesian corroboration updates, so knowledge confirmed across multiple conversations gains confidence automatically.
+**Extraction pipeline:** When conversations are archived, an LLM-powered pipeline chunks the text (~500 tokens), extracts entities and relationships in parallel (up to 10 concurrent), then deduplicates sequentially with LLM-assisted skip/create/merge decisions. Re-extracted relationships receive Bayesian corroboration updates weighted by the provenance of the chunk they came from — conversation turn roles are read to tell the human's words from the agent's, and `graph ingest --external` marks genuinely external material — so knowledge confirmed by independent sources gains confidence while the agent repeating itself barely moves the score.
 
 **Tiered content:** Entities store content at three levels — L0 (abstract, used for embeddings and cheap traversal), L1 (overview, used for reranking), and L2 (full content, pulled on demand). This keeps graph traversal fast.
 

--- a/docs/bayesian-confidence.md
+++ b/docs/bayesian-confidence.md
@@ -4,9 +4,13 @@ How `recall-echo` treats every relationship in its knowledge graph as a probabil
 
 ## TL;DR
 
-Most agent-memory systems treat the relationship between two facts as a boolean with a timestamp. `recall-echo` treats it as a Beta distribution. Each edge in the graph carries a calibrated confidence in `[0, 1]` that is updated with a Beta-Binomial conjugate prior on every new observation, then decayed over time with a 90-day half-life at read time. Multi-hop traversal multiplies confidence along the path, so weak chains attenuate automatically without an explicit pruning rule. Outcome feedback flows back through an EMA on per-entity utility scores. A linear combination of semantic similarity, hotness, and utility produces the final retrieval score.
+Most agent-memory systems treat the relationship between two facts as a boolean with a timestamp. `recall-echo` treats it as a Beta distribution whose pseudo-counts are **persisted on the edge**. Each relationship carries `alpha` (corroboration) and `beta` (contradiction) in the store, so evidence genuinely accumulates: the posterior after fifty corroborations is a different distribution from the posterior after five, with the same mean and a smaller variance. The stored `confidence` field is the posterior mean, kept in sync with the counts on every write so read paths can keep scoring on a single scalar.
 
-The implementation is a few hundred lines of Rust in `src/graph/confidence.rs`, `src/graph/utility.rs`, `src/graph/search.rs`, and `src/graph/query.rs`. The novelty is not the math — Beta-Binomial is textbook — it is that, as far as I can tell, no other open-source agent-memory system applies it to graph edges.
+Two things move those counts. First, observations: a re-extraction that agrees with an edge adds weight to α, one that disagrees adds weight to β. Second — and this is the part nobody else ships — **provenance**. Every observation is stamped at write time with who authored the text it came from (external / user / self), and the weight it contributes depends on that class. The agent restating its own belief adds 0.05, not 1.0, and is separately tallied in `self_reinforcements` so coherence never passes for evidence.
+
+On top of the posterior sits temporal decay with a 90-day half-life, computed at read time. Multi-hop traversal multiplies confidence along the path, so weak chains attenuate without an explicit pruning rule. Outcome feedback flows through an EMA on per-entity utility scores, and a linear combination of semantic similarity, hotness, and utility produces the final retrieval score.
+
+The implementation is `src/graph/confidence.rs` (the model), `src/graph/store.rs` (schema and migration), `src/graph/crud.rs` and `src/graph/ingest.rs` (the write paths), `src/graph/utility.rs` (the feedback loop), `src/graph/search.rs` and `src/graph/query.rs` (the read paths). The novelty is not the math — Beta-Binomial is textbook — it is that, as far as I can tell, no other open-source agent-memory system applies accumulating evidence to graph edges, and none of them weight that evidence by source independence.
 
 ## Why edge updates matter
 
@@ -20,11 +24,13 @@ An autonomous agent that runs for weeks or months hits the same recurring proble
 
 What all three miss: facts decay at different rates, observations have different trustworthiness, and the right merge of "stated three times, contradicted once" is not a deletion or an append — it is a posterior.
 
+Worth saying plainly, because an earlier version of this document overstated it: `recall-echo` used to miss something too. The confidence field was a mean with no memory. Every update re-derived α and β *from the stored mean* at a fixed concentration of 10, applied one observation, and threw the counts away. The mean moved correctly; the *amount of evidence behind it* was pinned at ten forever. An edge confirmed fifty times and an edge confirmed once were, to the system, the same object. Phase 1 is the fix, and everything below describes the fixed version.
+
 ## The model — three primitives
 
-### 1. Beta-Binomial confidence on edges
+### 1. Beta evidence that accumulates
 
-Every relationship starts with a prior determined by how it was extracted, defined in `src/graph/confidence.rs:13-33`:
+Every relationship starts with a prior determined by how it was extracted (`confidence.rs:47-58`):
 
 ```
 Authoritative → 1.0
@@ -33,35 +39,58 @@ Inferred      → 0.6
 Speculative   → 0.3
 ```
 
-The pseudocount is fixed at 10 (`confidence.rs:10`). This is the only knob that shapes how fast the posterior moves; everything else falls out of conjugacy.
-
-The stored confidence `c` is interpreted as the mean of a Beta distribution with concentration `PSEUDOCOUNT = 10`:
+That prior is a *mean*. It is turned into counts by `Evidence::from_prior` (`confidence.rs:218-225`), which splits the prior concentration between them so the mean is preserved exactly:
 
 ```
-α = c · 10
-β = 10 − α
+α = mean · C
+β = (1 − mean) · C        where C = PRIOR_CONCENTRATION = 10   (confidence.rs:18)
 ```
 
-When a new observation arrives, we add one success (corroboration) or one failure (contradiction):
+From then on the counts are what the edge stores, and observations add to them (`Evidence::corroborate` / `Evidence::contradict`, `confidence.rs:250-258`):
 
 ```
-corroborate:  c' = (α + 1) / (α + β + 1) = (α + 1) / 11
-contradict:   c' =       α / (α + β + 1) =       α / 11
+corroborate:  α += w
+contradict:   β += w
+mean         = α / (α + β)                    (confidence.rs:281-291)
+concentration = α + β                         (confidence.rs:272-279)
+variance      = αβ / ((α+β)²(α+β+1))          (confidence.rs:293-304)
 ```
 
-The full implementation is six lines (`confidence.rs:57-66`).
+`w` is the observation's evidence weight, which depends on provenance — see the next major section. With the provenance-blind weight of 1.0 (`DEFAULT_EVIDENCE_WEIGHT`, `confidence.rs:26`) this reduces exactly to counting observations, which is what makes the provenance mechanism differentially testable.
 
-**Worked example.** Take a fact extracted as `Inferred`, so the prior is 0.6 (α=6, β=4).
+Counts are non-negative by construction: `sanitize_count` (`confidence.rs:308-314`) clamps a corrupt or non-finite persisted value to zero rather than producing a nonsense mean, and `sanitize_weight` (`confidence.rs:318-324`) makes a negative or NaN weight record *nothing* rather than eroding evidence already accumulated. With no evidence at all the mean is 0.5 — maximal ignorance — and the variance is reported as 0.0, since there is no distribution to be uncertain about.
 
-| Step | Event | α | β | Posterior |
-|------|-------|---|---|-----------|
-| 0 | prior (Inferred) | 6 | 4 | 0.600 |
-| 1 | corroborate | 7 | 4 | 0.636 |
-| 2 | corroborate | 8 | 4 | 0.667 |
-| 3 | corroborate | 9 | 4 | 0.692 |
-| 4 | contradict | 9 | 5 | 0.643 |
+**Worked example.** Take a fact extracted as `Inferred`, so the prior is 0.6 (α=6, β=4, C=10), corroborated three times by independent sources and then contradicted once:
 
-Three statements followed by one contradiction land at 0.643 — meaningfully above the prior, well below "certain". This is the property we want. A single contradictory mention does not erase three corroborations, but it does register. Tests in `confidence.rs:139-172` lock the math.
+| Step | Event | α | β | C | Mean | Variance |
+|------|-------|---|---|---|------|----------|
+| 0 | prior (Inferred) | 6 | 4 | 10 | 0.600 | 0.0218 |
+| 1 | corroborate (external) | 7 | 4 | 11 | 0.636 | 0.0193 |
+| 2 | corroborate (external) | 8 | 4 | 12 | 0.667 | 0.0171 |
+| 3 | corroborate (external) | 9 | 4 | 13 | 0.692 | 0.0152 |
+| 4 | contradict (external) | 9 | 5 | 14 | 0.643 | 0.0153 |
+
+The mean column is identical to what the old stateless model produced — that was deliberate, so the change is not a silent re-scoring of anyone's graph. The *concentration* column is the new information: it grows. The variance narrows as it does, except at step 4, where the mean moving back toward 0.5 outweighs the extra observation. That is correct behavior, not a bug: a contradicted edge is genuinely less settled than an uncontradicted one at the same evidence count.
+
+`evidence_accumulates_across_observations` (`confidence.rs:497-516`) locks the mean sequence *and* asserts the final counts (α=9, β=5, concentration=14). `variance_narrows_with_corroboration` (`confidence.rs:518-541`) asserts the monotone narrowing across 1, 5 and 50 observations.
+
+**Convergence is slower than the old artifact suggested, and that is the point.** The stateless model recomputed α from the mean each time, which made every update a step of `c' = (10c + 1)/11` — geometric convergence to 1.0 that erased its own history. From a `Speculative` prior of 0.3 it reached 0.994 after fifty corroborations. The stateful model reaches **0.883** at fifty (α=53, β=7) and crosses 0.95 only at about **130**, reaching 0.967 at two hundred. The difference is entirely the seven units of contradiction mass in the prior, which now *persist* instead of being recomputed away. An edge that started life speculative carries that skepticism until real evidence buries it. Slower is the honest answer.
+
+**Migration.** The store carries a `schema_version` on a singleton `meta:schema` record; this build writes version 1 (`store.rs:29`). `init_schema` defines the tables and then runs `migrate` on every open (`store.rs:132-135`), which is a no-op once the version marker is current. The backfill itself is one re-runnable statement (`backfill_edge_evidence`, `store.rs:277-294`):
+
+```sql
+UPDATE relates_to SET
+    alpha = confidence * $concentration,
+    beta  = (1 - confidence) * $concentration,
+    self_reinforcements = 0
+WHERE alpha IS NONE
+```
+
+Every legacy edge keeps its stored mean exactly and gains the honest low concentration of something that was never actually counted. The pass is crash-only by construction: the backfill runs *before* the version marker is written (`store.rs:249-267`), and `WHERE alpha IS NONE` makes re-entry a no-op for edges already done. Kill it halfway and the next open finishes the rest, counting nothing twice.
+
+Until the migration reaches an edge, `Evidence::from_stored` (`confidence.rs:237-248`) falls back to `from_prior` over the bare mean — so an unmigrated store reads correctly rather than reading as zero evidence. The schema declares `alpha`, `beta` and `self_reinforcements` as `option<float>` / `option<int>` precisely to make that state representable (`store.rs:171-175`).
+
+Two write paths touch the counts, and the distinction between them matters. `reinforce_relationship` (`crud.rs:284-306`) *adds* an observation: the caller loads the edge's evidence, records the observation with its provenance, and the whole state is written back — mean, counts, coherence tally, and `last_reinforced = now`. `update_relationship_confidence` (`crud.rs:256-270`) *asserts a mean*: it resets the edge to the prior concentration around the new value, discarding accumulated evidence, because a hand-set confidence is a claim about the mean and not an observation about the world. Writing the counts whole rather than incrementing them in SurrealQL keeps the stored mean and the stored counts from ever disagreeing.
 
 ### 2. Temporal decay layered on top
 
@@ -71,7 +100,7 @@ The Bayesian posterior is what's stored. Effective confidence at read time also 
 effective = stored × 0.5^(days_since_reinforced / 90)
 ```
 
-implemented in `confidence.rs:85-97`, floored at `DECAY_FLOOR = 0.05` (`confidence.rs:73`). Decay is computed against `last_reinforced` if present, otherwise against `valid_from` (`confidence.rs:102-119`). A corroborating update calls `reinforce_relationship` (see `mod.rs:259-265`), which resets the decay clock — so a fact that keeps getting confirmed never decays.
+implemented in `temporal_decay` (`confidence.rs:396-409`), floored at `DECAY_FLOOR = 0.05` (`confidence.rs:385`), with the half-life default at `confidence.rs:382`. Decay is computed against `last_reinforced` if present, otherwise against `valid_from` (`effective_confidence`, `confidence.rs:414-431`). A corroborating update goes through `reinforce_relationship`, which resets the decay clock — so a fact that keeps getting confirmed never decays.
 
 Why layer decay on top of the posterior rather than baking it into the update? Two reasons:
 
@@ -82,7 +111,7 @@ The floor at 0.05 is a deliberate choice: edges never disappear through decay al
 
 ### 3. Path confidence as the edge product
 
-Multi-hop traversal compounds confidence multiplicatively (`confidence.rs:127-129`):
+Multi-hop traversal compounds confidence multiplicatively (`path_confidence`, `confidence.rs:439-441`):
 
 ```
 path_confidence([0.8, 0.7, 0.9]) = 0.504
@@ -90,7 +119,7 @@ path_confidence([0.8, 0.7, 0.9]) = 0.504
 
 This falls naturally out of treating edges as independent probabilities. The practical effect is that the long tail of weak chains is automatically suppressed. Two hops over 0.9 edges is a stronger signal than four hops over 0.7 edges (`0.81` vs `0.24`) — no special-case pruning needed.
 
-The hybrid query in `src/graph/query.rs:51-97` applies this directly: after the semantic phase identifies the top candidates, graph expansion adds neighbors scored as `parent_score · effective_confidence` (line 83). The effective confidence is computed with temporal decay at read time (`query.rs:158-163`), and edges below 0.1 effective confidence are filtered out (`query.rs:166-168`).
+The hybrid query in `src/graph/query.rs` applies this directly: after the semantic phase identifies the top candidates, graph expansion adds neighbors scored as `parent_score · effective_confidence` (`query.rs:83`). The effective confidence is computed with temporal decay at read time (`query.rs:158-163`), and edges below 0.1 effective confidence are filtered out (`query.rs:166-168`).
 
 ```
   semantic                graph expansion
@@ -102,6 +131,64 @@ The hybrid query in `src/graph/query.rs:51-97` applies this directly: after the 
     [E2: 0.71] ──[0.4]──→ [N3: 0.284]       ← below filter floor
                                               after second hop
 ```
+
+Note the honest asymmetry: the multiplicative rule assumes edge independence, and the provenance machinery below exists precisely because *observations* are frequently not independent. Path independence and observation independence are different assumptions; only the second one is modelled.
+
+## Provenance, or why corroboration requires independence
+
+Persisting evidence makes a second problem sharp rather than solving it. If every corroboration adds to α, then an agent that re-asserts its own beliefs across sessions manufactures confidence out of nothing. The graph grows more certain of what it already believed, for no reason other than that it keeps hearing its own voice.
+
+The provenance analysis below originates in research by **Echo, a `pulse-null` entity**, conducted 2026-08-04 on exactly this question — whether a memory system can tell independent corroboration from itself re-asserting. What follows is that analysis and the mechanism it implies, now shipped.
+
+### The epistemology: independence is a precondition, not a nicety
+
+**Bovens & Hartmann** (*Bayesian Epistemology*, 2003) make confidence in a set of reports a function of *both* source reliability and source **independence** — independence is an explicit node in their witness Bayesian network, not an assumption buried in the derivation. As dependence between sources rises, the confidence boost from their agreement shrinks toward zero. Three independent studies at reliability 0.8 beat one study at 0.8; three *copies* of one study at 0.8 are worth roughly one study.
+
+**Olsson**'s impossibility result (*Against Coherence*, 2005) sharpens this into a precondition. The witness model licenses a coherence→credence boost *only if* the reports are conditionally independent given the fact, and each witness has nonzero individual credibility. Drop conditional independence and the boost is not merely weaker — it is not licensed by the probability calculus at all. "Corroboration raises confidence" is a law with a precise precondition, and the precondition is independence.
+
+The default behavior of any count-based scheme is to violate it. This is the echo-chamber failure and the illusion of consensus: people are as convinced by one source cited many times as by many independent sources unless explicitly cued to the shared origin, and agent-based models of echo chambers inflate confidence purely from a single origin propagating. A naive `α += 1` on every re-extraction is that failure mode expressed in Rust.
+
+**Dong, Berti-Équille & Srivastava** (VLDB 2009, *Truth discovery and copying detection in a dynamic world*) show what the mature engineering answer looks like: model `P(S₂ copied from S₁)` and down-weight agreement among sources judged to be copiers, so "many sources say X" stops counting as strong evidence once copying is inferred. **Rekatsinas et al.** (*Fusing Data with Correlations*, arXiv:1503.00306) generalize the accounting to arbitrary correlations and show it is tractable — polynomial for tree-structured dependency models — with one load-bearing caveat: the framework *assumes the dependency structure is given as input*. It does not discover correlations from data.
+
+### The maximum-dependence limit
+
+`recall-echo` is not a mildly-correlated-sources problem. Its corroborating episodes are, in the common case, authored by one agent re-asserting across timestamps. Conditional independence given the fact is not weakened here; it is **structurally absent**. Confidence gained in that regime is coherence amplification, not evidence.
+
+And it cannot be recovered after the fact. Copy-detection works because it has a *population* of distinct nominal sources to triangulate among; at n=1 it is not expensive, it is undefined. Every statistic computable over the agent's own episode stream — corroboration count, semantic agreement, graph coherence, the posterior itself — is a function of the agent's own prior assertions. "I re-asserted X because X is true" and "I re-asserted X because I believe X" emit identical episode streams.
+
+Which leaves exactly one route, and it is the one taken: **capture the distinction at write time**. Recording lineage is cheap; reconstructing it is impossible. The tag must be applied where content crosses from world into memory, by something that is not the loop re-touching the belief. Echo's phrasing for the conclusion is the right one: the fix is *provenance tagging at write-time, not a smarter scorer*.
+
+### The mechanics, as shipped
+
+**Three classes, stamped on the episode.** `Provenance` (`confidence.rs:84-98`) has exactly three variants: `External` (ingested documents, web content, tool output — sources independent of the agent), `User` (statements authored by the human), and `SelfGenerated` (the agent's own summaries, reflections and re-assertions). Episodes carry it as a string field (`store.rs:199`), and `add_episode_from` (`crud.rs:427-461`) writes it. Provenance is a parameter of the ingestion call rather than a field of `NewEpisode` because it is a property of the *ingestion context*, not of the text: the same chunk is external when read out of a document and self-authored when the agent wrote it.
+
+Three classes rather than two is deliberate. Collapsing three into two at scoring time is always possible; splitting one class back into three after the fact is not.
+
+**Weights.** `ProvenanceWeights` (`confidence.rs:153-198`) maps class to evidence weight, defaulting to:
+
+```
+external → 1.0     (DEFAULT_WEIGHT_EXTERNAL, confidence.rs:29)
+user     → 0.8     (DEFAULT_WEIGHT_USER,     confidence.rs:32)
+self     → 0.05    (DEFAULT_WEIGHT_SELF,     confidence.rs:35)
+```
+
+They are configurable per deployment via `[graph.provenance]` in `.recall-echo.toml` (`config.rs:180-186`), settable individually through `config set graph.provenance.weight_self …` (`config.rs:409-419`), and negative values are rejected at parse time. `default_weights_rank_independence_above_repetition` (`confidence.rs:598-615`) asserts the ordering, not just the values.
+
+**Corroboration by class.** `EdgeEvidence` (`confidence.rs:334-378`) is the pair the write path actually manipulates: the Beta counts plus the coherence tally. `EdgeEvidence::corroborate` (`confidence.rs:351-358`) adds the class's weight to α *and*, when the class is `SelfGenerated`, increments `self_reinforcements`. `EdgeEvidence::contradict` (`confidence.rs:360-365`) adds the weight to β and leaves the tally alone — contradicting yourself is not coherence.
+
+The consequence is testable and tested. `external_contradiction_outweighs_accumulated_self_corroboration` (`confidence.rs:697-718`) runs twenty self-corroborations against an `Inferred` edge — which moves it from 0.600 to 0.636 and sets `self_reinforcements = 20` — then applies a *single* external contradiction and asserts the mean lands **below** where it started (7/12 = 0.583). Twenty rounds of the agent agreeing with itself do not survive one independent source disagreeing.
+
+**`self_reinforcements` as a separate tally.** The count is persisted on the edge (`store.rs:175`, `types.rs:180-183`) and never folded into the mean. Keeping it separate is what lets "believed because three independent sources said so" stay distinguishable from "believed because the agent has said it thirty times" — two edges that can otherwise sit at the same confidence. It is available on every `Relationship` read out of the store and is written on every reinforcement (`crud.rs:302`).
+
+**Unknown defaults to self.** `Provenance::from_stored` (`confidence.rs:100-123`) resolves both an *absent* value (an episode written before provenance existed) and an *unrecognised* one (written by a newer build, or by hand) to `SelfGenerated`. `Provenance`'s `#[derive(Default)]` points at the same variant. This is why the episode `provenance` field needed no backfill and no schema version bump (`store.rs:194-199`): the absent case already means the conservative thing. A legacy store never gains confidence from data it cannot vouch for. `stored_provenance_defaults_to_self` (`confidence.rs:648-660`) pins it.
+
+**Where the class comes from.** `ProvenancePolicy` (`ingest.rs:26-45`) has two modes. `FromTurnRoles` — the default — reads authorship off the `### User` / `### Assistant` headings the archive pipeline writes (`infer_from_turn_roles`, `ingest.rs:105-122`). A chunk is credited to the human only when *every* role heading in it is a user turn; mixed turns, assistant turns, and text with no headings at all are the agent's own. `Fixed(class)` stamps the whole run, which is what `graph ingest --external` does for document ingestion (`main.rs:266-276`, `main.rs:688-692`). The heuristic is conservative in both directions by design — `heading_matching_is_exact` (`ingest.rs:503-508`) checks that `### Users of the system` is read as a topic, not a turn.
+
+The class then rides through extraction: a relationship keeps the provenance of the chunk it came out of (`ingest.rs:250-264`), and re-extraction of an existing edge corroborates it at that class's weight (`ingest.rs:307-330`). Evidence is only ever as independent as the text that produced it.
+
+**The escape hatch.** `ProvenanceWeights::uniform(w)` (`confidence.rs:174-187`) weights every class identically. `uniform(DEFAULT_EVIDENCE_WEIGHT)` reproduces provenance-blind behavior *exactly*, which is what makes the whole mechanism differentially measurable: run a benchmark at `(1, 1, 1)` and at the defaults, and the delta is attributable to provenance weighting and nothing else. `uniform_weights_are_provenance_blind` (`confidence.rs:617-631`) asserts the reduction holds.
+
+**One knock-on effect.** Episode garbage collection uses the same signal: an episode is collectable only when it is old, never retrieved, cited by nothing, *and* self-authored (`gc.rs:501-528`). External and user episodes survive any age — they are the only evidence in the store that was not manufactured internally, and throwing them away would be throwing away the independence the whole mechanism depends on.
 
 ## Adaptive utility scoring
 
@@ -115,17 +202,23 @@ Partial → 0.5
 Failed  → 0.0
 ```
 
-When a session completes, retrieved entities receive an EMA update. The alpha depends on whether the entity was actually used in the response (`utility.rs:62-68`):
+When a session is adjudicated, the entities it touched receive an EMA update. The alpha depends on whether the entity was actually used (`utility.rs:61-68`):
 
 ```
-USED_ALPHA   = 0.1     // retrieved AND used → full signal
-UNUSED_ALPHA = 0.05    // retrieved but not used → muted
-UNUSED_REWARD = 0.3    // "you retrieved me and ignored me" → slight negative
+USED_ALPHA    = 0.1     // retrieved AND used → full signal
+UNUSED_ALPHA  = 0.05    // retrieved but not used → muted
+UNUSED_REWARD = 0.3     // "you retrieved me and ignored me" → slight negative
 ```
 
-The update is `new = (1 − α) · current + α · reward`, applied atomically in a single SurrealDB query to avoid read-modify-write races (`utility.rs:239-263`). The convergence test (`utility.rs:342-354`) confirms that ~50 successive successes push a score from 0.5 to >0.99.
+The update is `new = (1 − α) · current + α · reward`, applied atomically in a single SurrealDB query to avoid read-modify-write races (`utility.rs:479-505`). The convergence test (`utility.rs:584-596`) confirms that ~50 successive successes push a score from 0.5 to >0.99.
 
-These utility scores feed the final retrieval composition in `src/graph/search.rs:226-235`:
+Until Phase 1, this layer had no caller — it was correct, tested, and dead. It now has two.
+
+**Passive linkage at ingestion.** The last phase of extraction records which entities a session produced or reinforced (`record_session_use`, `utility.rs:206-233`, called from `ingest.rs:361`). Those records are `contributed_to` edges pointing at a per-session outcome entity marked `pending` — a state that carries no reward and moves no utility score, because an unadjudicated session is not evidence of usefulness (`ContributionResult`, `utility.rs:304-322`). Linkage is idempotent per session: re-ingesting rewrites the records rather than accumulating duplicates (`create_contribution_edge`, `utility.rs:447-476`), and one outcome entity is created on first use and reused thereafter whichever order the linkage and the verdict arrive in (`outcome_entity_for_session`, `utility.rs:329-341`).
+
+**Adjudication on demand.** `recall-echo graph feedback <session-id> --outcome success|partial|failed` (`main.rs:335-343`, `graph_cli.rs:1153`) resolves the session's entities from those records and applies the outcome (`GraphMemory::record_session_outcome`, `mod.rs:527`). If a store has no records for the session — ingested before passive linkage existed — it falls back to the entities the session authored (`session_entities`, `utility.rs:240-294`). The command reports every entity that moved and where its score landed. It runs through the daemon like search and ingest, so it can be issued while a session is still using the store.
+
+These utility scores feed the final retrieval composition (`score_with_utility`, `search.rs:231-239`):
 
 ```
 final_score = w_semantic · similarity
@@ -133,42 +226,46 @@ final_score = w_semantic · similarity
             + w_utility  · utility_score
 ```
 
-Default weights are `0.45 / 0.30 / 0.25` (`search.rs:22-23`), configurable per deployment via `[graph.scoring]` in `.recall-echo.toml`. Hotness itself is a separate signal — `sigmoid(ln(1 + access_count)) · exp(−ln(2)/7 · days)` — capturing recent activity with a 7-day half-life (`search.rs:239-253`).
+Default weights are `0.45 / 0.30 / 0.25` (`GraphScoringConfig`, `config.rs:249-255`), configurable per deployment via `[graph.scoring]` in `.recall-echo.toml`. Hotness itself is a separate signal — `sigmoid(ln(1 + access_count)) · exp(−ln(2)/7 · days)` — capturing recent activity with a 7-day half-life (`search.rs:244-258`).
 
 So the system has two decay clocks operating on different signals at different rates: 7 days for hotness (engagement), 90 days for confidence (epistemic decay). Both are tunable.
 
 ## Comparison to the landscape
 
-| System | Edge model | Contradiction handling | Stale-fact handling | Reinforcement |
-|---|---|---|---|---|
-| Graphiti | Bi-temporal validity intervals | Invalidate + new edge | Explicit `valid_to` | None — observation count not tracked |
-| mem0 | ADD-only with conflict tags | Flagged, manual resolve | None | Not represented |
-| Cognee | Graph rewrite on conflict | Regenerate region | Implicit via rewrite | Lost on rewrite |
-| recall-echo | Beta-Binomial posterior | Single contradiction shifts posterior, multiple erode it | Half-life decay at read time | α += 1 + clock reset |
+| System | Edge model | Contradiction handling | Stale-fact handling | Reinforcement | Source independence |
+|---|---|---|---|---|---|
+| Graphiti | Bi-temporal validity intervals | Invalidate + new edge | Explicit `valid_to` | None — observation count not tracked | Not modelled |
+| mem0 | ADD-only with conflict tags | Flagged, manual resolve | None | Not represented | Not modelled |
+| Cognee | Graph rewrite on conflict | Regenerate region | Implicit via rewrite | Lost on rewrite | Not modelled |
+| recall-echo | Beta posterior with **persisted** α/β | Contradiction mass accumulates and persists | Half-life decay at read time | α += provenance weight, clock reset, concentration grows | Three write-time classes, weighted 1.0 / 0.8 / 0.05, self-corroboration separately tallied |
+
+Both differentiating columns are new. Accumulating evidence means the system can distinguish "believed at 0.9" from "believed at 0.9 for good reason" — the variance is the difference, and nothing else in the space computes it. Provenance-aware weighting means it can distinguish corroboration from repetition — and here the gap is wider still: the truth-discovery literature has done this since 2009, and no open-source agent-memory system has picked it up.
 
 A few honest notes.
 
-**Graphiti's bi-temporal model gives you something Bayesian confidence does not: point-in-time queries.** "What did this agent believe about X on March 14?" is a clean SQL-like query against `valid_from`/`valid_to`. Against a Beta-Binomial graph, the equivalent question is "what was the posterior at that timestamp?" — answerable only if you log every update, which `recall-echo` does not currently do. If point-in-time auditability matters more than calibrated uncertainty for your use case, bi-temporal is the right design.
+**Graphiti's bi-temporal model gives you something Bayesian confidence does not: point-in-time queries.** "What did this agent believe about X on March 14?" is a clean SQL-like query against `valid_from`/`valid_to`. Against a Beta graph, the equivalent question is "what were the counts at that timestamp?" — answerable only if you log every update, which `recall-echo` still does not do. Persisting α and β makes the *current* state auditable; it does not make the history replayable. If point-in-time auditability matters more than calibrated uncertainty for your use case, bi-temporal is the right design.
 
-**mem0's strength is operational simplicity.** No conjugate priors, no half-lives. For short-horizon agents that won't accumulate enough observations for the math to matter, that simplicity is the correct call.
+**mem0's strength is operational simplicity.** No conjugate priors, no half-lives, no provenance policy to get wrong. For short-horizon agents that won't accumulate enough observations for the math to matter, that simplicity is the correct call.
 
 **Cognee's rewrite approach is the most aggressive about consistency** but trades history for it. For an agent whose memory needs to support "why did you think X?" introspection, that's a hard trade.
 
-The case for probabilistic edges is specifically about long-running autonomous entities — systems whose memory is being shaped by hundreds or thousands of observations over months, where the noise floor is high and "this is still probably true" is a useful concept. That is the design center for `recall-echo`.
+The case for probabilistic edges is specifically about long-running autonomous entities — systems whose memory is being shaped by hundreds or thousands of observations over months, where the noise floor is high, where "this is still probably true" is a useful concept, and where a large fraction of those observations are the agent talking to itself. That is the design center for `recall-echo`.
 
 ## Implementation notes
 
-The whole confidence model is ~130 lines of Rust including tests (`src/graph/confidence.rs`). The utility layer is ~365 lines including the SurrealDB feedback edges (`src/graph/utility.rs`). It runs on:
+The confidence model is ~440 lines of Rust plus ~410 of tests (`src/graph/confidence.rs`). The utility layer is ~540 lines plus tests including the SurrealDB feedback edges (`src/graph/utility.rs`). It runs on:
 
 - **SurrealDB** (embedded SurrealKV by default, WebSocket server optional) as the graph store and HNSW vector index
 - **FastEmbed** for local 384-dimension cosine embeddings
-- **Tokio** for async, with `futures::future::join_all` for concurrent per-entity feedback updates (`utility.rs:134`)
-- **AGPL-3.0**, version 3.11.0 at time of writing
+- **Tokio** for async, with `futures::future::join_all` for concurrent per-entity feedback updates (`utility.rs:166`)
+- **AGPL-3.0**
 
 A few design choices worth pulling out:
 
-- `PSEUDOCOUNT = 10` was chosen so that ~10 observations are needed to fully overwhelm the prior. Lower values make the posterior twitchy; higher values make corroboration too slow to register. Ten is the conventional weak-prior choice and it tested well in practice.
-- Half-life of 90 days is a default; the constant lives at `confidence.rs:70` and the function signature accepts a per-call value, so per-domain tuning is mechanical.
+- `PRIOR_CONCENTRATION = 10` sets how much evidence a *prior* is worth, and nothing else. It is no longer the fixed concentration of every edge forever — it is the starting point, and the migration's backfill value. Lower makes new edges twitchy; higher makes early corroboration slow to register. Ten is the conventional weak-prior choice.
+- Weights are floats, and α/β are weighted sums rather than integer counts. This is what lets a self-corroboration be worth 0.05 of an observation instead of requiring a separate mechanism.
+- The `Evidence` counts are private with accessor methods, so nothing outside the model can write a state where the mean and the counts disagree.
+- Half-life of 90 days is a default; the constant lives at `confidence.rs:382` and the `temporal_decay` signature accepts a per-call value, so per-domain tuning is mechanical.
 - The decay floor at 0.05 is deliberate. Edges below it are still queryable but ranked near the bottom. Hard deletion is a GC concern.
 - The hybrid query filters effective confidence below 0.1 during graph expansion (`query.rs:166`). Below this, the multiplicative chain attenuates results to noise.
 
@@ -178,23 +275,29 @@ Source: [`github.com/dnacenta/recall-echo`](https://github.com/dnacenta/recall-e
 
 Read in this order:
 
-- `src/graph/confidence.rs` — the Bayesian update, decay, and path composition (~300 lines including tests)
-- `src/graph/utility.rs` — EMA feedback loop and outcome edges
-- `src/graph/search.rs` — final scoring composition
-- `src/graph/query.rs` — hybrid query with confidence-weighted graph expansion
+- `src/graph/confidence.rs` — `Evidence`, `EdgeEvidence`, `Provenance`, `ProvenanceWeights`, decay, path composition
+- `src/graph/store.rs` — schema definition and the version-1 evidence migration
+- `src/graph/crud.rs` — `reinforce_relationship` (adds evidence) vs `update_relationship_confidence` (asserts a mean)
+- `src/graph/ingest.rs` — turn-role provenance inference and the corroboration path
+- `src/graph/utility.rs` — EMA feedback loop, passive session linkage, outcome edges
+- `src/graph/search.rs` / `src/graph/query.rs` — final scoring composition and confidence-weighted expansion
 
-The test suite in `confidence.rs:131-297` covers the update math, the decay function, the floor, and the path product. The utility tests in `utility.rs:301-365` cover EMA math, convergence behavior, and the used-vs-unused asymmetry. Run `cargo test -p recall-echo graph::confidence` and `cargo test -p recall-echo graph::utility` to reproduce.
+The test suite in `confidence.rs:443-849` covers the update math, accumulation, variance narrowing, weight and count sanitization, the three provenance classes and their serde wire names, the self-vs-external asymmetry, the decay function, the floor, and the path product. The utility tests in `utility.rs:543-661` cover EMA math, convergence, the used-vs-unused asymmetry, and the pending/resolved contribution states. Run `cargo test -p recall-echo graph::confidence` and `cargo test -p recall-echo graph::utility` to reproduce.
 
-## Open questions
+## Open questions and known limits
 
-A few directions that would extend this naturally:
+**Bi-temporal point-in-time queries are still unsupported.** Persisted counts make the current posterior auditable, not the history of it. Replaying "what did the graph believe last March" would need a per-observation log; the current design treats the counts as sufficient. A Beta posterior stored alongside `valid_from`/`valid_to` intervals would give both, at the cost of schema complexity — and it only pays off if anyone's agent actually issues point-in-time queries.
 
-**Learned per-relation-type priors.** The four extraction-context priors (`Authoritative` / `Explicit` / `Inferred` / `Speculative`) are hand-tuned constants. A more honest approach would track the calibration of each context over time — what fraction of "Speculative" claims actually held up under corroboration — and adjust the prior accordingly. This is straightforward Bayesian model-averaging and is currently future work.
+**The priors and the provenance weights are hand-tuned.** The four extraction-context priors and the three class weights (1.0 / 0.8 / 0.05) are constants chosen for plausibility, not fitted to anything. The honest version tracks the calibration of each context and each class over time — what fraction of "Speculative" claims, or of user-authored claims, actually held up under independent corroboration — and adjusts. That is straightforward Bayesian model-averaging and it is future work. Until the benchmark runs at `(1, 1, 1)` versus the defaults, the *direction* of the effect is argued from the epistemology, not measured.
 
-**Integration with bi-temporal validity intervals.** The two approaches are not actually in conflict. A Beta-Binomial posterior could be stored alongside `valid_from`/`valid_to` intervals to get both point-in-time queries *and* calibrated uncertainty. The cost is schema complexity. Whether it pays off depends on whether anyone's agent actually issues point-in-time queries — for `recall-echo`'s current use, they don't.
+**Retrieval consumes neither variance nor provenance.** `score_with_utility` sees similarity, hotness and utility; graph expansion sees the decayed mean. Variance is computed and tested but read by nothing outside the tests, and `self_reinforcements` is persisted on the edge but rendered by no CLI view. This is deliberate for Phase 1 — the point was to make the state true and the scoring unchanged, so that a benchmark can attribute any movement to the state rather than to a re-ranking. Consuming variance ("prefer the well-evidenced edge among equals") and surfacing the coherence tally are Phase 2.
 
-**Per-observation logs.** Storing every update event would enable replay, calibration analysis, and rollback. It would also bloat the graph considerably. The current design treats the posterior as sufficient.
+**The migration report goes nowhere.** `init_schema` returns a `MigrationReport` with the count of backfilled edges (`store.rs:225-241`), and both call sites currently discard it. Nothing tells an operator that their store was migrated, or how many edges moved. That is a gap, not a design.
+
+**The utility feedback loop is newly wired and unproven.** `record_outcome_feedback` was dead code until this phase; it now has a passive caller at ingestion and an explicit one in `graph feedback`. The EMA math is tested, the wiring is tested, but nothing yet demonstrates that the resulting utility scores improve retrieval on a real workload. Treat the loop as live and unvalidated.
+
+**Provenance inference is a heuristic at one boundary.** Turn-role inference is only as good as the archive format, and it is conservative by construction: anything ambiguous is credited to the agent. That is the right failure direction — under-crediting costs confidence that real evidence would have earned, over-crediting manufactures it — but it does mean a store whose archives lack role headings will treat genuinely external material as self-authored until someone passes `--external`. The tag's correctness is a function of where it is applied, and that remains an architectural property, not something the code can check.
 
 ---
 
-`recall-echo` exists because the entity it serves — `pulse-null`, a long-running autonomous Rust runtime — needed a memory layer that wouldn't degrade into noise after a few months of operation. The Bayesian model is the part that earns its keep. The rest is plumbing.
+`recall-echo` exists because the entity it serves — `pulse-null`, a long-running autonomous Rust runtime — needed a memory layer that wouldn't degrade into noise after a few months of operation. The Bayesian model is the part that earns its keep. Making it remember its own evidence, and making it refuse to count its own voice as a second witness, is what Phase 1 was for. The rest is plumbing.

--- a/specs/phase1-truth-layer.md
+++ b/specs/phase1-truth-layer.md
@@ -1,0 +1,60 @@
+# Phase 1 — Truth Layer: Stateful, Provenance-Aware Confidence
+
+**Status**: In progress
+**Date**: 2026-08-04
+**Parent roadmap**: `/opt/pulse-vault/pulse-null/specs/todo/recall-echo-v4-roadmap-spec.md` (Phase 1 of 5)
+**Base**: stacked on Phase 0 (`feat/RE-29-phase0-unblock-measurement`) — daemon + runtime backend assumed present.
+**Intellectual origin**: Echo's source-correlation research (2026-08-04, Bovens-Hartmann/Olsson: independence is a load-bearing precondition for corroboration; Dong et al.: model source copying, don't count copies) + rev-3 audit finding that the Beta-Binomial update is stateless.
+
+## Problem
+
+The confidence score is not what the essay says it is, in two independent ways:
+
+1. **Stateless update.** `confidence.rs` re-derives α/β from the stored mean with concentration pinned at 10 — evidence counts never accumulate. The posterior after 50 corroborations is indistinguishable from after 5; variance never narrows. The essay describes accumulation that does not happen.
+2. **Provenance-blind corroboration.** Every corroborating episode is counted as evidence regardless of who authored it. For an entity whose episodes are all written by one agent (Echo's case exactly), confidence gain is coherence amplification, not evidence — "well-corroborated" and "often-repeated-by-the-agent" are indistinguishable. Undetectable from inside; the only fix is provenance tagged at write-time.
+
+Adjacent debts in the same layer: episodes have **no GC/decay at all** (unbounded accumulation, the exact failure class that killed Echo); the outcome-feedback tier (`record_outcome_feedback`) has **no caller** — utility contributes a constant to every score in every real deployment.
+
+## Work items
+
+### 1. Stateful evidence (schema + math)
+- Persist per-edge evidence: `alpha: float`, `beta: float` pseudo-count fields on `relates_to` (schema migration, idempotent `DEFINE FIELD IF NOT EXISTS` + backfill from stored `confidence` at prior concentration — existing edges keep their mean, gain honest low concentration).
+- `corroborate`/`contradict` increment the persisted counts (by provenance weight, item 2); `effective_confidence` = decayed posterior mean; posterior variance now available and exposed in `graph status`/entity detail output.
+- Keep the two-clock design (7d hotness / 90d confidence half-life) unchanged. Decay applies to the *mean* at read time exactly as today.
+
+### 2. Provenance classes at write-time
+- Every episode and every confidence-moving event carries `provenance: external | user | self` (D's decision 2026-08-04: three classes; collapse is possible at scoring time, recovery is not).
+  - `external` — ingested documents, web content, tool outputs.
+  - `user` — statements authored by the human (D) in conversation.
+  - `self` — the agent's own summaries, reflections, re-assertions (includes everything the archive pipeline generates from assistant turns).
+- Class inference at ingest: conversation-turn role → user/self; non-conversation ingest sources (pipeline docs authored by the entity) → self; explicit override flag for genuinely external material. Default when unknown: `self` (the conservative choice — never over-credit).
+- Evidence weights in config `[graph.provenance]`: `weight_external = 1.0`, `weight_user = 0.8`, `weight_self = 0.05` (tunable; benchmark decides later). Corroboration increments α by the weight; contradiction increments β by the weight.
+- Coherence (self-corroboration) remains **visible as a separate signal** — a `self_reinforcements` counter on the edge — never laundered into confidence.
+
+### 3. Episode GC
+- Episodes gain the same governance edges have: read-time relevance decay already exists via hotness; add GC (dry-run default, thresholds config-gated) pruning episodes that are old + never-retrieved + not evidence for any surviving edge. Wire into existing `graph gc`.
+
+### 4. Wire the outcome-feedback tier
+- `recall-echo graph feedback <session-id> --outcome success|failure` CLI verb calling `record_outcome_feedback`; hook-side: SessionEnd archive records the session→entity `contributed_to` edges it already knows about (was-used signal), so utility learns passively.
+
+## Acceptance criteria
+
+### Happy path
+- [ ] AC1: Corroborating an edge N times with `external` provenance yields a posterior whose variance strictly decreases with N (test: var(α,β) after 5 < after 1; after 50 < after 5) and whose α+β grows by the configured weights — persisted across process restarts.
+- [ ] AC2: The same N corroborations with `self` provenance move the mean by ≤ the configured self-weight fraction; the `self_reinforcements` counter records them; an external contradiction outweighs any number of accumulated self-corroborations at default weights.
+- [ ] AC3: Schema migration is idempotent and non-destructive: opening a pre-Phase-1 store preserves every stored confidence mean; re-opening migrates nothing twice.
+- [ ] AC4: `graph gc` (episodes mode) in dry-run reports prune candidates; real run removes only old + never-retrieved + non-evidence episodes; evidence episodes survive regardless of age.
+- [ ] AC5: `graph feedback` moves utility scores (visible in entity detail before/after); SessionEnd hook records was-used edges without user action.
+- [ ] AC6: Full benchmark suite re-run shows no regression vs the Phase 0 baseline (retrieval metrics within noise; answer metrics not degraded).
+
+### Edge cases
+- [ ] AC7: Unknown/missing provenance on legacy episodes defaults to `self` — legacy stores never gain confidence from backfilled data.
+- [ ] AC8: Weights set to (1.0, 1.0, 1.0) reproduce provenance-blind behavior exactly (escape hatch + differential-testing lever).
+- [ ] AC9: Golden-set query tests (Phase 0) still pass unmodified — retrieval semantics untouched by this phase.
+
+### Failure modes
+- [ ] AC10: Migration interrupted mid-backfill (kill -9) leaves a store that re-opens and completes migration — no corruption, no double-count (crash-only discipline extends to migration).
+
+## Out of scope
+
+Retrieval changes (Phase 2 — including the three retrieval bugs from the golden-set findings), MCP (Phase 3), essay publication (Phase 4 — but this phase makes the essay true, and the provenance addendum draws directly on Echo's research, credited).

--- a/src/bench/ingest.rs
+++ b/src/bench/ingest.rs
@@ -17,7 +17,7 @@ use crate::conversation::{self, conversation_to_markdown, Conversation, Conversa
 use crate::ephemeral::{self, EphemeralEntry};
 use crate::error::RecallError;
 use crate::frontmatter::Frontmatter;
-use crate::graph::GraphMemory;
+use crate::graph::{GraphMemory, IngestContext};
 use crate::tags;
 
 use super::{BenchConversation, BenchSession};
@@ -76,13 +76,11 @@ pub async fn ingest_conversation(
         stats.sessions_written += 1;
         stats.log_numbers.push(written.log_number);
 
+        // Benchmark sessions are written through the same archive renderer as
+        // real conversations, so turn-role inference applies unchanged.
+        let context = IngestContext::new(&session_id, Some(written.log_number));
         let report = gm
-            .ingest_archive(
-                &written.full_content,
-                &session_id,
-                Some(written.log_number),
-                llm,
-            )
+            .ingest_archive(&written.full_content, &context, llm)
             .await?;
 
         stats.episodes += report.episodes_created as usize;

--- a/src/config.rs
+++ b/src/config.rs
@@ -4,6 +4,10 @@ use std::path::Path;
 
 use serde::{Deserialize, Serialize};
 
+/// Evidence weights per provenance class, re-exported from the confidence
+/// model that owns them: `[graph.provenance]` is only their config surface.
+pub use crate::graph::confidence::ProvenanceWeights;
+
 const DEFAULT_MAX_ENTRIES: usize = 5;
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 3600;
 const CONFIG_FILE: &str = ".recall-echo.toml";
@@ -173,6 +177,13 @@ pub struct GraphSection {
     /// (0.45 / 0.30 / 0.25). See `GraphScoringConfig` for details.
     #[serde(default)]
     pub scoring: GraphScoringConfig,
+    /// Evidence weights per provenance class.
+    ///
+    /// Maps to the `[graph.provenance]` section of `.recall-echo.toml`. When
+    /// absent, defaults are 1.0 external / 0.8 user / 0.05 self. See
+    /// [`ProvenanceWeights`] for details.
+    #[serde(default)]
+    pub provenance: ProvenanceWeights,
 }
 
 impl Default for GraphSection {
@@ -185,6 +196,7 @@ impl Default for GraphSection {
             username: String::new(),
             password_file: String::new(),
             scoring: GraphScoringConfig::default(),
+            provenance: ProvenanceWeights::default(),
         }
     }
 }
@@ -394,9 +406,42 @@ impl Config {
                 };
                 Ok(())
             }
+            "graph.provenance.weight_external" => {
+                self.graph_section().provenance.weight_external = parse_weight(value)?;
+                Ok(())
+            }
+            "graph.provenance.weight_user" => {
+                self.graph_section().provenance.weight_user = parse_weight(value)?;
+                Ok(())
+            }
+            "graph.provenance.weight_self" => {
+                self.graph_section().provenance.weight_self = parse_weight(value)?;
+                Ok(())
+            }
             other => Err(RecallError::Config(format!("unknown config key: {other}"))),
         }
     }
+
+    /// The `[graph]` section, created at its defaults if the config has none.
+    fn graph_section(&mut self) -> &mut GraphSection {
+        self.graph.get_or_insert_with(GraphSection::default)
+    }
+}
+
+/// Parse an evidence weight: a finite, non-negative number.
+///
+/// Zero is allowed — it is how a class is switched off entirely.
+fn parse_weight(value: &str) -> Result<f64, crate::error::RecallError> {
+    use crate::error::RecallError;
+    let weight: f64 = value
+        .parse()
+        .map_err(|_| RecallError::Config(format!("invalid number: {value}")))?;
+    if !weight.is_finite() || weight < 0.0 {
+        return Err(RecallError::Config(format!(
+            "evidence weight must be finite and non-negative, got {value}"
+        )));
+    }
+    Ok(weight)
 }
 
 #[cfg(test)]
@@ -617,6 +662,59 @@ mod tests {
         assert!((section.scoring.weight_semantic - defaults.weight_semantic).abs() < f64::EPSILON);
         assert!((section.scoring.weight_hotness - defaults.weight_hotness).abs() < f64::EPSILON);
         assert!((section.scoring.weight_utility - defaults.weight_utility).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn graph_provenance_defaults_when_section_absent() {
+        let section: GraphSection = toml::from_str("mode = \"embedded\"\n").expect("parse section");
+        let defaults = ProvenanceWeights::default();
+        assert_eq!(section.provenance, defaults);
+        assert!((defaults.weight_external - 1.0).abs() < f64::EPSILON);
+        assert!((defaults.weight_user - 0.8).abs() < f64::EPSILON);
+        assert!((defaults.weight_self - 0.05).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn graph_provenance_partial_toml_fills_defaults() {
+        let cfg: Config =
+            toml::from_str("[graph]\n\n[graph.provenance]\nweight_self = 0.5\n").expect("parse");
+        let provenance = cfg.graph.expect("graph section present").provenance;
+        assert!((provenance.weight_self - 0.5).abs() < f64::EPSILON);
+        assert!((provenance.weight_external - 1.0).abs() < f64::EPSILON);
+        assert!((provenance.weight_user - 0.8).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn set_key_provenance_weights() {
+        let mut cfg = Config::default();
+        cfg.set_key("graph.provenance.weight_self", "0.2").unwrap();
+        cfg.set_key("graph.provenance.weight_user", "0").unwrap();
+        cfg.set_key("graph.provenance.weight_external", "1.5")
+            .unwrap();
+
+        let provenance = cfg
+            .graph
+            .as_ref()
+            .expect("graph section created")
+            .provenance;
+        assert!((provenance.weight_self - 0.2).abs() < f64::EPSILON);
+        assert!(provenance.weight_user.abs() < f64::EPSILON);
+        assert!((provenance.weight_external - 1.5).abs() < f64::EPSILON);
+
+        assert!(cfg.set_key("graph.provenance.weight_self", "-1").is_err());
+        assert!(cfg.set_key("graph.provenance.weight_self", "lots").is_err());
+    }
+
+    #[test]
+    fn provenance_weights_round_trip_through_toml() {
+        let mut cfg = Config::default();
+        cfg.set_key("graph.provenance.weight_self", "0.05").unwrap();
+        let rendered = toml::to_string_pretty(&cfg).expect("render");
+        let parsed: Config = toml::from_str(&rendered).expect("reparse");
+        assert_eq!(
+            parsed.graph.expect("graph section survives").provenance,
+            ProvenanceWeights::default()
+        );
     }
 
     #[test]

--- a/src/graph/confidence.rs
+++ b/src/graph/confidence.rs
@@ -1,13 +1,26 @@
 //! Bayesian confidence model for relationship edges.
 //!
-//! Uses Beta-Binomial conjugate prior with pseudocount 10.
-//! Confidence moves slowly per observation but accumulates with repeated evidence.
+//! Uses a Beta-Binomial conjugate prior. The pseudo-counts (`alpha`, `beta`)
+//! are **persisted on the edge**, so evidence accumulates: the posterior after
+//! fifty corroborations is a different distribution from the posterior after
+//! five, and its variance is smaller. The stored `confidence` field is the
+//! posterior mean — a derived value kept in sync with the counts on every
+//! write, so read paths can keep scoring on the mean alone.
+//!
+//! A new edge (or an edge from a store predating evidence persistence) starts
+//! at [`PRIOR_CONCENTRATION`]: the mean is preserved and the concentration is
+//! honestly low.
 
 use serde::{Deserialize, Serialize};
 
-/// Pseudocount total for the Beta-Binomial prior.
+/// Total pseudo-count of the Beta prior an edge starts from.
 /// ~10 observations to overwhelm the prior.
-const PSEUDOCOUNT: f64 = 10.0;
+pub const PRIOR_CONCENTRATION: f64 = 10.0;
+
+/// Evidence weight of a single observation whose provenance is not (yet)
+/// modelled. Provenance-weighted observations arrive in Phase 1 increment 2;
+/// until then every observation counts once.
+pub const DEFAULT_EVIDENCE_WEIGHT: f64 = 1.0;
 
 /// How a relationship was established — determines initial confidence prior.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -46,22 +59,129 @@ impl std::str::FromStr for ExtractionContext {
     }
 }
 
-/// Bayesian update using Beta-Binomial conjugate prior.
+/// The accumulated evidence for one relationship: the pseudo-counts of its
+/// Beta posterior.
 ///
-/// Given a current confidence (interpreted as alpha / (alpha + beta) with
-/// total pseudocount), updates the posterior by adding one observation.
-///
-/// - `corroborate = true`: alpha += 1 (evidence supports the relationship)
-/// - `corroborate = false`: beta += 1 (evidence contradicts the relationship)
-#[must_use]
-pub fn bayesian_update(current_confidence: f64, corroborate: bool) -> f64 {
-    let alpha = current_confidence * PSEUDOCOUNT;
-    let beta = PSEUDOCOUNT - alpha;
+/// `alpha` counts corroboration, `beta` counts contradiction. Both are
+/// weighted sums, not integers — an observation contributes its provenance
+/// weight. Counts are non-negative by construction.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Evidence {
+    alpha: f64,
+    beta: f64,
+}
 
-    if corroborate {
-        (alpha + 1.0) / (alpha + beta + 1.0)
+impl Evidence {
+    /// Evidence for an edge that has only a mean: split [`PRIOR_CONCENTRATION`]
+    /// between the two counts so the mean is preserved exactly.
+    ///
+    /// This is the shape a brand-new edge starts in, and the shape the schema
+    /// migration backfills legacy edges into.
+    #[must_use]
+    pub fn from_prior(mean: f64) -> Self {
+        let mean = mean.clamp(0.0, 1.0);
+        Self {
+            alpha: mean * PRIOR_CONCENTRATION,
+            beta: (1.0 - mean) * PRIOR_CONCENTRATION,
+        }
+    }
+
+    /// Evidence from persisted counts. Non-finite or negative counts are
+    /// clamped to zero — a corrupt count must not produce a nonsense mean.
+    #[must_use]
+    pub fn from_counts(alpha: f64, beta: f64) -> Self {
+        Self {
+            alpha: sanitize_count(alpha),
+            beta: sanitize_count(beta),
+        }
+    }
+
+    /// Evidence for an edge as read from the store.
+    ///
+    /// Uses the persisted counts when present; falls back to
+    /// [`Evidence::from_prior`] over the stored mean when they are absent —
+    /// the shape of an edge on a store whose migration has not run yet.
+    #[must_use]
+    pub fn from_stored(alpha: Option<f64>, beta: Option<f64>, confidence: f64) -> Self {
+        match (alpha, beta) {
+            (Some(a), Some(b)) => Self::from_counts(a, b),
+            _ => Self::from_prior(confidence),
+        }
+    }
+
+    /// Record supporting evidence of the given weight.
+    pub fn corroborate(&mut self, weight: f64) {
+        self.alpha += sanitize_weight(weight);
+    }
+
+    /// Record contradicting evidence of the given weight.
+    pub fn contradict(&mut self, weight: f64) {
+        self.beta += sanitize_weight(weight);
+    }
+
+    /// Corroboration pseudo-count.
+    #[must_use]
+    pub fn alpha(self) -> f64 {
+        self.alpha
+    }
+
+    /// Contradiction pseudo-count.
+    #[must_use]
+    pub fn beta(self) -> f64 {
+        self.beta
+    }
+
+    /// Total evidence weight behind this edge (`alpha + beta`).
+    ///
+    /// This is what never grew in the pre-Phase-1 model: it is the difference
+    /// between "believed at 0.9" and "believed at 0.9 for good reason".
+    #[must_use]
+    pub fn concentration(self) -> f64 {
+        self.alpha + self.beta
+    }
+
+    /// Posterior mean — the value stored as the edge's `confidence`.
+    ///
+    /// With no evidence in either direction the mean is 0.5 (maximal ignorance).
+    #[must_use]
+    pub fn mean(self) -> f64 {
+        let total = self.concentration();
+        if total <= 0.0 {
+            return 0.5;
+        }
+        self.alpha / total
+    }
+
+    /// Posterior variance — `αβ / ((α+β)²(α+β+1))`.
+    ///
+    /// Strictly decreasing in the amount of evidence at a fixed mean, which is
+    /// how "corroborated fifty times" is told apart from "corroborated once".
+    #[must_use]
+    pub fn variance(self) -> f64 {
+        let total = self.concentration();
+        if total <= 0.0 {
+            return 0.0;
+        }
+        (self.alpha * self.beta) / (total * total * (total + 1.0))
+    }
+}
+
+/// Clamp a persisted count into the non-negative reals.
+fn sanitize_count(count: f64) -> f64 {
+    if count.is_finite() && count > 0.0 {
+        count
     } else {
-        alpha / (alpha + beta + 1.0)
+        0.0
+    }
+}
+
+/// Clamp an observation weight; non-positive or non-finite weights record
+/// nothing rather than eroding accumulated evidence.
+fn sanitize_weight(weight: f64) -> f64 {
+    if weight.is_finite() && weight > 0.0 {
+        weight
+    } else {
+        0.0
     }
 }
 
@@ -136,39 +256,151 @@ mod tests {
         (a - b).abs() < 0.001
     }
 
+    /// One weighted observation on evidence derived from a bare mean.
+    fn one_observation(mean: f64, corroborate: bool) -> Evidence {
+        let mut evidence = Evidence::from_prior(mean);
+        if corroborate {
+            evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+        } else {
+            evidence.contradict(DEFAULT_EVIDENCE_WEIGHT);
+        }
+        evidence
+    }
+
     #[test]
-    fn bayesian_update_corroborate_0_6() {
-        let result = bayesian_update(0.6, true);
+    fn corroborate_from_prior_0_6() {
+        let result = one_observation(0.6, true).mean();
         // alpha=6, beta=4 -> (6+1)/(10+1) = 7/11 ≈ 0.636
         assert!(approx_eq(result, 0.636), "got {}", result);
     }
 
     #[test]
-    fn bayesian_update_contradict_0_6() {
-        let result = bayesian_update(0.6, false);
+    fn contradict_from_prior_0_6() {
+        let result = one_observation(0.6, false).mean();
         // alpha=6, beta=4 -> 6/(10+1) = 6/11 ≈ 0.545
         assert!(approx_eq(result, 0.545), "got {}", result);
     }
 
     #[test]
-    fn bayesian_update_corroborate_0_9() {
-        let result = bayesian_update(0.9, true);
+    fn corroborate_from_prior_0_9() {
+        let result = one_observation(0.9, true).mean();
         // alpha=9, beta=1 -> (9+1)/(10+1) = 10/11 ≈ 0.909
         assert!(approx_eq(result, 0.909), "got {}", result);
     }
 
     #[test]
-    fn bayesian_update_contradict_0_9() {
-        let result = bayesian_update(0.9, false);
+    fn contradict_from_prior_0_9() {
+        let result = one_observation(0.9, false).mean();
         // alpha=9, beta=1 -> 9/(10+1) = 9/11 ≈ 0.818
         assert!(approx_eq(result, 0.818), "got {}", result);
     }
 
     #[test]
-    fn bayesian_update_corroborate_0_3() {
-        let result = bayesian_update(0.3, true);
+    fn corroborate_from_prior_0_3() {
+        let result = one_observation(0.3, true).mean();
         // alpha=3, beta=7 -> (3+1)/(10+1) = 4/11 ≈ 0.364
         assert!(approx_eq(result, 0.364), "got {}", result);
+    }
+
+    #[test]
+    fn evidence_accumulates_across_observations() {
+        // docs/bayesian-confidence.md, worked example: an Inferred fact (0.6)
+        // corroborated three times, then contradicted once.
+        let mut evidence = Evidence::from_prior(0.6);
+        assert!(approx_eq(evidence.mean(), 0.600));
+
+        evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+        assert!(approx_eq(evidence.mean(), 0.636), "step 1: {evidence:?}");
+        evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+        assert!(approx_eq(evidence.mean(), 0.667), "step 2: {evidence:?}");
+        evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+        assert!(approx_eq(evidence.mean(), 0.692), "step 3: {evidence:?}");
+        evidence.contradict(DEFAULT_EVIDENCE_WEIGHT);
+        assert!(approx_eq(evidence.mean(), 0.643), "step 4: {evidence:?}");
+
+        assert!(approx_eq(evidence.alpha(), 9.0));
+        assert!(approx_eq(evidence.beta(), 5.0));
+        assert!(approx_eq(evidence.concentration(), 14.0));
+    }
+
+    #[test]
+    fn variance_narrows_with_corroboration() {
+        // AC1: more evidence at a comparable mean is a tighter posterior.
+        let after = |n: usize| {
+            let mut evidence = Evidence::from_prior(0.6);
+            for _ in 0..n {
+                evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+            }
+            evidence.variance()
+        };
+
+        assert!(
+            after(5) < after(1),
+            "5 obs: {} vs 1: {}",
+            after(5),
+            after(1)
+        );
+        assert!(
+            after(50) < after(5),
+            "50 obs: {} vs 5: {}",
+            after(50),
+            after(5)
+        );
+    }
+
+    #[test]
+    fn concentration_grows_by_observation_weight() {
+        let mut evidence = Evidence::from_prior(0.5);
+        assert!(approx_eq(evidence.concentration(), PRIOR_CONCENTRATION));
+
+        evidence.corroborate(0.05);
+        evidence.contradict(0.8);
+
+        assert!(approx_eq(evidence.alpha(), 5.05), "got {evidence:?}");
+        assert!(approx_eq(evidence.beta(), 5.8), "got {evidence:?}");
+        assert!(approx_eq(
+            evidence.concentration(),
+            PRIOR_CONCENTRATION + 0.85
+        ));
+    }
+
+    #[test]
+    fn non_positive_weights_record_nothing() {
+        let mut evidence = Evidence::from_prior(0.6);
+        evidence.corroborate(-1.0);
+        evidence.contradict(f64::NAN);
+
+        assert!(approx_eq(evidence.alpha(), 6.0));
+        assert!(approx_eq(evidence.beta(), 4.0));
+    }
+
+    #[test]
+    fn from_stored_prefers_persisted_counts() {
+        let persisted = Evidence::from_stored(Some(56.0), Some(4.0), 0.6);
+        assert!(approx_eq(persisted.concentration(), 60.0));
+        assert!(approx_eq(persisted.mean(), 56.0 / 60.0));
+    }
+
+    #[test]
+    fn from_stored_falls_back_to_prior_when_unmigrated() {
+        let legacy = Evidence::from_stored(None, None, 0.6);
+        assert!(approx_eq(legacy.alpha(), 6.0));
+        assert!(approx_eq(legacy.beta(), 4.0));
+        assert!(approx_eq(legacy.mean(), 0.6));
+    }
+
+    #[test]
+    fn empty_evidence_is_maximally_uncertain() {
+        let empty = Evidence::from_counts(0.0, 0.0);
+        assert!(approx_eq(empty.mean(), 0.5));
+        assert_eq!(empty.variance(), 0.0);
+    }
+
+    #[test]
+    fn corrupt_counts_are_clamped() {
+        let corrupt = Evidence::from_counts(-3.0, f64::INFINITY);
+        assert_eq!(corrupt.alpha(), 0.0);
+        assert_eq!(corrupt.beta(), 0.0);
     }
 
     #[test]

--- a/src/graph/confidence.rs
+++ b/src/graph/confidence.rs
@@ -17,10 +17,22 @@ use serde::{Deserialize, Serialize};
 /// ~10 observations to overwhelm the prior.
 pub const PRIOR_CONCENTRATION: f64 = 10.0;
 
-/// Evidence weight of a single observation whose provenance is not (yet)
-/// modelled. Provenance-weighted observations arrive in Phase 1 increment 2;
-/// until then every observation counts once.
+/// Evidence weight of a single observation whose provenance is not modelled:
+/// one observation, one count.
+///
+/// Now that observations carry a [`Provenance`], this is the provenance-blind
+/// reference behavior — what [`ProvenanceWeights::uniform`] reproduces, and
+/// what the differential test measures against.
 pub const DEFAULT_EVIDENCE_WEIGHT: f64 = 1.0;
+
+/// Default evidence weight of an observation from an independent source.
+pub const DEFAULT_WEIGHT_EXTERNAL: f64 = 1.0;
+
+/// Default evidence weight of an observation authored by the human.
+pub const DEFAULT_WEIGHT_USER: f64 = 0.8;
+
+/// Default evidence weight of the agent restating itself.
+pub const DEFAULT_WEIGHT_SELF: f64 = 0.05;
 
 /// How a relationship was established — determines initial confidence prior.
 #[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
@@ -55,6 +67,132 @@ impl std::str::FromStr for ExtractionContext {
             "speculative" => Ok(Self::Speculative),
             "authoritative" => Ok(Self::Authoritative),
             other => Err(format!("unknown extraction context: {other}")),
+        }
+    }
+}
+
+// ── Provenance ───────────────────────────────────────────────────────
+//
+// Who authored the text an observation came from. Recorded at write time
+// because it cannot be recovered afterwards: nothing in a store of unlabelled
+// episodes distinguishes an independent report from the agent restating
+// itself. Collapsing three classes into two at scoring time is always
+// possible; splitting one class back into three is not.
+
+/// The authorship class of an episode, and of every confidence-moving
+/// observation drawn from it.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Provenance {
+    /// Ingested documents, web content, tool output — sources independent of
+    /// the agent.
+    External,
+    /// Statements authored by the human in conversation.
+    User,
+    /// The agent's own summaries, reflections and re-assertions — and the
+    /// default for anything unlabelled, so unknown evidence never earns full
+    /// weight.
+    #[default]
+    #[serde(rename = "self")]
+    SelfGenerated,
+}
+
+impl Provenance {
+    /// The class of a value read from the store, which may be absent (an
+    /// episode written before provenance existed) or unrecognised (written by
+    /// a newer build, or by hand).
+    ///
+    /// Both resolve to [`Provenance::SelfGenerated`]: a legacy store never
+    /// gains confidence from backfilled data.
+    #[must_use]
+    pub fn from_stored(stored: Option<&str>) -> Self {
+        stored
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(Self::SelfGenerated)
+    }
+
+    /// The string persisted on an episode and accepted on the CLI.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::External => "external",
+            Self::User => "user",
+            Self::SelfGenerated => "self",
+        }
+    }
+}
+
+impl std::str::FromStr for Provenance {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.trim().to_lowercase().as_str() {
+            "external" | "document" => Ok(Self::External),
+            "user" | "human" => Ok(Self::User),
+            "self" | "agent" | "self-generated" => Ok(Self::SelfGenerated),
+            other => Err(format!("unknown provenance: {other}")),
+        }
+    }
+}
+
+impl std::fmt::Display for Provenance {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Evidence weight of one observation, by provenance class.
+///
+/// Corroboration adds the weight to α, contradiction adds it to β. The
+/// defaults say an independent source counts fully, the human counts nearly
+/// fully, and the agent restating itself counts for almost nothing — which is
+/// the point of the whole mechanism: repetition by a single source is
+/// coherence, not evidence.
+///
+/// Maps to the `[graph.provenance]` section of `.recall-echo.toml`.
+#[derive(Debug, Clone, Copy, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ProvenanceWeights {
+    /// Weight of an [`Provenance::External`] observation. Default `1.0`.
+    pub weight_external: f64,
+    /// Weight of a [`Provenance::User`] observation. Default `0.8`.
+    pub weight_user: f64,
+    /// Weight of a [`Provenance::SelfGenerated`] observation. Default `0.05`.
+    pub weight_self: f64,
+}
+
+impl Default for ProvenanceWeights {
+    fn default() -> Self {
+        Self {
+            weight_external: DEFAULT_WEIGHT_EXTERNAL,
+            weight_user: DEFAULT_WEIGHT_USER,
+            weight_self: DEFAULT_WEIGHT_SELF,
+        }
+    }
+}
+
+impl ProvenanceWeights {
+    /// Weight every class identically — the provenance-blind escape hatch.
+    ///
+    /// `uniform(DEFAULT_EVIDENCE_WEIGHT)` reproduces pre-provenance behavior
+    /// exactly, which is what makes provenance weighting differentially
+    /// testable.
+    #[must_use]
+    pub fn uniform(weight: f64) -> Self {
+        Self {
+            weight_external: weight,
+            weight_user: weight,
+            weight_self: weight,
+        }
+    }
+
+    /// Evidence weight of one observation authored by `provenance`.
+    #[must_use]
+    pub fn for_provenance(&self, provenance: Provenance) -> f64 {
+        match provenance {
+            Provenance::External => self.weight_external,
+            Provenance::User => self.weight_user,
+            Provenance::SelfGenerated => self.weight_self,
         }
     }
 }
@@ -182,6 +320,60 @@ fn sanitize_weight(weight: f64) -> f64 {
         weight
     } else {
         0.0
+    }
+}
+
+/// Everything one edge persists about why it is believed: the Beta counts
+/// that move confidence, and the coherence counter that must not.
+///
+/// A self-authored corroboration is weighted into α like any other
+/// observation — at the (normally tiny) self weight — *and* tallied in
+/// `self_reinforcements`. Keeping the tally separate is what lets "believed
+/// because three independent sources said so" stay distinguishable from
+/// "believed because the agent has said it thirty times".
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct EdgeEvidence {
+    evidence: Evidence,
+    self_reinforcements: i64,
+}
+
+impl EdgeEvidence {
+    /// Evidence state as read from an edge. A negative stored tally (only
+    /// reachable by hand-editing the store) is treated as zero.
+    #[must_use]
+    pub fn new(evidence: Evidence, self_reinforcements: i64) -> Self {
+        Self {
+            evidence,
+            self_reinforcements: self_reinforcements.max(0),
+        }
+    }
+
+    /// Record corroboration authored by `provenance`.
+    pub fn corroborate(&mut self, provenance: Provenance, weights: &ProvenanceWeights) {
+        self.evidence
+            .corroborate(weights.for_provenance(provenance));
+        if provenance == Provenance::SelfGenerated {
+            self.self_reinforcements += 1;
+        }
+    }
+
+    /// Record contradiction authored by `provenance`.
+    ///
+    /// Contradicting yourself is not coherence: the tally does not move.
+    pub fn contradict(&mut self, provenance: Provenance, weights: &ProvenanceWeights) {
+        self.evidence.contradict(weights.for_provenance(provenance));
+    }
+
+    /// The Beta pseudo-counts.
+    #[must_use]
+    pub fn evidence(self) -> Evidence {
+        self.evidence
+    }
+
+    /// How many corroborations the agent produced itself.
+    #[must_use]
+    pub fn self_reinforcements(self) -> i64 {
+        self.self_reinforcements
     }
 }
 
@@ -401,6 +593,134 @@ mod tests {
         let corrupt = Evidence::from_counts(-3.0, f64::INFINITY);
         assert_eq!(corrupt.alpha(), 0.0);
         assert_eq!(corrupt.beta(), 0.0);
+    }
+
+    #[test]
+    fn default_weights_rank_independence_above_repetition() {
+        let weights = ProvenanceWeights::default();
+        assert!(approx_eq(
+            weights.for_provenance(Provenance::External),
+            DEFAULT_WEIGHT_EXTERNAL
+        ));
+        assert!(approx_eq(
+            weights.for_provenance(Provenance::User),
+            DEFAULT_WEIGHT_USER
+        ));
+        assert!(approx_eq(
+            weights.for_provenance(Provenance::SelfGenerated),
+            DEFAULT_WEIGHT_SELF
+        ));
+        assert!(weights.weight_external > weights.weight_user);
+        assert!(weights.weight_user > weights.weight_self);
+    }
+
+    #[test]
+    fn uniform_weights_are_provenance_blind() {
+        let weights = ProvenanceWeights::uniform(DEFAULT_EVIDENCE_WEIGHT);
+        for provenance in [
+            Provenance::External,
+            Provenance::User,
+            Provenance::SelfGenerated,
+        ] {
+            assert_eq!(
+                weights.for_provenance(provenance),
+                DEFAULT_EVIDENCE_WEIGHT,
+                "{provenance} must weigh the same as every other class"
+            );
+        }
+    }
+
+    #[test]
+    fn provenance_parses_and_renders() {
+        assert_eq!("external".parse::<Provenance>(), Ok(Provenance::External));
+        assert_eq!("User".parse::<Provenance>(), Ok(Provenance::User));
+        assert_eq!(
+            " SELF ".parse::<Provenance>(),
+            Ok(Provenance::SelfGenerated)
+        );
+        assert!("mostly-true".parse::<Provenance>().is_err());
+
+        assert_eq!(Provenance::External.to_string(), "external");
+        assert_eq!(Provenance::User.to_string(), "user");
+        assert_eq!(Provenance::SelfGenerated.to_string(), "self");
+    }
+
+    #[test]
+    fn stored_provenance_defaults_to_self() {
+        // AC7: absent and unrecognised both land on the conservative class.
+        assert_eq!(Provenance::from_stored(None), Provenance::SelfGenerated);
+        assert_eq!(
+            Provenance::from_stored(Some("nonsense")),
+            Provenance::SelfGenerated
+        );
+        assert_eq!(
+            Provenance::from_stored(Some("external")),
+            Provenance::External
+        );
+    }
+
+    #[test]
+    fn provenance_serde_uses_wire_names() {
+        for (provenance, wire) in [
+            (Provenance::External, "\"external\""),
+            (Provenance::User, "\"user\""),
+            (Provenance::SelfGenerated, "\"self\""),
+        ] {
+            assert_eq!(serde_json::to_string(&provenance).unwrap(), wire);
+            assert_eq!(
+                serde_json::from_str::<Provenance>(wire).unwrap(),
+                provenance
+            );
+        }
+    }
+
+    #[test]
+    fn self_corroboration_is_counted_separately_from_confidence() {
+        let weights = ProvenanceWeights::default();
+        let mut edge = EdgeEvidence::new(Evidence::from_prior(0.6), 0);
+
+        for _ in 0..3 {
+            edge.corroborate(Provenance::SelfGenerated, &weights);
+        }
+        edge.corroborate(Provenance::External, &weights);
+        edge.contradict(Provenance::SelfGenerated, &weights);
+
+        assert_eq!(
+            edge.self_reinforcements(),
+            3,
+            "only self-corroboration is coherence"
+        );
+        assert!(approx_eq(edge.evidence().alpha(), 6.0 + 0.15 + 1.0));
+        assert!(approx_eq(edge.evidence().beta(), 4.0 + 0.05));
+    }
+
+    #[test]
+    fn external_contradiction_outweighs_accumulated_self_corroboration() {
+        // AC2: twenty self-corroborations are erased by a single independent
+        // contradiction at the default weights.
+        let weights = ProvenanceWeights::default();
+        let mut edge = EdgeEvidence::new(Evidence::from_prior(0.6), 0);
+        let before = edge.evidence().mean();
+
+        for _ in 0..20 {
+            edge.corroborate(Provenance::SelfGenerated, &weights);
+        }
+        let after_coherence = edge.evidence().mean();
+        assert!(after_coherence > before);
+        assert_eq!(edge.self_reinforcements(), 20);
+
+        edge.contradict(Provenance::External, &weights);
+        assert!(
+            edge.evidence().mean() < before,
+            "one external contradiction must undo the whole coherence run: {} vs {before}",
+            edge.evidence().mean()
+        );
+    }
+
+    #[test]
+    fn negative_stored_tally_is_clamped() {
+        let edge = EdgeEvidence::new(Evidence::from_prior(0.5), -7);
+        assert_eq!(edge.self_reinforcements(), 0);
     }
 
     #[test]

--- a/src/graph/crud.rs
+++ b/src/graph/crud.rs
@@ -2,6 +2,7 @@
 
 use surrealdb::Surreal;
 
+use super::confidence::Evidence;
 use super::embed::Embedder;
 use super::error::GraphError;
 use super::store::Db;
@@ -180,6 +181,12 @@ pub async fn add_relationship(
     let from_id = from.id_string();
     let to_id = to.id_string();
 
+    // A new edge starts at the prior: its mean is the requested confidence,
+    // its concentration is PRIOR_CONCENTRATION. The mean is stored as
+    // requested rather than re-derived, so creation is bit-for-bit unchanged.
+    let confidence = rel.confidence.unwrap_or(1.0) as f64;
+    let evidence = Evidence::from_prior(confidence);
+
     let mut response = db
         .query(
             r#"
@@ -191,6 +198,9 @@ pub async fn add_relationship(
                 valid_from = time::now(),
                 valid_until = NONE,
                 confidence = $confidence,
+                alpha = $alpha,
+                beta = $beta,
+                self_reinforcements = 0,
                 last_reinforced = time::now(),
                 source = $source
             "#,
@@ -199,7 +209,9 @@ pub async fn add_relationship(
         .bind(("to_id", to_id))
         .bind(("rel_type", rel.rel_type))
         .bind(("description", rel.description))
-        .bind(("confidence", rel.confidence.unwrap_or(1.0) as f64))
+        .bind(("confidence", confidence))
+        .bind(("alpha", evidence.alpha()))
+        .bind(("beta", evidence.beta()))
         .bind(("source", rel.source))
         .await?;
 
@@ -236,34 +248,50 @@ pub async fn get_relationships(
     deserialize_take(&mut response, 0)
 }
 
-/// Update a relationship's confidence score.
+/// Overwrite a relationship's confidence, discarding its accumulated evidence.
+///
+/// This is an assertion of a mean, not an observation: the edge is reset to the
+/// prior concentration around the new value, so the stored counts keep matching
+/// the stored mean. Use [`reinforce_relationship`] to *add* evidence.
 pub async fn update_relationship_confidence(
     db: &Surreal<Db>,
     rel_id: &str,
     confidence: f64,
 ) -> Result<(), GraphError> {
-    db.query("UPDATE type::record($id) SET confidence = $confidence")
+    let evidence = Evidence::from_prior(confidence);
+    db.query("UPDATE type::record($id) SET confidence = $confidence, alpha = $alpha, beta = $beta")
         .bind(("id", rel_id.to_string()))
         .bind(("confidence", confidence))
+        .bind(("alpha", evidence.alpha()))
+        .bind(("beta", evidence.beta()))
         .await?
         .check()?;
     Ok(())
 }
 
-/// Reinforce a relationship: Bayesian update + reset last_reinforced timestamp.
+/// Persist updated evidence for a relationship and reset its decay clock.
 ///
-/// Called when a relationship is corroborated by re-extraction. Updates confidence
-/// via Bayesian posterior and resets the decay clock by setting `last_reinforced = now`.
+/// Called when a relationship is corroborated (or contradicted) by
+/// re-extraction: the caller loads the edge's [`Evidence`], records the
+/// observation, and hands the result here. The stored `confidence` is the
+/// posterior mean of the new counts, and `last_reinforced = now` restarts
+/// temporal decay.
 pub async fn reinforce_relationship(
     db: &Surreal<Db>,
     rel_id: &str,
-    new_confidence: f64,
+    evidence: Evidence,
 ) -> Result<(), GraphError> {
     db.query(
-        "UPDATE type::record($id) SET confidence = $confidence, last_reinforced = time::now()",
+        r#"UPDATE type::record($id) SET
+               confidence = $confidence,
+               alpha = $alpha,
+               beta = $beta,
+               last_reinforced = time::now()"#,
     )
     .bind(("id", rel_id.to_string()))
-    .bind(("confidence", new_confidence))
+    .bind(("confidence", evidence.mean()))
+    .bind(("alpha", evidence.alpha()))
+    .bind(("beta", evidence.beta()))
     .await?
     .check()?;
     Ok(())

--- a/src/graph/crud.rs
+++ b/src/graph/crud.rs
@@ -473,6 +473,33 @@ pub async fn get_episodes_by_session(
     deserialize_take(&mut response, 0)
 }
 
+/// Delete a single episode by its record ID.
+pub async fn delete_episode(db: &Surreal<Db>, id: &str) -> Result<(), GraphError> {
+    db.query("DELETE FROM type::record($id)")
+        .bind(("id", id.to_string()))
+        .await?
+        .check()?;
+    Ok(())
+}
+
+/// Batch increment episode retrieval counts.
+///
+/// Coalesces the absent case: episodes written before the counter existed
+/// read as NONE, and `NONE + 1` is not a count.
+pub async fn increment_episode_access_counts(
+    db: &Surreal<Db>,
+    ids: &[String],
+) -> Result<(), GraphError> {
+    for id in ids {
+        let _ = db
+            .query("UPDATE type::record($id) SET access_count = (access_count ?? 0) + 1")
+            .bind(("id", id.clone()))
+            .await;
+    }
+
+    Ok(())
+}
+
 /// Mark all episodes with a given log_number as extracted.
 pub async fn mark_episodes_extracted(db: &Surreal<Db>, log_number: u32) -> Result<(), GraphError> {
     db.query("UPDATE episode SET extracted = true WHERE log_number = $ln")

--- a/src/graph/crud.rs
+++ b/src/graph/crud.rs
@@ -2,7 +2,7 @@
 
 use surrealdb::Surreal;
 
-use super::confidence::Evidence;
+use super::confidence::{EdgeEvidence, Evidence, Provenance};
 use super::embed::Embedder;
 use super::error::GraphError;
 use super::store::Db;
@@ -272,26 +272,34 @@ pub async fn update_relationship_confidence(
 /// Persist updated evidence for a relationship and reset its decay clock.
 ///
 /// Called when a relationship is corroborated (or contradicted) by
-/// re-extraction: the caller loads the edge's [`Evidence`], records the
-/// observation, and hands the result here. The stored `confidence` is the
-/// posterior mean of the new counts, and `last_reinforced = now` restarts
-/// temporal decay.
+/// re-extraction: the caller loads the edge's [`EdgeEvidence`], records the
+/// observation with its provenance, and hands the result here. The stored
+/// `confidence` is the posterior mean of the new counts, `self_reinforcements`
+/// is the coherence tally kept out of that mean, and `last_reinforced = now`
+/// restarts temporal decay.
+///
+/// The counts are written whole rather than incremented in SurrealQL: the
+/// caller has already read them, and a full write keeps mean and counts from
+/// ever disagreeing.
 pub async fn reinforce_relationship(
     db: &Surreal<Db>,
     rel_id: &str,
-    evidence: Evidence,
+    evidence: EdgeEvidence,
 ) -> Result<(), GraphError> {
+    let counts = evidence.evidence();
     db.query(
         r#"UPDATE type::record($id) SET
                confidence = $confidence,
                alpha = $alpha,
                beta = $beta,
+               self_reinforcements = $self_reinforcements,
                last_reinforced = time::now()"#,
     )
     .bind(("id", rel_id.to_string()))
-    .bind(("confidence", evidence.mean()))
-    .bind(("alpha", evidence.alpha()))
-    .bind(("beta", evidence.beta()))
+    .bind(("confidence", counts.mean()))
+    .bind(("alpha", counts.alpha()))
+    .bind(("beta", counts.beta()))
+    .bind(("self_reinforcements", evidence.self_reinforcements()))
     .await?
     .check()?;
     Ok(())
@@ -397,11 +405,30 @@ pub async fn increment_access_counts(db: &Surreal<Db>, ids: &[String]) -> Result
 
 // ── Episode CRUD ─────────────────────────────────────────────────────
 
-/// Add a new episode to the graph. Embeds the abstract text for vector search.
+/// Add a new episode authored by the agent itself.
+///
+/// The conservative default for callers that cannot say where the text came
+/// from: unattributed text must never be counted as independent evidence.
 pub async fn add_episode(
     db: &Surreal<Db>,
     embedder: &dyn Embedder,
     episode: NewEpisode,
+) -> Result<Episode, GraphError> {
+    add_episode_from(db, embedder, episode, Provenance::SelfGenerated).await
+}
+
+/// Add a new episode stamped with who authored it. Embeds the abstract text
+/// for vector search.
+///
+/// Provenance is an argument rather than a field of [`NewEpisode`] because it
+/// is a property of the *ingestion context*, not of the text: the same chunk
+/// is external when read out of a document and self-authored when the agent
+/// wrote it.
+pub async fn add_episode_from(
+    db: &Surreal<Db>,
+    embedder: &dyn Embedder,
+    episode: NewEpisode,
+    provenance: Provenance,
 ) -> Result<Episode, GraphError> {
     let embedding = embedder.embed_single(&episode.abstract_text)?;
 
@@ -415,7 +442,8 @@ pub async fn add_episode(
                 overview = $overview,
                 content = $content,
                 embedding = $embedding,
-                log_number = $log_number
+                log_number = $log_number,
+                provenance = $provenance
             "#,
         )
         .bind(("session_id", episode.session_id))
@@ -424,6 +452,7 @@ pub async fn add_episode(
         .bind(("content", episode.content))
         .bind(("embedding", embedding))
         .bind(("log_number", episode.log_number.map(|n| n as i64)))
+        .bind(("provenance", provenance.as_str().to_string()))
         .await?;
 
     let created: Option<Episode> = deserialize_take_opt(&mut response, 0)?;

--- a/src/graph/gc.rs
+++ b/src/graph/gc.rs
@@ -1,16 +1,25 @@
 //! Garbage collection for the knowledge graph.
 //!
-//! Four-phase sweep: stale relationships → dead relationships → orphaned entities → delete.
-//! Dry-run by default. Pipeline-linked entities are protected.
+//! Sweep order: stale relationships → dead relationships → orphaned entities →
+//! spent episodes → delete. Dry-run by default. Pipeline-linked entities are
+//! protected, and so is anything a surviving record cites as its source.
+
+use std::collections::HashSet;
 
 use chrono::{DateTime, Utc};
 use surrealdb::Surreal;
 
-use super::confidence;
+use super::confidence::{self, Provenance};
 use super::crud;
 use super::error::GraphError;
 use super::store::Db;
 use super::types::{Entity, Relationship};
+
+/// Default age, in days, before a never-retrieved episode may be collected.
+///
+/// Two confidence half-lives: an episode nothing has read in half a year, and
+/// which no surviving entity or edge cites, is storage rather than memory.
+pub const DEFAULT_EPISODE_MAX_AGE_DAYS: u64 = 180;
 
 /// Configuration for garbage collection thresholds.
 #[derive(Debug, Clone)]
@@ -23,6 +32,11 @@ pub struct GcConfig {
     pub dead_confidence: f64,
     /// Minimum age in days for dead relationship pruning.
     pub dead_min_age_days: u64,
+    /// If true, also sweep episodes. Off by default: the relationship sweep
+    /// predates episode collection and must keep behaving as it did.
+    pub collect_episodes: bool,
+    /// Days since an episode's timestamp before it may be collected.
+    pub episode_max_age_days: u64,
     /// If true, only report — don't delete anything.
     pub dry_run: bool,
     /// If true, never GC entities linked to pipeline documents.
@@ -36,6 +50,8 @@ impl Default for GcConfig {
             stale_confidence: 0.5,
             dead_confidence: 0.2,
             dead_min_age_days: 14,
+            collect_episodes: false,
+            episode_max_age_days: DEFAULT_EPISODE_MAX_AGE_DAYS,
             dry_run: true,
             protect_pipeline: true,
         }
@@ -57,6 +73,7 @@ pub enum GcActionKind {
     StaleRelationship,
     DeadRelationship,
     OrphanedEntity,
+    SpentEpisode,
 }
 
 impl std::fmt::Display for GcActionKind {
@@ -65,6 +82,7 @@ impl std::fmt::Display for GcActionKind {
             Self::StaleRelationship => write!(f, "stale_relationship"),
             Self::DeadRelationship => write!(f, "dead_relationship"),
             Self::OrphanedEntity => write!(f, "orphaned_entity"),
+            Self::SpentEpisode => write!(f, "spent_episode"),
         }
     }
 }
@@ -74,9 +92,11 @@ impl std::fmt::Display for GcActionKind {
 pub struct GcReport {
     pub entities_scanned: u64,
     pub relationships_scanned: u64,
+    pub episodes_scanned: u64,
     pub stale_relationships: u64,
     pub dead_relationships: u64,
     pub orphaned_entities: u64,
+    pub spent_episodes: u64,
     pub total_removed: u64,
     pub dry_run: bool,
     pub actions: Vec<GcAction>,
@@ -112,7 +132,15 @@ pub async fn run_gc(db: &Surreal<Db>, config: &GcConfig) -> Result<GcReport, Gra
     let orphan_ids =
         phase_orphaned_entities(db, &all_entities, config, &rel_ids_to_delete, &mut report).await?;
 
-    // Phase 4: Execute deletions
+    // Phase 4: Spent episodes (must account for everything above being removed:
+    // an episode is evidence only for records that survive the sweep)
+    let pending = Pending {
+        relationships: &rel_ids_to_delete,
+        entities: &orphan_ids,
+    };
+    let episode_ids = phase_spent_episodes(db, config, &now, &pending, &mut report).await?;
+
+    // Phase 5: Execute deletions
     if !config.dry_run {
         for rel_id in &rel_ids_to_delete {
             if let Err(e) = crud::delete_relationship(db, rel_id).await {
@@ -133,11 +161,29 @@ pub async fn run_gc(db: &Surreal<Db>, config: &GcConfig) -> Result<GcReport, Gra
                 report.total_removed += 1;
             }
         }
+
+        for episode_id in &episode_ids {
+            if let Err(e) = crud::delete_episode(db, episode_id).await {
+                report
+                    .errors
+                    .push(format!("Failed to delete episode {episode_id}: {e}"));
+            } else {
+                report.total_removed += 1;
+            }
+        }
     } else {
-        report.total_removed = rel_ids_to_delete.len() as u64 + orphan_ids.len() as u64;
+        report.total_removed =
+            (rel_ids_to_delete.len() + orphan_ids.len() + episode_ids.len()) as u64;
     }
 
     Ok(report)
+}
+
+/// Records this sweep has already decided to remove. Episode collection reads
+/// it so that "cited by a surviving record" means what it says.
+struct Pending<'a> {
+    relationships: &'a [String],
+    entities: &'a [String],
 }
 
 /// Phase 1: Find relationships older than stale_days with effective confidence below stale_confidence.
@@ -369,6 +415,163 @@ async fn count_pending_deletions_for_entity(
     Ok(count as u64)
 }
 
+// ── Episodes ─────────────────────────────────────────────────────────
+//
+// Episodes are the raw text a session left behind. The graph does not link
+// them to entities or edges directly; the one linkage the schema has is by
+// session: entities and relationships extracted from a session carry its id
+// in `source`. So "evidence for a surviving record" is exactly "some record
+// that survives this sweep cites my session as its source", and an episode is
+// collectable only when it is old, never retrieved, self-authored, and cited
+// by nothing.
+
+/// The scan projection for an episode: everything the sweep judges on, and
+/// nothing it does not — no content, no embedding.
+#[derive(Debug, Clone, serde::Deserialize)]
+struct EpisodeRow {
+    id: serde_json::Value,
+    session_id: String,
+    timestamp: serde_json::Value,
+    #[serde(default)]
+    log_number: Option<i64>,
+    #[serde(default)]
+    provenance: Option<String>,
+    #[serde(default, deserialize_with = "super::util::count_or_zero")]
+    access_count: i64,
+}
+
+impl EpisodeRow {
+    fn id_string(&self) -> String {
+        value_to_record_id(&self.id)
+    }
+
+    /// Who authored this episode; absent and unrecognised resolve to `self`.
+    fn provenance(&self) -> Provenance {
+        Provenance::from_stored(self.provenance.as_deref())
+    }
+
+    /// How this episode reads in a GC report.
+    fn label(&self) -> String {
+        match self.log_number {
+            Some(n) => format!("{} (log {n:03})", self.session_id),
+            None => self.session_id.clone(),
+        }
+    }
+}
+
+/// Phase 4: find episodes nothing needs any more.
+async fn phase_spent_episodes(
+    db: &Surreal<Db>,
+    config: &GcConfig,
+    now: &DateTime<Utc>,
+    pending: &Pending<'_>,
+    report: &mut GcReport,
+) -> Result<Vec<String>, GraphError> {
+    if !config.collect_episodes {
+        return Ok(Vec::new());
+    }
+
+    let episodes = load_episode_rows(db).await?;
+    report.episodes_scanned = episodes.len() as u64;
+
+    let cited = cited_session_ids(db, pending).await?;
+    let mut spent_ids = Vec::new();
+
+    for episode in &episodes {
+        let Some(reason) = episode_prune_reason(episode, &cited, config, now) else {
+            continue;
+        };
+
+        report.actions.push(GcAction {
+            target_id: episode.id_string(),
+            target_name: episode.label(),
+            kind: GcActionKind::SpentEpisode,
+            reason,
+        });
+        spent_ids.push(episode.id_string());
+        report.spent_episodes += 1;
+    }
+
+    Ok(spent_ids)
+}
+
+/// Why this episode is collectable, or `None` if it is not.
+///
+/// All four conditions must hold, and the order is cheapest-first:
+/// never retrieved, self-authored, cited by no surviving record, older than
+/// the configured age. An unparseable timestamp keeps the episode.
+fn episode_prune_reason(
+    episode: &EpisodeRow,
+    cited_sessions: &HashSet<String>,
+    config: &GcConfig,
+    now: &DateTime<Utc>,
+) -> Option<String> {
+    if episode.access_count > 0 {
+        return None;
+    }
+    if episode.provenance() != Provenance::SelfGenerated {
+        return None;
+    }
+    if cited_sessions.contains(&episode.session_id) {
+        return None;
+    }
+
+    let age_days = (*now - parse_datetime(&episode.timestamp)?).num_days();
+    if age_days < config.episode_max_age_days as i64 {
+        return None;
+    }
+
+    Some(format!(
+        "age {age_days} days > {}, never retrieved, provenance self, session {} cited by nothing",
+        config.episode_max_age_days, episode.session_id
+    ))
+}
+
+/// Load every episode's judgeable fields.
+async fn load_episode_rows(db: &Surreal<Db>) -> Result<Vec<EpisodeRow>, GraphError> {
+    let mut response = db
+        .query(
+            "SELECT id, session_id, timestamp, log_number, provenance, access_count FROM episode",
+        )
+        .await?;
+
+    super::deserialize_take(&mut response, 0)
+}
+
+/// Session ids cited as `source` by records that survive this sweep.
+async fn cited_session_ids(
+    db: &Surreal<Db>,
+    pending: &Pending<'_>,
+) -> Result<HashSet<String>, GraphError> {
+    #[derive(serde::Deserialize)]
+    struct SourceRow {
+        id: serde_json::Value,
+        source: Option<String>,
+    }
+
+    let mut cited = HashSet::new();
+
+    for (table, doomed) in [
+        ("relates_to", pending.relationships),
+        ("entity", pending.entities),
+    ] {
+        let query = format!("SELECT id, source FROM {table} WHERE source IS NOT NONE");
+        let mut response = db.query(&query).await?;
+        let rows: Vec<SourceRow> = super::deserialize_take(&mut response, 0)?;
+
+        for row in rows {
+            if doomed.contains(&value_to_record_id(&row.id)) {
+                continue;
+            }
+            if let Some(source) = row.source {
+                cited.insert(source);
+            }
+        }
+    }
+
+    Ok(cited)
+}
+
 /// Check if an entity is linked to a pipeline document.
 fn is_pipeline_entity(entity: &Entity) -> bool {
     // Check source field
@@ -394,6 +597,14 @@ use super::util::parse_datetime;
 fn value_to_short_id(val: &serde_json::Value) -> String {
     match val {
         serde_json::Value::String(s) => s.split(':').next_back().unwrap_or(s).to_string(),
+        other => other.to_string(),
+    }
+}
+
+/// Render a record ID value whole (e.g. "entity:abc"), as deletion needs it.
+fn value_to_record_id(val: &serde_json::Value) -> String {
+    match val {
+        serde_json::Value::String(s) => s.clone(),
         other => other.to_string(),
     }
 }
@@ -760,6 +971,169 @@ mod tests {
             "dead_relationship"
         );
         assert_eq!(GcActionKind::OrphanedEntity.to_string(), "orphaned_entity");
+        assert_eq!(GcActionKind::SpentEpisode.to_string(), "spent_episode");
+    }
+
+    // ── Episode collection ───────────────────────────────────────────
+
+    /// An episode as old as `age_days`, never retrieved, self-authored — the
+    /// shape that is collectable unless a test says otherwise.
+    fn spent_episode(age_days: i64) -> EpisodeRow {
+        EpisodeRow {
+            id: serde_json::Value::String("episode:old".to_string()),
+            session_id: "session-1".to_string(),
+            timestamp: serde_json::Value::String(
+                (Utc::now() - chrono::Duration::days(age_days)).to_rfc3339(),
+            ),
+            log_number: Some(7),
+            provenance: Some("self".to_string()),
+            access_count: 0,
+        }
+    }
+
+    fn cited(sessions: &[&str]) -> HashSet<String> {
+        sessions.iter().map(|s| (*s).to_string()).collect()
+    }
+
+    #[test]
+    fn old_unread_self_authored_episode_is_collectable() {
+        let reason = episode_prune_reason(
+            &spent_episode(200),
+            &HashSet::new(),
+            &GcConfig::default(),
+            &Utc::now(),
+        );
+        let reason = reason.expect("200-day-old orphan episode should be a candidate");
+        assert!(reason.contains("never retrieved"), "{reason}");
+        assert!(reason.contains("session session-1"), "{reason}");
+    }
+
+    #[test]
+    fn young_episode_survives() {
+        assert!(episode_prune_reason(
+            &spent_episode(179),
+            &HashSet::new(),
+            &GcConfig::default(),
+            &Utc::now(),
+        )
+        .is_none());
+    }
+
+    #[test]
+    fn retrieved_episode_survives_any_age() {
+        let mut episode = spent_episode(3650);
+        episode.access_count = 1;
+
+        assert!(
+            episode_prune_reason(&episode, &HashSet::new(), &GcConfig::default(), &Utc::now())
+                .is_none(),
+            "an episode retrieval has returned is not spent"
+        );
+    }
+
+    #[test]
+    fn non_self_authored_episodes_survive_any_age() {
+        // The human's words and ingested documents are not the agent's to
+        // discard: they are the only evidence in the store that is not the
+        // agent restating itself.
+        for class in ["user", "external"] {
+            let mut episode = spent_episode(3650);
+            episode.provenance = Some(class.to_string());
+
+            assert!(
+                episode_prune_reason(&episode, &HashSet::new(), &GcConfig::default(), &Utc::now())
+                    .is_none(),
+                "{class}-authored episodes must survive"
+            );
+        }
+    }
+
+    #[test]
+    fn legacy_episodes_without_provenance_are_collectable() {
+        // AC7's conservative default cuts the other way here: unlabelled text
+        // reads as self-authored, and self-authored text is collectable.
+        let mut episode = spent_episode(200);
+        episode.provenance = None;
+
+        assert!(
+            episode_prune_reason(&episode, &HashSet::new(), &GcConfig::default(), &Utc::now())
+                .is_some()
+        );
+    }
+
+    #[test]
+    fn episode_cited_as_evidence_survives_any_age() {
+        let episode = spent_episode(3650);
+
+        assert!(
+            episode_prune_reason(
+                &episode,
+                &cited(&["session-1"]),
+                &GcConfig::default(),
+                &Utc::now()
+            )
+            .is_none(),
+            "an episode a surviving record cites is evidence, not garbage"
+        );
+        assert!(
+            episode_prune_reason(
+                &episode,
+                &cited(&["some-other-session"]),
+                &GcConfig::default(),
+                &Utc::now()
+            )
+            .is_some(),
+            "another session's citation protects nothing here"
+        );
+    }
+
+    #[test]
+    fn unparseable_timestamp_keeps_the_episode() {
+        let mut episode = spent_episode(200);
+        episode.timestamp = serde_json::Value::String("not-a-date".to_string());
+
+        assert!(
+            episode_prune_reason(&episode, &HashSet::new(), &GcConfig::default(), &Utc::now())
+                .is_none(),
+            "an episode whose age cannot be established is never collected"
+        );
+    }
+
+    #[test]
+    fn episode_age_threshold_is_configurable() {
+        let config = GcConfig {
+            episode_max_age_days: 30,
+            ..Default::default()
+        };
+
+        assert!(
+            episode_prune_reason(&spent_episode(31), &HashSet::new(), &config, &Utc::now())
+                .is_some()
+        );
+        assert!(
+            episode_prune_reason(&spent_episode(29), &HashSet::new(), &config, &Utc::now())
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn episode_labels_carry_the_log_number_when_there_is_one() {
+        assert_eq!(spent_episode(1).label(), "session-1 (log 007)");
+
+        let mut unnumbered = spent_episode(1);
+        unnumbered.log_number = None;
+        assert_eq!(unnumbered.label(), "session-1");
+    }
+
+    #[test]
+    fn episode_collection_is_off_by_default() {
+        let config = GcConfig::default();
+        assert!(!config.collect_episodes, "episodes are opt-in");
+        assert_eq!(config.episode_max_age_days, DEFAULT_EPISODE_MAX_AGE_DAYS);
+        assert!(
+            config.dry_run,
+            "and the sweep still only reports by default"
+        );
     }
 
     #[test]

--- a/src/graph/gc.rs
+++ b/src/graph/gc.rs
@@ -591,6 +591,9 @@ mod tests {
             valid_from: serde_json::Value::String(old_date),
             valid_until: None,
             confidence: 0.3,
+            alpha: Some(3.0),
+            beta: Some(7.0),
+            self_reinforcements: Some(0),
             last_reinforced: None,
             source: Some("ingest".to_string()),
         }];
@@ -617,6 +620,9 @@ mod tests {
             valid_from: serde_json::Value::String(old_date),
             valid_until: None,
             confidence: 0.8,
+            alpha: Some(8.0),
+            beta: Some(2.0),
+            self_reinforcements: Some(0),
             last_reinforced: None,
             source: None,
         }];
@@ -642,6 +648,9 @@ mod tests {
             valid_from: serde_json::Value::String(recent_date),
             valid_until: None,
             confidence: 0.3,
+            alpha: Some(3.0),
+            beta: Some(7.0),
+            self_reinforcements: Some(0),
             last_reinforced: None,
             source: None,
         }];
@@ -667,6 +676,9 @@ mod tests {
             valid_from: serde_json::Value::String(old_date.clone()),
             valid_until: Some(serde_json::Value::String(old_date)),
             confidence: 0.3,
+            alpha: Some(3.0),
+            beta: Some(7.0),
+            self_reinforcements: Some(0),
             last_reinforced: None,
             source: None,
         }];
@@ -692,6 +704,9 @@ mod tests {
             valid_from: serde_json::Value::String(old_date),
             valid_until: None,
             confidence: 0.1,
+            alpha: Some(1.0),
+            beta: Some(9.0),
+            self_reinforcements: Some(0),
             last_reinforced: None,
             source: None,
         }];
@@ -719,6 +734,9 @@ mod tests {
             valid_from: serde_json::Value::String(old_date),
             valid_until: None,
             confidence: 0.1,
+            alpha: Some(1.0),
+            beta: Some(9.0),
+            self_reinforcements: Some(0),
             last_reinforced: None,
             source: None,
         }];
@@ -759,7 +777,10 @@ mod tests {
             description: Some("decayed rel".to_string()),
             valid_from: serde_json::Value::String(old_date),
             valid_until: None,
-            confidence: 0.6,       // Above stale threshold!
+            confidence: 0.6, // Above stale threshold!
+            alpha: Some(6.0),
+            beta: Some(4.0),
+            self_reinforcements: Some(0),
             last_reinforced: None, // Never reinforced, so decays from valid_from
             source: None,
         }];
@@ -793,6 +814,9 @@ mod tests {
             valid_from: serde_json::Value::String(old_date),
             valid_until: None,
             confidence: 0.6,
+            alpha: Some(6.0),
+            beta: Some(4.0),
+            self_reinforcements: Some(0),
             last_reinforced: Some(serde_json::Value::String(recent_reinforce)),
             source: None,
         }];

--- a/src/graph/ingest.rs
+++ b/src/graph/ingest.rs
@@ -11,6 +11,7 @@ use super::error::GraphError;
 use super::extract;
 use super::llm::LlmProvider;
 use super::types::*;
+use super::utility;
 use super::GraphMemory;
 
 /// Maximum number of concurrent LLM calls during extraction and dedup.
@@ -213,11 +214,12 @@ async fn extract_indexed(
 
 /// Shared extraction logic — parallel extraction, sequential dedup.
 ///
-/// Four phases:
+/// Five phases:
 /// 1. Extract all chunks in parallel (up to LLM_CONCURRENCY)
 /// 2. Local pre-dedup: merge same-name entities from different chunks
 /// 3. Dedup sequentially against the DB (each call sees prior results)
 /// 4. Create relationships sequentially (fast, no LLM)
+/// 5. Record which entities the session touched (passive was-used signal)
 async fn process_extraction(
     gm: &GraphMemory,
     chunks: &[String],
@@ -281,10 +283,12 @@ async fn process_extraction(
         match dedup::resolve_entity(gm, llm, candidate, session_id).await {
             Ok(ResolvedEntity::Created(entity)) => {
                 name_map.insert(candidate.name.clone(), entity.name.clone());
+                report.entity_ids.push(entity.id_string());
                 report.entities_created += 1;
             }
             Ok(ResolvedEntity::Merged(entity)) => {
                 name_map.insert(candidate.name.clone(), entity.name.clone());
+                report.entity_ids.push(entity.id_string());
                 report.entities_merged += 1;
             }
             Ok(ResolvedEntity::Skipped) => {
@@ -349,6 +353,15 @@ async fn process_extraction(
                     .push(format!("relationship {from_name} -> {to_name}: {e}"));
             }
         }
+    }
+
+    // Phase 5: link the session to the entities it touched, so a later
+    // outcome knows what it applies to. Bookkeeping, never fatal: a failed
+    // link costs the feedback loop one session, not the ingestion.
+    if let Err(e) = utility::record_session_use(gm.db(), session_id, &report.entity_ids).await {
+        report
+            .errors
+            .push(format!("session use record for {session_id}: {e}"));
     }
 
     Ok(())

--- a/src/graph/ingest.rs
+++ b/src/graph/ingest.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use futures::stream::{self, StreamExt};
 
-use super::confidence::{ExtractionContext, DEFAULT_EVIDENCE_WEIGHT};
+use super::confidence::{ExtractionContext, Provenance};
 use super::crud;
 use super::dedup::{self, ResolvedEntity};
 use super::error::GraphError;
@@ -16,18 +16,122 @@ use super::GraphMemory;
 /// Maximum number of concurrent LLM calls during extraction and dedup.
 const LLM_CONCURRENCY: usize = 10;
 
+/// Role headings written by the archive pipeline, lower-cased.
+const USER_TURN_HEADING: &str = "### user";
+const ASSISTANT_TURN_HEADING: &str = "### assistant";
+
+/// How one ingestion run assigns a provenance class to what it writes.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum ProvenancePolicy {
+    /// Read the class off each chunk's conversation turn roles. Text with no
+    /// visible human-only turn is treated as the agent's own.
+    #[default]
+    FromTurnRoles,
+    /// Stamp every episode in the run with one class — document ingestion
+    /// (`--external`), and any caller that knows better than the heuristic.
+    Fixed(Provenance),
+}
+
+impl ProvenancePolicy {
+    /// The class this policy assigns to one chunk of archive text.
+    #[must_use]
+    pub fn classify(self, chunk: &str) -> Provenance {
+        match self {
+            Self::Fixed(provenance) => provenance,
+            Self::FromTurnRoles => infer_from_turn_roles(chunk),
+        }
+    }
+}
+
+/// Where a run of ingestion is reading from, and what that makes its output.
+///
+/// Carried as one value rather than three parameters because every write the
+/// run performs — episodes and confidence updates alike — must agree on it.
+#[derive(Debug, Clone)]
+pub struct IngestContext {
+    session_id: String,
+    log_number: Option<u32>,
+    provenance: ProvenancePolicy,
+}
+
+impl IngestContext {
+    /// Context for a conversation archive: provenance is read off turn roles.
+    #[must_use]
+    pub fn new(session_id: impl Into<String>, log_number: Option<u32>) -> Self {
+        Self {
+            session_id: session_id.into(),
+            log_number,
+            provenance: ProvenancePolicy::default(),
+        }
+    }
+
+    /// Override the class assignment for the whole run.
+    #[must_use]
+    pub fn with_provenance(mut self, provenance: ProvenancePolicy) -> Self {
+        self.provenance = provenance;
+        self
+    }
+
+    /// Force every episode in the run to one class, or infer per chunk when
+    /// `provenance` is `None`. The shape a CLI `--external` flag arrives in.
+    #[must_use]
+    pub fn with_override(self, provenance: Option<Provenance>) -> Self {
+        match provenance {
+            Some(class) => self.with_provenance(ProvenancePolicy::Fixed(class)),
+            None => self,
+        }
+    }
+
+    /// Session this text belongs to.
+    #[must_use]
+    pub fn session_id(&self) -> &str {
+        &self.session_id
+    }
+
+    /// Archive log number, when the text came from a numbered archive.
+    #[must_use]
+    pub fn log_number(&self) -> Option<u32> {
+        self.log_number
+    }
+}
+
+/// Infer authorship from the role headings the archive pipeline writes.
+///
+/// A chunk is credited to the human only when every role heading in it is a
+/// user turn. Anything else — mixed turns, assistant turns, or text with no
+/// headings at all (pipeline documents, summaries) — is the agent's own, per
+/// the conservative default: never over-credit.
+fn infer_from_turn_roles(chunk: &str) -> Provenance {
+    let mut saw_user = false;
+    for line in chunk.lines() {
+        let heading = line.trim().to_lowercase();
+        if heading == ASSISTANT_TURN_HEADING {
+            return Provenance::SelfGenerated;
+        }
+        if heading == USER_TURN_HEADING {
+            saw_user = true;
+        }
+    }
+
+    if saw_user {
+        Provenance::User
+    } else {
+        Provenance::SelfGenerated
+    }
+}
+
 /// Ingest a conversation archive into the knowledge graph.
 ///
 /// Flow:
 /// 1. Chunk the conversation text
-/// 2. Create an Episode for each chunk (always, even without LLM)
+/// 2. Create an Episode for each chunk, stamped with its provenance (always,
+///    even without LLM)
 /// 3. If LLM provided: extract entities/relationships, dedup, store
 /// 4. Return a report of what was created/merged/skipped
 pub async fn ingest_archive(
     gm: &GraphMemory,
     archive_text: &str,
-    session_id: &str,
-    log_number: Option<u32>,
+    context: &IngestContext,
     llm: Option<&dyn LlmProvider>,
 ) -> Result<IngestionReport, GraphError> {
     let mut report = IngestionReport::default();
@@ -37,18 +141,22 @@ pub async fn ingest_archive(
         return Ok(report);
     }
 
-    // Create episodes for each chunk
+    // Create episodes for each chunk, each stamped with its own authorship —
+    // one archive can hold both the human's words and the agent's.
     for (i, chunk) in chunks.iter().enumerate() {
         let abstract_text = build_episode_abstract(chunk);
         let episode = NewEpisode {
-            session_id: session_id.to_string(),
+            session_id: context.session_id.clone(),
             abstract_text,
             overview: None,
             content: Some(chunk.clone()),
-            log_number,
+            log_number: context.log_number,
         };
 
-        match gm.add_episode(episode).await {
+        match gm
+            .add_episode_from(episode, context.provenance.classify(chunk))
+            .await
+        {
             Ok(_) => report.episodes_created += 1,
             Err(e) => {
                 report.errors.push(format!("episode chunk {i}: {e}"));
@@ -58,7 +166,7 @@ pub async fn ingest_archive(
 
     // If LLM provided, run extraction on all chunks
     if let Some(llm) = llm {
-        process_extraction(gm, &chunks, session_id, log_number, llm, &mut report).await?;
+        process_extraction(gm, &chunks, context, llm, &mut report).await?;
     }
 
     Ok(report)
@@ -71,8 +179,7 @@ pub async fn ingest_archive(
 pub async fn extract_from_archive(
     gm: &GraphMemory,
     archive_text: &str,
-    session_id: &str,
-    log_number: Option<u32>,
+    context: &IngestContext,
     llm: &dyn LlmProvider,
 ) -> Result<IngestionReport, GraphError> {
     let mut report = IngestionReport::default();
@@ -82,7 +189,7 @@ pub async fn extract_from_archive(
         return Ok(report);
     }
 
-    process_extraction(gm, &chunks, session_id, log_number, llm, &mut report).await?;
+    process_extraction(gm, &chunks, context, llm, &mut report).await?;
 
     Ok(report)
 }
@@ -114,11 +221,12 @@ async fn extract_indexed(
 async fn process_extraction(
     gm: &GraphMemory,
     chunks: &[String],
-    session_id: &str,
-    log_number: Option<u32>,
+    context: &IngestContext,
     llm: &dyn LlmProvider,
     report: &mut IngestionReport,
 ) -> Result<(), GraphError> {
+    let session_id = context.session_id.as_str();
+    let log_number = context.log_number;
     // Phase 1: Extract all chunks in parallel.
     // The per-chunk futures are built by the iterator, not by a stream
     // combinator: a closure applied inside the stream would have to be
@@ -135,15 +243,23 @@ async fn process_extraction(
             .collect()
             .await;
 
-    // Collect entities and relationships from successful extractions
+    // Collect entities and relationships from successful extractions. A
+    // relationship keeps the class of the chunk it came out of: the evidence
+    // is only ever as independent as the text that produced it.
     let mut all_entities: Vec<ExtractedEntity> = Vec::new();
-    let mut all_relationships: Vec<ExtractedRelationship> = Vec::new();
+    let mut all_relationships: Vec<(Provenance, ExtractedRelationship)> = Vec::new();
 
     for (i, result) in extraction_results {
         match result {
             Ok(extraction) => {
+                let provenance = context.provenance.classify(&chunks[i]);
                 all_entities.extend(extract::flatten_extraction(&extraction));
-                all_relationships.extend(extraction.relationships);
+                all_relationships.extend(
+                    extraction
+                        .relationships
+                        .into_iter()
+                        .map(|rel| (provenance, rel)),
+                );
                 // Estimate ~2500 tokens per extracted chunk (system prompt + chunk input + output)
                 report.estimated_tokens += 2500;
             }
@@ -184,7 +300,7 @@ async fn process_extraction(
     }
 
     // Phase 4: Create relationships or Bayesian-update existing ones
-    for rel in &all_relationships {
+    for (provenance, rel) in &all_relationships {
         let from_name = name_map.get(&rel.source).unwrap_or(&rel.source);
         let to_name = name_map.get(&rel.target).unwrap_or(&rel.target);
 
@@ -192,10 +308,12 @@ async fn process_extraction(
         if let Some(existing) =
             find_existing_relationship(gm, from_name, to_name, &rel.rel_type).await
         {
-            // Re-extraction is corroborating evidence: add weight to the edge's
-            // accumulated counts and reset the decay clock.
-            let mut evidence = existing.evidence();
-            evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+            // Re-extraction is corroborating evidence — worth what its source
+            // is worth. Self-authored corroboration also lands in the edge's
+            // coherence tally, where it stays visible instead of passing for
+            // independent support.
+            let mut evidence = existing.edge_evidence();
+            evidence.corroborate(*provenance, gm.provenance_weights());
             if let Err(e) =
                 crud::reinforce_relationship(gm.db(), &existing.id_string(), evidence).await
             {
@@ -341,5 +459,65 @@ mod tests {
         let short = "Hello world";
         let abs = build_episode_abstract(short);
         assert_eq!(abs, "Hello world");
+    }
+
+    #[test]
+    fn user_only_chunk_is_credited_to_the_human() {
+        let chunk = "### User\n\nI moved the repo to /opt/recall-echo.";
+        assert_eq!(infer_from_turn_roles(chunk), Provenance::User);
+    }
+
+    #[test]
+    fn assistant_turns_make_a_chunk_self_authored() {
+        let chunk = "### Assistant\n\nThe repo now lives at /opt/recall-echo.";
+        assert_eq!(infer_from_turn_roles(chunk), Provenance::SelfGenerated);
+    }
+
+    #[test]
+    fn mixed_chunk_is_self_authored() {
+        // The conservative half of the rule: a chunk the agent contributed to
+        // cannot be counted as independent testimony.
+        let chunk = "### User\n\nWhere does it live?\n\n---\n\n### Assistant\n\n/opt.";
+        assert_eq!(infer_from_turn_roles(chunk), Provenance::SelfGenerated);
+    }
+
+    #[test]
+    fn text_without_role_headings_is_self_authored() {
+        let chunk = "A pipeline document with no conversation structure at all.";
+        assert_eq!(infer_from_turn_roles(chunk), Provenance::SelfGenerated);
+    }
+
+    #[test]
+    fn heading_matching_is_exact() {
+        // "### Users of the system" is a topic, not a turn.
+        let chunk = "### Users of the system\n\nThey prefer NeoVim.";
+        assert_eq!(infer_from_turn_roles(chunk), Provenance::SelfGenerated);
+    }
+
+    #[test]
+    fn fixed_policy_overrides_turn_roles() {
+        let chunk = "### User\n\nA quote from a paper.";
+        let policy = ProvenancePolicy::Fixed(Provenance::External);
+        assert_eq!(policy.classify(chunk), Provenance::External);
+        assert_eq!(
+            ProvenancePolicy::FromTurnRoles.classify(chunk),
+            Provenance::User
+        );
+    }
+
+    #[test]
+    fn context_override_is_applied_only_when_present() {
+        let context = IngestContext::new("s1", Some(7));
+        assert_eq!(context.session_id(), "s1");
+        assert_eq!(context.log_number(), Some(7));
+
+        let inferring = context.clone().with_override(None);
+        assert_eq!(inferring.provenance, ProvenancePolicy::FromTurnRoles);
+
+        let forced = context.with_override(Some(Provenance::External));
+        assert_eq!(
+            forced.provenance,
+            ProvenancePolicy::Fixed(Provenance::External)
+        );
     }
 }

--- a/src/graph/ingest.rs
+++ b/src/graph/ingest.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use futures::stream::{self, StreamExt};
 
-use super::confidence::{bayesian_update, ExtractionContext};
+use super::confidence::{ExtractionContext, DEFAULT_EVIDENCE_WEIGHT};
 use super::crud;
 use super::dedup::{self, ResolvedEntity};
 use super::error::GraphError;
@@ -192,10 +192,12 @@ async fn process_extraction(
         if let Some(existing) =
             find_existing_relationship(gm, from_name, to_name, &rel.rel_type).await
         {
-            // Re-extraction is corroborating evidence — Bayesian update + reset decay clock
-            let updated = bayesian_update(existing.confidence, true);
+            // Re-extraction is corroborating evidence: add weight to the edge's
+            // accumulated counts and reset the decay clock.
+            let mut evidence = existing.evidence();
+            evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
             if let Err(e) =
-                crud::reinforce_relationship(gm.db(), &existing.id_string(), updated).await
+                crud::reinforce_relationship(gm.db(), &existing.id_string(), evidence).await
             {
                 report
                     .errors

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -254,7 +254,8 @@ impl GraphMemory {
         crud::supersede_relationship(&self.db, old_id, new).await
     }
 
-    /// Update relationship confidence (Bayesian posterior).
+    /// Overwrite a relationship's confidence, resetting its evidence to the
+    /// prior around the new mean.
     pub async fn update_relationship_confidence(
         &self,
         rel_id: &str,
@@ -263,16 +264,17 @@ impl GraphMemory {
         crud::update_relationship_confidence(&self.db, rel_id, confidence).await
     }
 
-    /// Reinforce a relationship: Bayesian update + reset decay clock.
+    /// Persist updated evidence for a relationship and reset its decay clock.
     ///
-    /// Called when a relationship is corroborated. Updates confidence and resets
-    /// `last_reinforced` to now, preventing temporal decay from eroding the edge.
+    /// Called when a relationship is corroborated: the new posterior mean is
+    /// stored as `confidence` and `last_reinforced` is set to now, preventing
+    /// temporal decay from eroding the edge.
     pub async fn reinforce_relationship(
         &self,
         rel_id: &str,
-        new_confidence: f64,
+        evidence: confidence::Evidence,
     ) -> Result<(), GraphError> {
-        crud::reinforce_relationship(&self.db, rel_id, new_confidence).await
+        crud::reinforce_relationship(&self.db, rel_id, evidence).await
     }
 
     // --- Episodes ---

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -518,6 +518,41 @@ impl GraphMemory {
         .await
     }
 
+    /// Apply an outcome to every entity a session touched.
+    ///
+    /// Resolves the session's entities from the `contributed_to` records
+    /// ingestion left behind (falling back to the entities the session
+    /// authored), then records the outcome and moves their utility scores.
+    /// The report says which entities moved and where they landed.
+    pub async fn record_session_outcome(
+        &self,
+        session_id: &str,
+        outcome: utility::OutcomeKind,
+    ) -> Result<utility::FeedbackReport, GraphError> {
+        let session = utility::session_entities(&self.db, session_id).await?;
+        if session.is_empty() {
+            return Ok(utility::FeedbackReport::default());
+        }
+
+        utility::record_outcome_feedback(
+            &self.db,
+            session_id,
+            outcome,
+            &session.retrieved,
+            Some(&session.used),
+        )
+        .await
+    }
+
+    /// Record that a session touched these entities, without judging it.
+    pub async fn record_session_use(
+        &self,
+        session_id: &str,
+        entity_ids: &[String],
+    ) -> Result<u32, GraphError> {
+        utility::record_session_use(&self.db, session_id, entity_ids).await
+    }
+
     // --- Garbage Collection ---
 
     /// Run garbage collection with the given config.

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -26,8 +26,10 @@ pub mod vigil_sync;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+pub use confidence::{Provenance, ProvenanceWeights};
 use embed::{FastEmbedder, LazyEmbedder};
 use error::GraphError;
+pub use ingest::{IngestContext, ProvenancePolicy};
 use store::Db;
 pub use store::ServerConfig;
 #[allow(unused_imports)] // Required in scope for SurrealValue derive macro expansion
@@ -62,6 +64,7 @@ pub struct GraphMemory {
     embedder: LazyEmbedder,
     path: PathBuf,
     scoring: crate::config::GraphScoringConfig,
+    provenance: confidence::ProvenanceWeights,
 }
 
 impl GraphMemory {
@@ -98,13 +101,14 @@ impl GraphMemory {
         std::fs::create_dir_all(&models_dir)?;
         let embedder = LazyEmbedder::new(&models_dir);
 
-        let scoring = load_scoring_config(path);
+        let graph_config = load_graph_section(path);
 
         Ok(Self {
             db,
             embedder,
             path: path.to_path_buf(),
-            scoring,
+            scoring: graph_config.scoring,
+            provenance: graph_config.provenance,
         })
     }
 
@@ -140,6 +144,7 @@ impl GraphMemory {
         };
 
         let scoring = graph_section.scoring.clone();
+        let provenance = graph_section.provenance;
         let server_config = store::ServerConfig {
             url: graph_section.url,
             username: graph_section.username,
@@ -151,6 +156,7 @@ impl GraphMemory {
         let models_dir = path.join("models");
         let mut gm = Self::connect(&server_config, &models_dir).await?;
         gm.scoring = scoring;
+        gm.provenance = provenance;
         Ok(gm)
     }
 
@@ -170,12 +176,20 @@ impl GraphMemory {
             embedder,
             path: models_dir.to_path_buf(),
             scoring: crate::config::GraphScoringConfig::default(),
+            provenance: confidence::ProvenanceWeights::default(),
         })
     }
 
     /// Path to the graph store.
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    /// Evidence weights this store applies to observations, by provenance
+    /// class (`[graph.provenance]`).
+    #[must_use]
+    pub fn provenance_weights(&self) -> &confidence::ProvenanceWeights {
+        &self.provenance
     }
 
     /// Internal access to the database handle.
@@ -267,21 +281,35 @@ impl GraphMemory {
     /// Persist updated evidence for a relationship and reset its decay clock.
     ///
     /// Called when a relationship is corroborated: the new posterior mean is
-    /// stored as `confidence` and `last_reinforced` is set to now, preventing
-    /// temporal decay from eroding the edge.
+    /// stored as `confidence`, the coherence tally is stored beside it, and
+    /// `last_reinforced` is set to now, preventing temporal decay from eroding
+    /// the edge.
     pub async fn reinforce_relationship(
         &self,
         rel_id: &str,
-        evidence: confidence::Evidence,
+        evidence: confidence::EdgeEvidence,
     ) -> Result<(), GraphError> {
         crud::reinforce_relationship(&self.db, rel_id, evidence).await
     }
 
     // --- Episodes ---
 
-    /// Add a new episode to the graph.
+    /// Add a new episode authored by the agent itself.
+    ///
+    /// The conservative default: a caller that cannot say where the text came
+    /// from must not have it counted as independent evidence. Ingestion, which
+    /// does know, uses [`GraphMemory::add_episode_from`].
     pub async fn add_episode(&self, episode: NewEpisode) -> Result<Episode, GraphError> {
         crud::add_episode(&self.db, self.embedder.get()?, episode).await
+    }
+
+    /// Add a new episode stamped with the class of whoever authored it.
+    pub async fn add_episode_from(
+        &self,
+        episode: NewEpisode,
+        provenance: Provenance,
+    ) -> Result<Episode, GraphError> {
+        crud::add_episode_from(&self.db, self.embedder.get()?, episode, provenance).await
     }
 
     /// Get episodes by session ID.
@@ -303,25 +331,27 @@ impl GraphMemory {
     // --- Ingestion ---
 
     /// Ingest a conversation archive into the knowledge graph.
+    ///
+    /// The [`IngestContext`] carries the provenance policy: conversation
+    /// archives infer per chunk from turn roles, document ingestion forces a
+    /// class.
     pub async fn ingest_archive(
         &self,
         archive_text: &str,
-        session_id: &str,
-        log_number: Option<u32>,
+        context: &IngestContext,
         llm: Option<&dyn llm::LlmProvider>,
     ) -> Result<IngestionReport, GraphError> {
-        ingest::ingest_archive(self, archive_text, session_id, log_number, llm).await
+        ingest::ingest_archive(self, archive_text, context, llm).await
     }
 
     /// Run LLM extraction on an archive without creating episodes.
     pub async fn extract_from_archive(
         &self,
         archive_text: &str,
-        session_id: &str,
-        log_number: Option<u32>,
+        context: &IngestContext,
         llm: &dyn llm::LlmProvider,
     ) -> Result<IngestionReport, GraphError> {
-        ingest::extract_from_archive(self, archive_text, session_id, log_number, llm).await
+        ingest::extract_from_archive(self, archive_text, context, llm).await
     }
 
     /// Mark all episodes with a given log_number as extracted.
@@ -534,14 +564,13 @@ impl GraphMemory {
     }
 }
 
-/// Load `[graph.scoring]` from `.recall-echo.toml` in the memory directory
-/// (the parent of the graph store path). Returns defaults if the config file
-/// or the `[graph.scoring]` section is absent, preserving legacy behavior.
-fn load_scoring_config(graph_path: &Path) -> crate::config::GraphScoringConfig {
+/// Load `[graph]` from `.recall-echo.toml` in the memory directory (the parent
+/// of the graph store path). Returns defaults if the config file or the
+/// section is absent, preserving legacy behavior.
+fn load_graph_section(graph_path: &Path) -> crate::config::GraphSection {
     let memory_dir = graph_path.parent().unwrap_or(graph_path);
     crate::config::load_from_dir(memory_dir)
         .graph
-        .map(|g| g.scoring)
         .unwrap_or_default()
 }
 

--- a/src/graph/search.rs
+++ b/src/graph/search.rs
@@ -188,7 +188,7 @@ pub async fn search_episodes(
 
     let rows: Vec<EpisodeWithDistance> = super::deserialize_take(&mut response, 0)?;
 
-    let results = rows
+    let results: Vec<EpisodeSearchResult> = rows
         .into_iter()
         .map(|row| {
             let similarity = 1.0 - row.distance;
@@ -199,6 +199,11 @@ pub async fn search_episodes(
             }
         })
         .collect();
+
+    // Retrieval is the signal episode GC reads: an episode that has been
+    // returned to someone is not spent, however old it is.
+    let ids: Vec<String> = results.iter().map(|r| r.episode.id_string()).collect();
+    super::crud::increment_episode_access_counts(db, &ids).await?;
 
     Ok(results)
 }

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -191,6 +191,10 @@ async fn define_schema(db: &Surreal<Db>) -> Result<(), GraphError> {
         DEFINE FIELD IF NOT EXISTS embedding   ON episode TYPE option<array<float>>;
         DEFINE FIELD IF NOT EXISTS log_number  ON episode TYPE option<int>;
         DEFINE FIELD IF NOT EXISTS extracted  ON episode TYPE bool DEFAULT false;
+        -- How many times retrieval has returned this episode. Absent on
+        -- episodes written before the field existed; read paths resolve that
+        -- to zero, which is also what it means. No backfill, no version bump.
+        DEFINE FIELD IF NOT EXISTS access_count ON episode TYPE option<int>;
         -- Authorship class: 'external' | 'user' | 'self'. `option` with no
         -- default on purpose — an absent value means an episode written
         -- before provenance existed, and reads resolve that to 'self'. No

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -191,6 +191,12 @@ async fn define_schema(db: &Surreal<Db>) -> Result<(), GraphError> {
         DEFINE FIELD IF NOT EXISTS embedding   ON episode TYPE option<array<float>>;
         DEFINE FIELD IF NOT EXISTS log_number  ON episode TYPE option<int>;
         DEFINE FIELD IF NOT EXISTS extracted  ON episode TYPE bool DEFAULT false;
+        -- Authorship class: 'external' | 'user' | 'self'. `option` with no
+        -- default on purpose — an absent value means an episode written
+        -- before provenance existed, and reads resolve that to 'self'. No
+        -- backfill, so no schema version bump: the absent case is already
+        -- the conservative one.
+        DEFINE FIELD IF NOT EXISTS provenance ON episode TYPE option<string>;
 
         DEFINE INDEX IF NOT EXISTS episode_session ON episode FIELDS session_id;
         DEFINE INDEX IF NOT EXISTS episode_time    ON episode FIELDS timestamp;

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -16,9 +16,20 @@ use std::time::Duration;
 use surrealdb::engine::any::Any;
 use surrealdb::Surreal;
 
+use super::confidence::PRIOR_CONCENTRATION;
 use super::error::GraphError;
 
 pub type Db = Any;
+
+/// Schema version this build writes. Bumped by every migration.
+///
+/// - `0` — pre-Phase-1: edges carry a bare `confidence` mean.
+/// - `1` — edges carry persisted Beta evidence (`alpha`, `beta`) and a
+///   `self_reinforcements` coherence counter.
+pub const SCHEMA_VERSION: i64 = 1;
+
+/// Record ID of the singleton row holding graph-wide metadata.
+const META_RECORD: &str = "meta:schema";
 
 /// How many times to retry opening an embedded store that is locked by
 /// another process, and the base backoff between attempts (doubled each try).
@@ -120,8 +131,15 @@ pub async fn connect(config: &ServerConfig) -> Result<Surreal<Db>, GraphError> {
     Ok(db)
 }
 
-/// Initialize the graph schema. Idempotent — safe to call on every open.
-pub async fn init_schema(db: &Surreal<Db>) -> Result<(), GraphError> {
+/// Initialize the graph schema, then bring the store up to
+/// [`SCHEMA_VERSION`]. Idempotent — safe to call on every open.
+pub async fn init_schema(db: &Surreal<Db>) -> Result<MigrationReport, GraphError> {
+    define_schema(db).await?;
+    migrate(db).await
+}
+
+/// Declare tables, fields and indexes. Every statement is `IF NOT EXISTS`.
+async fn define_schema(db: &Surreal<Db>) -> Result<(), GraphError> {
     db.query(
         r#"
         DEFINE TABLE IF NOT EXISTS entity SCHEMAFULL;
@@ -154,6 +172,11 @@ pub async fn init_schema(db: &Surreal<Db>) -> Result<(), GraphError> {
         DEFINE FIELD IF NOT EXISTS valid_from  ON relates_to TYPE datetime DEFAULT time::now();
         DEFINE FIELD IF NOT EXISTS valid_until ON relates_to TYPE option<datetime>;
         DEFINE FIELD IF NOT EXISTS confidence  ON relates_to TYPE float DEFAULT 1.0;
+        -- Persisted Beta evidence. `option` because edges written before
+        -- schema version 1 have none until the backfill reaches them.
+        DEFINE FIELD IF NOT EXISTS alpha       ON relates_to TYPE option<float>;
+        DEFINE FIELD IF NOT EXISTS beta        ON relates_to TYPE option<float>;
+        DEFINE FIELD IF NOT EXISTS self_reinforcements ON relates_to TYPE option<int>;
         DEFINE FIELD IF NOT EXISTS last_reinforced ON relates_to TYPE option<datetime>;
         DEFINE FIELD IF NOT EXISTS source      ON relates_to TYPE option<string>;
 
@@ -180,11 +203,113 @@ pub async fn init_schema(db: &Surreal<Db>) -> Result<(), GraphError> {
         DEFINE FIELD IF NOT EXISTS timestamp      ON contributed_to TYPE datetime DEFAULT time::now();
 
         DEFINE INDEX IF NOT EXISTS ct_session ON contributed_to FIELDS session_id;
+
+        DEFINE TABLE IF NOT EXISTS meta SCHEMAFULL;
+        DEFINE FIELD IF NOT EXISTS schema_version ON meta TYPE int DEFAULT 0;
         "#,
     )
     .await?
     .check()?;
 
+    Ok(())
+}
+
+/// What one migration pass did. `edges_backfilled` is zero on an already
+/// current store.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MigrationReport {
+    /// Schema version the store was at when the pass started.
+    pub from_version: i64,
+    /// Schema version the store is at now.
+    pub to_version: i64,
+    /// Number of edges that gained evidence counts in this pass.
+    pub edges_backfilled: u64,
+}
+
+impl MigrationReport {
+    /// True when this pass actually moved the store forward.
+    #[must_use]
+    pub fn ran(&self) -> bool {
+        self.from_version < self.to_version
+    }
+}
+
+/// Bring the store up to [`SCHEMA_VERSION`].
+///
+/// Crash-only: the backfill runs *before* the version marker is written, and
+/// only touches edges that still lack evidence (`alpha IS NONE`). An
+/// interrupted pass therefore leaves a store that re-opens, finishes the
+/// remaining edges, and never counts an edge twice.
+async fn migrate(db: &Surreal<Db>) -> Result<MigrationReport, GraphError> {
+    let from_version = read_schema_version(db).await?;
+    if from_version >= SCHEMA_VERSION {
+        return Ok(MigrationReport {
+            from_version,
+            to_version: from_version,
+            edges_backfilled: 0,
+        });
+    }
+
+    let edges_backfilled = backfill_edge_evidence(db).await?;
+    write_schema_version(db, SCHEMA_VERSION).await?;
+
+    Ok(MigrationReport {
+        from_version,
+        to_version: SCHEMA_VERSION,
+        edges_backfilled,
+    })
+}
+
+/// Give every evidence-less edge the Beta counts implied by its stored mean.
+///
+/// `alpha = confidence · C`, `beta = (1 − confidence) · C` with
+/// `C = PRIOR_CONCENTRATION`: the mean is preserved exactly, and the edge
+/// gains the honest low concentration of something never actually counted.
+///
+/// A single re-runnable statement — `WHERE alpha IS NONE` makes re-entry a
+/// no-op for edges that already have evidence.
+async fn backfill_edge_evidence(db: &Surreal<Db>) -> Result<u64, GraphError> {
+    let mut response = db
+        .query(
+            r#"
+            UPDATE relates_to SET
+                alpha = confidence * $concentration,
+                beta = (1 - confidence) * $concentration,
+                self_reinforcements = 0
+            WHERE alpha IS NONE
+            RETURN id
+            "#,
+        )
+        .bind(("concentration", PRIOR_CONCENTRATION))
+        .await?;
+
+    let updated: Vec<serde_json::Value> = super::deserialize_take(&mut response, 0)?;
+    Ok(updated.len() as u64)
+}
+
+/// Read the store's schema version. An absent meta record means version 0 —
+/// a store written before versioning existed.
+async fn read_schema_version(db: &Surreal<Db>) -> Result<i64, GraphError> {
+    let mut response = db
+        .query("SELECT schema_version FROM type::record($id)")
+        .bind(("id", META_RECORD.to_string()))
+        .await?;
+
+    #[derive(serde::Deserialize)]
+    struct VersionRow {
+        schema_version: i64,
+    }
+
+    let rows: Vec<VersionRow> = super::deserialize_take(&mut response, 0)?;
+    Ok(rows.first().map(|r| r.schema_version).unwrap_or(0))
+}
+
+async fn write_schema_version(db: &Surreal<Db>, version: i64) -> Result<(), GraphError> {
+    db.query("UPSERT type::record($id) SET schema_version = $version")
+        .bind(("id", META_RECORD.to_string()))
+        .bind(("version", version))
+        .await?
+        .check()?;
     Ok(())
 }
 

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -167,7 +167,20 @@ pub struct Relationship {
     pub description: Option<String>,
     pub valid_from: serde_json::Value,
     pub valid_until: Option<serde_json::Value>,
+    /// Posterior mean of the edge's Beta distribution — `alpha / (alpha + beta)`.
+    /// Kept in sync with the counts on every write; this is what read paths score on.
     pub confidence: f64,
+    /// Accumulated corroborating evidence (Beta α).
+    /// `None` only on an edge the schema migration has not reached yet.
+    #[serde(default)]
+    pub alpha: Option<f64>,
+    /// Accumulated contradicting evidence (Beta β).
+    #[serde(default)]
+    pub beta: Option<f64>,
+    /// How many corroborations came from the agent itself — counted, never
+    /// laundered into confidence. Populated from Phase 1 increment 2 onward.
+    #[serde(default)]
+    pub self_reinforcements: Option<i64>,
     /// When this relationship was last reinforced (Bayesian corroboration).
     /// Used by temporal decay: effective_confidence = confidence × 0.5^(days_since / half_life).
     #[serde(default)]
@@ -183,6 +196,13 @@ impl Relationship {
             serde_json::Value::String(s) => s.clone(),
             other => other.to_string(),
         }
+    }
+
+    /// The edge's accumulated evidence, falling back to the prior implied by
+    /// its mean when the counts have not been backfilled yet.
+    #[must_use]
+    pub fn evidence(&self) -> crate::graph::confidence::Evidence {
+        crate::graph::confidence::Evidence::from_stored(self.alpha, self.beta, self.confidence)
     }
 }
 

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -441,6 +441,10 @@ pub struct Episode {
     /// resolves absent and unrecognised values conservatively.
     #[serde(default)]
     pub provenance: Option<String>,
+    /// How many times retrieval has returned this episode. Absent on episodes
+    /// written before the counter existed — which reads as never retrieved.
+    #[serde(default, deserialize_with = "super::util::count_or_zero")]
+    pub access_count: i64,
 }
 
 impl Episode {
@@ -650,6 +654,11 @@ pub struct IngestionReport {
     pub relationships_skipped: u32,
     pub errors: Vec<String>,
     pub estimated_tokens: u64,
+    /// Record IDs of the entities this run created or merged into — the
+    /// entities the session touched, and so the ones a session outcome
+    /// applies to. Empty when the run had no LLM to extract with.
+    #[serde(default)]
+    pub entity_ids: Vec<String>,
 }
 
 #[cfg(test)]

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -675,6 +675,8 @@ mod tests {
             content: None,
             embedding,
             log_number: Some(1),
+            provenance: None,
+            access_count: 0,
         }
     }
 

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -3,6 +3,8 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use super::confidence::{EdgeEvidence, Evidence, Provenance};
+
 /// Node types in the knowledge graph.
 /// Mutable types can be merged/updated. Immutable types are historical facts.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -201,8 +203,15 @@ impl Relationship {
     /// The edge's accumulated evidence, falling back to the prior implied by
     /// its mean when the counts have not been backfilled yet.
     #[must_use]
-    pub fn evidence(&self) -> crate::graph::confidence::Evidence {
-        crate::graph::confidence::Evidence::from_stored(self.alpha, self.beta, self.confidence)
+    pub fn evidence(&self) -> Evidence {
+        Evidence::from_stored(self.alpha, self.beta, self.confidence)
+    }
+
+    /// The edge's full evidence state — Beta counts plus coherence tally.
+    /// This is what a confidence-moving observation is applied to.
+    #[must_use]
+    pub fn edge_evidence(&self) -> EdgeEvidence {
+        EdgeEvidence::new(self.evidence(), self.self_reinforcements.unwrap_or(0))
     }
 }
 
@@ -427,6 +436,11 @@ pub struct Episode {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub embedding: Option<Vec<f32>>,
     pub log_number: Option<i64>,
+    /// Authorship class as stored. Absent on episodes written before
+    /// provenance existed; read it through [`Episode::provenance`], which
+    /// resolves absent and unrecognised values conservatively.
+    #[serde(default)]
+    pub provenance: Option<String>,
 }
 
 impl Episode {
@@ -436,6 +450,14 @@ impl Episode {
             serde_json::Value::String(s) => s.clone(),
             other => other.to_string(),
         }
+    }
+
+    /// Who authored this episode. Legacy and unrecognised values resolve to
+    /// [`Provenance::SelfGenerated`] — unlabelled text never earns full
+    /// evidence weight.
+    #[must_use]
+    pub fn provenance(&self) -> Provenance {
+        Provenance::from_stored(self.provenance.as_deref())
     }
 }
 

--- a/src/graph/util.rs
+++ b/src/graph/util.rs
@@ -1,6 +1,19 @@
 //! Shared utility functions for the graph subsystem.
 
 use chrono::{DateTime, Utc};
+use serde::Deserialize;
+
+/// Read a counter that a record may predate.
+///
+/// SurrealDB renders a field an older record never had as absent under
+/// `SELECT *` and as `null` under a projection; both mean the same thing here,
+/// and both mean zero.
+pub fn count_or_zero<'de, D>(deserializer: D) -> Result<i64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Ok(Option::<i64>::deserialize(deserializer)?.unwrap_or(0))
+}
 
 /// Strip markdown code fencing (```json ... ```) from LLM responses.
 #[must_use]

--- a/src/graph/utility.rs
+++ b/src/graph/utility.rs
@@ -67,13 +67,43 @@ const UNUSED_ALPHA: f64 = 0.05;
 /// Reward override for "retrieved but not used" — slight negative signal.
 const UNUSED_REWARD: f64 = 0.3;
 
+/// One entity's utility score after an outcome was applied to it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EntityUtility {
+    pub entity_id: String,
+    pub utility_score: f64,
+}
+
 /// Report from a feedback recording operation.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct FeedbackReport {
     pub outcome_entity_id: String,
     pub edges_created: u32,
     pub entities_updated: u32,
+    /// Post-update utility of every entity the outcome reached — the
+    /// observable half of the feedback loop.
+    #[serde(default)]
+    pub utilities: Vec<EntityUtility>,
     pub errors: Vec<String>,
+}
+
+/// The entities one session is known to have touched.
+///
+/// `retrieved` is everything linked to the session; `used` is the subset the
+/// session's own records say it actually leaned on. Entities in `retrieved`
+/// but not `used` get the muted "retrieved and ignored" signal.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SessionEntities {
+    pub retrieved: Vec<String>,
+    pub used: Vec<String>,
+}
+
+impl SessionEntities {
+    /// True when the session has no entities to apply an outcome to.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.retrieved.is_empty()
+    }
 }
 
 /// Record outcome feedback: link retrieved entities to an outcome and update utility scores.
@@ -90,7 +120,8 @@ pub async fn record_outcome_feedback(
         return Ok(report);
     }
 
-    let outcome_id = create_outcome_entity(db, session_id, outcome).await?;
+    let result = ContributionResult::Resolved(outcome);
+    let outcome_id = outcome_entity_for_session(db, session_id, result).await?;
     report.outcome_entity_id = outcome_id.clone();
 
     let reward = outcome.reward();
@@ -119,21 +150,22 @@ pub async fn record_outcome_feedback(
                     db,
                     entity_id,
                     outcome_id_ref,
-                    outcome,
+                    result,
                     was_used,
                     session_id,
                 )
                 .await;
                 let utility_result =
                     update_utility_score(db, entity_id, effective_reward, alpha).await;
-                (entity_id, edge_result, utility_result)
+                let score = get_utility_score(db, entity_id).await;
+                (entity_id, edge_result, utility_result, score)
             }
         })
         .collect();
 
     let results = futures::future::join_all(futures).await;
 
-    for (entity_id, edge_result, utility_result) in results {
+    for (entity_id, edge_result, utility_result, score) in results {
         match edge_result {
             Ok(()) => report.edges_created += 1,
             Err(e) => {
@@ -150,17 +182,224 @@ pub async fn record_outcome_feedback(
                     .push(format!("utility update {entity_id}: {e}"));
             }
         }
+        if let Ok(utility_score) = score {
+            report.utilities.push(EntityUtility {
+                entity_id: entity_id.clone(),
+                utility_score,
+            });
+        }
     }
 
     Ok(report)
 }
 
+/// Record that a session touched these entities, without judging the outcome.
+///
+/// The passive half of the feedback loop: ingestion knows which entities a
+/// session produced or reinforced, and says so here. A later
+/// `graph feedback <session>` supplies the outcome and this is what tells it
+/// which entities the outcome applies to.
+///
+/// Idempotent per session: re-ingesting a session rewrites its records rather
+/// than accumulating duplicates. Utility scores are untouched — an
+/// unadjudicated session is not evidence of usefulness.
+pub async fn record_session_use(
+    db: &Surreal<Db>,
+    session_id: &str,
+    entity_ids: &[String],
+) -> Result<u32, GraphError> {
+    if entity_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let outcome_id =
+        outcome_entity_for_session(db, session_id, ContributionResult::Pending).await?;
+
+    let mut recorded = 0;
+    for entity_id in entity_ids {
+        create_contribution_edge(
+            db,
+            entity_id,
+            &outcome_id,
+            ContributionResult::Pending,
+            true,
+            session_id,
+        )
+        .await?;
+        recorded += 1;
+    }
+
+    Ok(recorded)
+}
+
+/// The entities a session touched, as its `contributed_to` records tell it.
+///
+/// Falls back to the entities the session authored (`source = session_id`)
+/// when no records exist — the shape of a store whose sessions were ingested
+/// before passive recording, where authorship is the only session link.
+pub async fn session_entities(
+    db: &Surreal<Db>,
+    session_id: &str,
+) -> Result<SessionEntities, GraphError> {
+    #[derive(Deserialize)]
+    struct EdgeRow {
+        #[serde(rename = "in")]
+        entity: serde_json::Value,
+        #[serde(default = "default_was_used")]
+        was_used: bool,
+    }
+
+    fn default_was_used() -> bool {
+        true
+    }
+
+    let mut response = db
+        .query("SELECT in, was_used FROM contributed_to WHERE session_id = $sid")
+        .bind(("sid", session_id.to_string()))
+        .await?;
+
+    let rows: Vec<EdgeRow> = super::deserialize_take(&mut response, 0)?;
+    if !rows.is_empty() {
+        let mut session = SessionEntities::default();
+        for row in rows {
+            let id = record_id_string(&row.entity);
+            if session.retrieved.contains(&id) {
+                continue;
+            }
+            if row.was_used {
+                session.used.push(id.clone());
+            }
+            session.retrieved.push(id);
+        }
+        return Ok(session);
+    }
+
+    let mut response = db
+        .query("SELECT id FROM entity WHERE source = $sid")
+        .bind(("sid", session_id.to_string()))
+        .await?;
+
+    #[derive(Deserialize)]
+    struct IdRow {
+        id: serde_json::Value,
+    }
+
+    let rows: Vec<IdRow> = super::deserialize_take(&mut response, 0)?;
+    let retrieved: Vec<String> = rows.iter().map(|r| record_id_string(&r.id)).collect();
+
+    Ok(SessionEntities {
+        used: retrieved.clone(),
+        retrieved,
+    })
+}
+
+/// Render a record ID value as `table:id`.
+fn record_id_string(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(s) => s.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// What a contribution record says about its session so far.
+///
+/// A session is linked to its entities the moment ingestion knows about them,
+/// which is before anyone has judged how it went. `Pending` is that state; it
+/// carries no reward and never moves a utility score.
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum ContributionResult {
+    Pending,
+    Resolved(OutcomeKind),
+}
+
+impl std::fmt::Display for ContributionResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Pending => write!(f, "pending"),
+            Self::Resolved(outcome) => write!(f, "{outcome}"),
+        }
+    }
+}
+
+/// The session's outcome entity, created on first use and reused after.
+///
+/// One outcome record per session, whatever order the passive linkage and the
+/// adjudicated outcome arrive in: re-running feedback for a session corrects
+/// its record rather than growing a second one.
+async fn outcome_entity_for_session(
+    db: &Surreal<Db>,
+    session_id: &str,
+    result: ContributionResult,
+) -> Result<String, GraphError> {
+    match find_outcome_entity(db, session_id).await? {
+        Some(id) => {
+            update_outcome_entity(db, &id, session_id, result).await?;
+            Ok(id)
+        }
+        None => create_outcome_entity(db, session_id, result).await,
+    }
+}
+
+async fn find_outcome_entity(
+    db: &Surreal<Db>,
+    session_id: &str,
+) -> Result<Option<String>, GraphError> {
+    #[derive(Deserialize)]
+    struct IdRow {
+        id: serde_json::Value,
+    }
+
+    let mut response = db
+        .query(
+            r#"SELECT id FROM entity
+               WHERE entity_type = "outcome" AND attributes.session_id = $sid
+               LIMIT 1"#,
+        )
+        .bind(("sid", session_id.to_string()))
+        .await?;
+
+    let rows: Vec<IdRow> = super::deserialize_take(&mut response, 0)?;
+    Ok(rows.first().map(|r| record_id_string(&r.id)))
+}
+
+async fn update_outcome_entity(
+    db: &Surreal<Db>,
+    outcome_id: &str,
+    session_id: &str,
+    result: ContributionResult,
+) -> Result<(), GraphError> {
+    db.query(
+        r#"UPDATE type::record($id) SET
+               abstract = $abstract,
+               attributes = $attributes,
+               updated_at = time::now()"#,
+    )
+    .bind(("id", outcome_id.to_string()))
+    .bind(("abstract", outcome_abstract(session_id, result)))
+    .bind(("attributes", outcome_attributes(session_id, result)))
+    .await?
+    .check()?;
+
+    Ok(())
+}
+
+fn outcome_abstract(session_id: &str, result: ContributionResult) -> String {
+    format!("Session {session_id} outcome: {result}")
+}
+
+fn outcome_attributes(session_id: &str, result: ContributionResult) -> serde_json::Value {
+    serde_json::json!({
+        "outcome_result": result.to_string(),
+        "session_id": session_id,
+    })
+}
+
 async fn create_outcome_entity(
     db: &Surreal<Db>,
     session_id: &str,
-    outcome: OutcomeKind,
+    outcome: ContributionResult,
 ) -> Result<String, GraphError> {
-    let abstract_text = format!("Session {session_id} outcome: {outcome}");
+    let abstract_text = outcome_abstract(session_id, outcome);
 
     let mut response = db
         .query(
@@ -184,13 +423,7 @@ async fn create_outcome_entity(
         )
         .bind(("name", format!("outcome-{session_id}")))
         .bind(("abstract", abstract_text))
-        .bind((
-            "attributes",
-            serde_json::json!({
-                "outcome_result": outcome.to_string(),
-                "session_id": session_id,
-            }),
-        ))
+        .bind(("attributes", outcome_attributes(session_id, outcome)))
         .bind(("utility", DEFAULT_UTILITY))
         .bind(("source", format!("caliber:{session_id}")))
         .await?;
@@ -205,11 +438,17 @@ async fn create_outcome_entity(
     Ok(entity.id_string())
 }
 
+/// Write one entity's contribution record for a session, replacing any
+/// earlier record for the same pair.
+///
+/// One record per entity per session: the passive "this session touched it"
+/// marker and the adjudicated outcome are the same fact learned twice, not
+/// two contributions.
 async fn create_contribution_edge(
     db: &Surreal<Db>,
     entity_id: &str,
     outcome_id: &str,
-    outcome: OutcomeKind,
+    outcome: ContributionResult,
     was_used: bool,
     session_id: &str,
 ) -> Result<(), GraphError> {
@@ -217,6 +456,7 @@ async fn create_contribution_edge(
         r#"
         LET $from = type::record($from_id);
         LET $to = type::record($to_id);
+        DELETE contributed_to WHERE in = $from AND session_id = $session_id;
         RELATE $from -> contributed_to -> $to SET
             outcome_result = $outcome_result,
             was_used = $was_used,
@@ -243,11 +483,12 @@ async fn update_utility_score(
     alpha: f64,
 ) -> Result<(), GraphError> {
     // Inline EMA: new = (1 - alpha) * current + alpha * reward, clamped to [0, 1].
-    // SurrealDB doesn't have math::clamp, so we use nested IF expressions.
+    // SurrealDB has no clamp, so the bounds are an IF chain — one chain, one
+    // `END`, whatever the branch count.
     db.query(
         r#"
         LET $raw = (1.0 - $alpha) * type::record($id).utility_score + $alpha * $reward;
-        LET $clamped = IF $raw < 0.0 THEN 0.0 ELSE IF $raw > 1.0 THEN 1.0 ELSE $raw END END;
+        LET $clamped = IF $raw < 0.0 THEN 0.0 ELSE IF $raw > 1.0 THEN 1.0 ELSE $raw END;
         UPDATE type::record($id) SET
             utility_score = $clamped,
             utility_updates += 1,
@@ -257,7 +498,8 @@ async fn update_utility_score(
     .bind(("id", entity_id.to_string()))
     .bind(("alpha", alpha))
     .bind(("reward", reward))
-    .await?;
+    .await?
+    .check()?;
 
     Ok(())
 }
@@ -351,6 +593,60 @@ mod tests {
             score = (1.0 - USED_ALPHA) * score + USED_ALPHA * 0.0;
         }
         assert!(score < 0.01);
+    }
+
+    #[test]
+    fn pending_contribution_reads_as_unadjudicated() {
+        assert_eq!(ContributionResult::Pending.to_string(), "pending");
+        assert_eq!(
+            ContributionResult::Resolved(OutcomeKind::Success).to_string(),
+            "success"
+        );
+        assert_eq!(
+            outcome_abstract("s1", ContributionResult::Pending),
+            "Session s1 outcome: pending"
+        );
+        assert_eq!(
+            outcome_attributes("s1", ContributionResult::Resolved(OutcomeKind::Failed)),
+            serde_json::json!({"outcome_result": "failed", "session_id": "s1"})
+        );
+    }
+
+    #[test]
+    fn session_with_no_entities_is_empty() {
+        assert!(SessionEntities::default().is_empty());
+        assert!(!SessionEntities {
+            retrieved: vec!["entity:a".into()],
+            used: vec![],
+        }
+        .is_empty());
+    }
+
+    #[test]
+    fn record_ids_render_as_table_colon_id() {
+        assert_eq!(
+            record_id_string(&serde_json::json!("entity:abc")),
+            "entity:abc"
+        );
+        assert_eq!(record_id_string(&serde_json::json!(42)), "42");
+    }
+
+    #[test]
+    fn feedback_report_crosses_the_wire() {
+        let report = FeedbackReport {
+            outcome_entity_id: "entity:outcome".into(),
+            edges_created: 2,
+            entities_updated: 2,
+            utilities: vec![EntityUtility {
+                entity_id: "entity:a".into(),
+                utility_score: 0.55,
+            }],
+            errors: vec![],
+        };
+        let json = serde_json::to_value(&report).expect("serialize");
+        let parsed: FeedbackReport = serde_json::from_value(json).expect("deserialize");
+        assert_eq!(parsed.utilities, report.utilities);
+        assert_eq!(parsed.entities_updated, 2);
     }
 
     #[test]

--- a/src/graph_bridge.rs
+++ b/src/graph_bridge.rs
@@ -23,10 +23,13 @@ pub async fn ingest_into_graph(
     // Hot path (SessionEnd hook): goes through the serve daemon so a
     // concurrent session never collides on the embedded store lock.
     // No LLM provider in standalone mode — episodes only, no entity extraction.
+    // Provenance is left to per-chunk turn-role inference: this is a
+    // conversation archive, the one place where authorship is visible.
     let request = crate::serve::Request::IngestArchive(crate::serve::IngestArchiveArgs {
         content: archive_content.to_string(),
         session_id: session_id.to_string(),
         log_number,
+        provenance: None,
     });
     let report: crate::graph::types::IngestionReport =
         serde_json::from_value(crate::serve_client::execute(memory_dir, &request).await?)?;
@@ -87,6 +90,7 @@ pub async fn ingest_into_graph_with_llm(
 
     // LLM-backed extraction cannot cross the socket (the provider lives in
     // this process), so this path takes the store exclusively instead.
+    let context = crate::graph::IngestContext::new(session_id, log_number);
     let report = crate::serve_client::exclusive(memory_dir, |gm| async move {
         let bridge = provider.map(GraphLlmBridge::new);
         let llm_ref: Option<&dyn crate::graph::llm::LlmProvider> = bridge
@@ -94,7 +98,7 @@ pub async fn ingest_into_graph_with_llm(
             .map(|b| b as &dyn crate::graph::llm::LlmProvider);
 
         Ok(gm
-            .ingest_archive(archive_content, session_id, log_number, llm_ref)
+            .ingest_archive(archive_content, &context, llm_ref)
             .await?)
     })
     .await?;

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -990,18 +990,62 @@ fn find_conversations_dir(memory_dir: &Path) -> Result<PathBuf, RecallError> {
     ))
 }
 
+/// Thresholds and mode for one `graph gc` invocation.
+///
+/// A struct rather than eight positional arguments: every field is a knob the
+/// CLI exposes, and callers should be able to take the defaults.
+#[derive(Debug, Clone)]
+pub struct GcOptions {
+    /// Actually delete. The default is a dry run.
+    pub execute: bool,
+    pub stale_days: u64,
+    pub stale_confidence: f64,
+    pub dead_confidence: f64,
+    pub dead_min_age_days: u64,
+    /// Also sweep episodes.
+    pub episodes: bool,
+    pub episode_max_age_days: u64,
+    /// Report health only, computing no deletion candidates.
+    pub stats_only: bool,
+}
+
+impl Default for GcOptions {
+    fn default() -> Self {
+        let defaults = crate::graph::gc::GcConfig::default();
+        Self {
+            execute: false,
+            stale_days: defaults.stale_days,
+            stale_confidence: defaults.stale_confidence,
+            dead_confidence: defaults.dead_confidence,
+            dead_min_age_days: defaults.dead_min_age_days,
+            episodes: false,
+            episode_max_age_days: defaults.episode_max_age_days,
+            stats_only: false,
+        }
+    }
+}
+
+impl GcOptions {
+    fn to_config(&self) -> crate::graph::gc::GcConfig {
+        crate::graph::gc::GcConfig {
+            stale_days: self.stale_days,
+            stale_confidence: self.stale_confidence,
+            dead_confidence: self.dead_confidence,
+            dead_min_age_days: self.dead_min_age_days,
+            collect_episodes: self.episodes,
+            episode_max_age_days: self.episode_max_age_days,
+            dry_run: !self.execute,
+            protect_pipeline: true,
+        }
+    }
+}
+
 /// Run garbage collection on the graph.
-#[allow(clippy::too_many_arguments)]
-pub async fn gc(
-    memory_dir: &Path,
-    execute: bool,
-    stale_days: u64,
-    stale_confidence: f64,
-    dead_confidence: f64,
-    dead_min_age_days: u64,
-    stats_only: bool,
-) -> Result<(), RecallError> {
-    use crate::graph::gc::{GcActionKind, GcConfig};
+pub async fn gc(memory_dir: &Path, options: &GcOptions) -> Result<(), RecallError> {
+    use crate::graph::gc::GcActionKind;
+
+    let stats_only = options.stats_only;
+    let config = options.to_config();
 
     let graph_dir = memory_dir.join("graph");
     if !graph_dir.exists() {
@@ -1033,15 +1077,6 @@ pub async fn gc(
             return Ok(());
         }
 
-        let config = GcConfig {
-            stale_days,
-            stale_confidence,
-            dead_confidence,
-            dead_min_age_days,
-            dry_run: !execute,
-            protect_pipeline: true,
-        };
-
         let report = gm.run_gc(&config).await?;
 
         // Header
@@ -1056,11 +1091,17 @@ pub async fn gc(
         println!("\n{BOLD}Scan{RESET}");
         println!("  Entities scanned:      {}", report.entities_scanned);
         println!("  Relationships scanned: {}", report.relationships_scanned);
+        if config.collect_episodes {
+            println!("  Episodes scanned:      {}", report.episodes_scanned);
+        }
 
         println!("\n{BOLD}Results{RESET}");
         println!("  Stale relationships:   {}", report.stale_relationships);
         println!("  Dead relationships:    {}", report.dead_relationships);
         println!("  Orphaned entities:     {}", report.orphaned_entities);
+        if config.collect_episodes {
+            println!("  Spent episodes:        {}", report.spent_episodes);
+        }
 
         let verb = if report.dry_run {
             "would remove"
@@ -1077,6 +1118,7 @@ pub async fn gc(
                     GcActionKind::StaleRelationship => format!("{YELLOW}⚠{RESET}"),
                     GcActionKind::DeadRelationship => format!("{YELLOW}✗{RESET}"),
                     GcActionKind::OrphanedEntity => format!("{CYAN}○{RESET}"),
+                    GcActionKind::SpentEpisode => format!("{CYAN}◌{RESET}"),
                 };
                 println!(
                     "  {icon} [{kind}] {name}",
@@ -1097,6 +1139,58 @@ pub async fn gc(
         Ok(())
     })
     .await
+}
+
+/// Apply an outcome to every entity a session touched.
+///
+/// A hot operation: it goes through the daemon like search and ingest, so it
+/// can be run while a session is still using the store.
+pub async fn feedback(
+    memory_dir: &Path,
+    session_id: &str,
+    outcome: &str,
+) -> Result<(), RecallError> {
+    use crate::graph::utility::OutcomeKind;
+    use crate::serve::FeedbackArgs;
+
+    let outcome: OutcomeKind = outcome.parse().map_err(RecallError::Other)?;
+
+    let request = Request::Feedback(FeedbackArgs {
+        session_id: session_id.to_string(),
+        outcome,
+    });
+    let report: crate::graph::utility::FeedbackReport =
+        serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
+
+    if report.entities_updated == 0 && report.utilities.is_empty() {
+        println!(
+            "{YELLOW}No entities recorded for session {session_id}.{RESET} \
+             {DIM}Nothing to apply the outcome to.{RESET}"
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{GREEN}✓{RESET} Session {BOLD}{session_id}{RESET} recorded as {BOLD}{outcome}{RESET} \
+         — {} entities updated",
+        report.entities_updated
+    );
+
+    for entity in &report.utilities {
+        println!(
+            "  {DIM}{}{RESET} utility {CYAN}{:.3}{RESET}",
+            entity.entity_id, entity.utility_score
+        );
+    }
+
+    if !report.errors.is_empty() {
+        println!("\n{YELLOW}Warnings:{RESET}");
+        for err in &report.errors {
+            println!("  {DIM}{err}{RESET}");
+        }
+    }
+
+    Ok(())
 }
 
 /// Show relationship decay report — lists all relationships with their stored vs effective confidence.

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -5,6 +5,7 @@ use std::path::{Path, PathBuf};
 use crate::error::RecallError;
 use crate::graph::traverse::format_traversal;
 use crate::graph::types::*;
+use crate::graph::{IngestContext, Provenance};
 use crate::serve::{
     AddEntityArgs, IngestArchiveArgs, QueryArgs, RelateArgs, Request, SearchArgs, TraverseArgs,
 };
@@ -199,7 +200,15 @@ pub async fn search(
 }
 
 /// Ingest a single archive file into the graph (episodes only, no LLM extraction).
-pub async fn ingest(memory_dir: &Path, archive_path: &Path) -> Result<(), RecallError> {
+///
+/// `provenance` forces an authorship class on every episode of the run — how
+/// `--external` marks genuinely external material. `None` infers per chunk
+/// from conversation turn roles.
+pub async fn ingest(
+    memory_dir: &Path,
+    archive_path: &Path,
+    provenance: Option<Provenance>,
+) -> Result<(), RecallError> {
     let graph_dir = memory_dir.join("graph");
     if !graph_dir.exists() {
         return Err(RecallError::NotInitialized(
@@ -216,14 +225,16 @@ pub async fn ingest(memory_dir: &Path, archive_path: &Path) -> Result<(), Recall
         content,
         session_id,
         log_number,
+        provenance,
     });
     let report: IngestionReport =
         serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
 
     println!(
-        "{GREEN}✓{RESET} Ingested {}: {} episodes created",
+        "{GREEN}✓{RESET} Ingested {}: {} episodes created {DIM}(provenance: {}){RESET}",
         archive_path.display(),
-        report.episodes_created
+        report.episodes_created,
+        provenance_label(provenance)
     );
     if !report.errors.is_empty() {
         for err in &report.errors {
@@ -233,8 +244,21 @@ pub async fn ingest(memory_dir: &Path, archive_path: &Path) -> Result<(), Recall
     Ok(())
 }
 
+/// How an ingest run's provenance choice reads in its summary line.
+fn provenance_label(provenance: Option<Provenance>) -> &'static str {
+    match provenance {
+        Some(Provenance::External) => "external",
+        Some(Provenance::User) => "user",
+        Some(Provenance::SelfGenerated) => "self",
+        None => "per turn role",
+    }
+}
+
 /// Ingest all un-ingested archives in conversations/.
-pub async fn ingest_all(memory_dir: &Path) -> Result<(), RecallError> {
+pub async fn ingest_all(
+    memory_dir: &Path,
+    provenance: Option<Provenance>,
+) -> Result<(), RecallError> {
     let graph_dir = memory_dir.join("graph");
     if !graph_dir.exists() {
         return Err(RecallError::NotInitialized(
@@ -278,9 +302,8 @@ pub async fn ingest_all(memory_dir: &Path) -> Result<(), RecallError> {
                 }
             }
 
-            let report = gm
-                .ingest_archive(&content, &session_id, log_number, None)
-                .await?;
+            let context = IngestContext::new(session_id, log_number).with_override(provenance);
+            let report = gm.ingest_archive(&content, &context, None).await?;
 
             total_episodes += report.episodes_created;
             ingested += 1;
@@ -293,7 +316,8 @@ pub async fn ingest_all(memory_dir: &Path) -> Result<(), RecallError> {
         }
 
         println!(
-            "\n{GREEN}✓{RESET} Ingested {ingested} archives ({total_episodes} episodes), skipped {skipped} already ingested"
+            "\n{GREEN}✓{RESET} Ingested {ingested} archives ({total_episodes} episodes), skipped {skipped} already ingested {DIM}(provenance: {}){RESET}",
+            provenance_label(provenance)
         );
         Ok(())
     })
@@ -596,12 +620,10 @@ pub async fn extract(
 
             let content = std::fs::read_to_string(&archive_path)?;
             let (session_id, _) = extract_archive_metadata(&content, &archive_path);
+            let context = IngestContext::new(session_id, Some(*ln));
 
             // Try extraction, retry once on failure, quarantine on second failure
-            let report = match gm
-                .extract_from_archive(&content, &session_id, Some(*ln), &*llm)
-                .await
-            {
+            let report = match gm.extract_from_archive(&content, &context, &*llm).await {
                 Ok(r) => r,
                 Err(e) => {
                     println!(
@@ -609,10 +631,7 @@ pub async fn extract(
                         idx + 1,
                         total_count
                     );
-                    match gm
-                        .extract_from_archive(&content, &session_id, Some(*ln), &*llm)
-                        .await
-                    {
+                    match gm.extract_from_archive(&content, &context, &*llm).await {
                         Ok(r) => r,
                         Err(e2) => {
                             println!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -305,7 +305,7 @@ enum GraphCommands {
         #[command(subcommand)]
         command: PipelineCommands,
     },
-    /// Garbage collection — prune stale/dead relationships and orphaned entities
+    /// Garbage collection — prune stale/dead relationships, orphaned entities, spent episodes
     Gc {
         /// Actually delete (default is dry-run)
         #[arg(long)]
@@ -322,9 +322,23 @@ enum GraphCommands {
         /// Minimum age in days for dead relationship pruning (default: 14)
         #[arg(long, default_value = "14")]
         dead_min_age_days: u64,
+        /// Also sweep episodes: old, never-retrieved, self-authored, cited by nothing
+        #[arg(long)]
+        episodes: bool,
+        /// Days before a never-retrieved episode may be collected (default: 180)
+        #[arg(long, default_value = "180")]
+        episode_max_age_days: u64,
         /// Only show graph health stats, don't compute GC candidates
         #[arg(long)]
         stats_only: bool,
+    },
+    /// Apply a session outcome to the entities it touched (utility feedback)
+    Feedback {
+        /// Session identifier the archive was ingested under
+        session_id: String,
+        /// How the session went: success, partial, failed
+        #[arg(long, default_value = "success")]
+        outcome: String,
     },
     /// Sync vigil-pulse signals and outcomes into the graph
     VigilSync {
@@ -599,19 +613,26 @@ fn main() {
                                 stale_confidence,
                                 dead_confidence,
                                 dead_min_age_days,
+                                episodes,
+                                episode_max_age_days,
                                 stats_only,
                             } => {
-                                graph_cli::gc(
-                                    &memory_dir,
+                                let options = graph_cli::GcOptions {
                                     execute,
                                     stale_days,
                                     stale_confidence,
                                     dead_confidence,
                                     dead_min_age_days,
+                                    episodes,
+                                    episode_max_age_days,
                                     stats_only,
-                                )
-                                .await
+                                };
+                                graph_cli::gc(&memory_dir, &options).await
                             }
+                            GraphCommands::Feedback {
+                                session_id,
+                                outcome,
+                            } => graph_cli::feedback(&memory_dir, &session_id, &outcome).await,
                             GraphCommands::Daemon { command } => match command {
                                 DaemonCommands::Status => {
                                     graph_cli::daemon_status(&memory_dir).await

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,9 +263,18 @@ enum GraphCommands {
     Ingest {
         /// Path to conversation archive file
         archive: PathBuf,
+        /// Treat the file as externally authored (documents, tool output)
+        /// instead of inferring authorship from conversation turn roles
+        #[arg(long)]
+        external: bool,
     },
     /// Scan conversations/ for un-ingested archives and ingest them all
-    IngestAll,
+    IngestAll {
+        /// Treat every file as externally authored instead of inferring
+        /// authorship from conversation turn roles
+        #[arg(long)]
+        external: bool,
+    },
     /// Extract entities from already-ingested archives using an LLM
     #[cfg(feature = "llm")]
     Extract {
@@ -539,10 +548,18 @@ fn main() {
                                 )
                                 .await
                             }
-                            GraphCommands::Ingest { archive } => {
-                                graph_cli::ingest(&memory_dir, &archive).await
+                            GraphCommands::Ingest { archive, external } => {
+                                graph_cli::ingest(
+                                    &memory_dir,
+                                    &archive,
+                                    external_provenance(external),
+                                )
+                                .await
                             }
-                            GraphCommands::IngestAll => graph_cli::ingest_all(&memory_dir).await,
+                            GraphCommands::IngestAll { external } => {
+                                graph_cli::ingest_all(&memory_dir, external_provenance(external))
+                                    .await
+                            }
                             #[cfg(feature = "llm")]
                             GraphCommands::Extract {
                                 log,
@@ -654,6 +671,12 @@ fn run_serve(
 
 fn resolve_entity_root(explicit: Option<PathBuf>) -> PathBuf {
     explicit.unwrap_or_else(|| paths::entity_root().unwrap_or_else(|_| PathBuf::from(".")))
+}
+
+/// The provenance override a `--external` flag asks for. Without the flag the
+/// class is inferred per chunk from conversation turn roles.
+fn external_provenance(external: bool) -> Option<recall_echo::graph::Provenance> {
+    external.then_some(recall_echo::graph::Provenance::External)
 }
 
 #[cfg(feature = "bench")]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -30,7 +30,7 @@ use crate::graph::error::GraphError;
 use crate::graph::types::{
     EntityType, NewEntity, NewRelationship, PipelineDocuments, QueryOptions, SearchOptions,
 };
-use crate::graph::GraphMemory;
+use crate::graph::{GraphMemory, IngestContext, Provenance};
 use crate::serve_security::{
     append_private_file, check_peer_uid, current_uid, unlink_socket, PRIVATE_FILE_MODE,
 };
@@ -192,6 +192,10 @@ pub struct IngestArchiveArgs {
     pub session_id: String,
     #[serde(default)]
     pub log_number: Option<u32>,
+    /// Force one provenance class on every episode of this run. Absent — the
+    /// shape older clients send — means infer per chunk from turn roles.
+    #[serde(default)]
+    pub provenance: Option<Provenance>,
 }
 
 /// Pipeline sync needs no LLM provider, so it runs against the daemon like any
@@ -406,9 +410,9 @@ async fn execute_graph(
             serde_json::to_value(relationship)?
         }
         Request::IngestArchive(args) => {
-            let report = graph
-                .ingest_archive(&args.content, &args.session_id, args.log_number, None)
-                .await?;
+            let context = IngestContext::new(args.session_id.clone(), args.log_number)
+                .with_override(args.provenance);
+            let report = graph.ingest_archive(&args.content, &context, None).await?;
             serde_json::to_value(report)?
         }
         Request::SyncPipeline(args) => {
@@ -1065,6 +1069,7 @@ mod tests {
                 content: "# log".into(),
                 session_id: "s1".into(),
                 log_number: Some(7),
+                provenance: Some(Provenance::External),
             }),
             Request::SyncPipeline(SyncPipelineArgs {
                 docs: PipelineDocuments {
@@ -1080,6 +1085,25 @@ mod tests {
             let parsed: Request = serde_json::from_str(&line).unwrap();
             assert_eq!(parsed, request, "round trip failed for {line}");
         }
+    }
+
+    #[test]
+    fn ingest_requests_without_provenance_still_parse() {
+        // The wire shape older clients send: absent means "infer from turn
+        // roles", so a pre-provenance client keeps working unchanged.
+        let parsed: Request = serde_json::from_str(
+            r##"{"op":"ingest_archive","args":{"content":"# log","session_id":"s1"}}"##,
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            Request::IngestArchive(IngestArchiveArgs {
+                content: "# log".into(),
+                session_id: "s1".into(),
+                log_number: None,
+                provenance: None,
+            })
+        );
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1265,6 +1265,7 @@ mod tests {
             content: "# log".into(),
             session_id: "s1".into(),
             log_number: Some(1),
+            provenance: None,
         })
         .is_retryable());
         assert!(!Request::AddEntity(AddEntityArgs {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -30,6 +30,7 @@ use crate::graph::error::GraphError;
 use crate::graph::types::{
     EntityType, NewEntity, NewRelationship, PipelineDocuments, QueryOptions, SearchOptions,
 };
+use crate::graph::utility::OutcomeKind;
 use crate::graph::{GraphMemory, IngestContext, Provenance};
 use crate::serve_security::{
     append_private_file, check_peer_uid, current_uid, unlink_socket, PRIVATE_FILE_MODE,
@@ -82,6 +83,8 @@ pub enum Request {
     IngestArchive(IngestArchiveArgs),
     /// Sync the pipeline documents into the graph (no LLM extraction).
     SyncPipeline(SyncPipelineArgs),
+    /// Apply an outcome to the entities a session touched.
+    Feedback(FeedbackArgs),
     /// Ask the daemon to exit.
     Shutdown,
 }
@@ -101,6 +104,7 @@ impl Request {
             Request::Relate(_) => "relate",
             Request::IngestArchive(_) => "ingest_archive",
             Request::SyncPipeline(_) => "sync_pipeline",
+            Request::Feedback(_) => "feedback",
             Request::Shutdown => "shutdown",
         }
     }
@@ -122,6 +126,8 @@ impl Request {
             | Request::Traverse(_)
             // Pipeline sync diffs documents against the graph.
             | Request::SyncPipeline(_)
+            // Outcome records replace per (entity, session) — reruns correct.
+            | Request::Feedback(_)
             | Request::Shutdown => true,
             Request::AddEntity(_) | Request::Relate(_) | Request::IngestArchive(_) => false,
         }
@@ -203,6 +209,12 @@ pub struct IngestArchiveArgs {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SyncPipelineArgs {
     pub docs: PipelineDocuments,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct FeedbackArgs {
+    pub session_id: String,
+    pub outcome: OutcomeKind,
 }
 
 /// A daemon response. Wire form is `{"ok": true, "data": ...}` or
@@ -418,6 +430,11 @@ async fn execute_graph(
         Request::SyncPipeline(args) => {
             serde_json::to_value(graph.sync_pipeline(&args.docs).await?)?
         }
+        Request::Feedback(args) => serde_json::to_value(
+            graph
+                .record_session_outcome(&args.session_id, args.outcome)
+                .await?,
+        )?,
     };
     Ok(Some(data))
 }
@@ -1077,6 +1094,10 @@ mod tests {
                     ..PipelineDocuments::default()
                 },
             }),
+            Request::Feedback(FeedbackArgs {
+                session_id: "s1".into(),
+                outcome: OutcomeKind::Success,
+            }),
             Request::Shutdown,
         ];
 
@@ -1104,6 +1125,19 @@ mod tests {
                 provenance: None,
             })
         );
+    }
+
+    #[test]
+    fn feedback_is_a_hot_op_with_a_snake_case_outcome() {
+        let request = Request::Feedback(FeedbackArgs {
+            session_id: "conversation-042".into(),
+            outcome: OutcomeKind::Failed,
+        });
+        let json = serde_json::to_value(&request).unwrap();
+        assert_eq!(json["op"], "feedback");
+        assert_eq!(json["args"]["session_id"], "conversation-042");
+        assert_eq!(json["args"]["outcome"], "failed");
+        assert_eq!(request.op_name(), "feedback");
     }
 
     #[test]

--- a/tests/feedback.rs
+++ b/tests/feedback.rs
@@ -1,0 +1,368 @@
+//! The outcome-feedback tier, wired end to end (Phase 1, increment 3 — AC5).
+//!
+//! Two properties:
+//!
+//! - **Passive was-used.** Recording what a session touched creates the
+//!   `contributed_to` records a later outcome needs, without judging the
+//!   session and without moving a utility score.
+//! - **`graph feedback` moves utility.** The CLI verb's request, run through
+//!   the daemon exactly as the CLI runs it, changes the stored utility scores
+//!   of the entities the session touched.
+//!
+//! Fixtures are raw SurrealQL — feedback is graph writes and arithmetic, so no
+//! embedding model is involved.
+
+use std::path::{Path, PathBuf};
+use std::sync::Once;
+
+use recall_echo::graph::store::{self, Db};
+use recall_echo::graph::utility::{self, FeedbackReport, OutcomeKind, DEFAULT_UTILITY};
+use recall_echo::serve::{FeedbackArgs, Request};
+use recall_echo::serve_client;
+use surrealdb::Surreal;
+use tempfile::TempDir;
+
+const SESSION: &str = "conversation-042";
+
+static BIN_ENV: Once = Once::new();
+
+/// Point the daemon client at the binary cargo just built.
+fn use_test_binary() {
+    BIN_ENV.call_once(|| {
+        std::env::set_var(
+            serve_client::DAEMON_BIN_ENV,
+            env!("CARGO_BIN_EXE_recall-echo"),
+        );
+    });
+}
+
+/// A memory directory with a graph store and its own daemon socket.
+struct Fixture {
+    _dir: TempDir,
+    memory_dir: PathBuf,
+    graph_dir: PathBuf,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        use_test_binary();
+
+        let dir = TempDir::new().expect("temp dir");
+        let memory_dir = dir.path().join("e").join("memory");
+        let graph_dir = memory_dir.join("graph");
+        std::fs::create_dir_all(&graph_dir).expect("memory dir");
+
+        std::fs::write(
+            memory_dir.join(".recall-echo.toml"),
+            format!(
+                "[serve]\nsocket_path = \"{}\"\nidle_timeout_secs = 120\n",
+                dir.path().join("g.sock").display()
+            ),
+        )
+        .expect("write config");
+
+        Self {
+            _dir: dir,
+            memory_dir,
+            graph_dir,
+        }
+    }
+
+    /// Open the store directly. Only valid while no daemon holds it.
+    async fn open(&self) -> Surreal<Db> {
+        let db = store::open(&self.graph_dir).await.expect("open store");
+        store::init_schema(&db).await.expect("init schema");
+        db
+    }
+}
+
+/// Release the embedded store's process lock.
+async fn close(db: Surreal<Db>) {
+    drop(db);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}
+
+async fn create_entity(db: &Surreal<Db>, id: &str, name: &str, source: &str) {
+    db.query(
+        r#"CREATE type::record($id) SET
+               name = $name,
+               entity_type = 'concept',
+               abstract = $name,
+               overview = '',
+               mutable = true,
+               access_count = 0,
+               utility_score = $utility,
+               utility_updates = 0,
+               created_at = time::now(),
+               updated_at = time::now(),
+               source = $source"#,
+    )
+    .bind(("id", id.to_string()))
+    .bind(("name", name.to_string()))
+    .bind(("utility", DEFAULT_UTILITY))
+    .bind(("source", source.to_string()))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create entity {id}: {e}"));
+}
+
+/// The `contributed_to` records of one session, as (entity, result, was_used).
+async fn contribution_records(db: &Surreal<Db>, session_id: &str) -> Vec<(String, String, bool)> {
+    let mut response = db
+        .query(
+            r#"SELECT type::string(in) AS entity, outcome_result, was_used
+               FROM contributed_to WHERE session_id = $sid"#,
+        )
+        .bind(("sid", session_id.to_string()))
+        .await
+        .expect("list contribution records");
+
+    let rows: Vec<serde_json::Value> = response.take(0).expect("read contribution records");
+    let mut records: Vec<(String, String, bool)> = rows
+        .iter()
+        .map(|row| {
+            (
+                row["entity"].as_str().unwrap_or_default().to_string(),
+                row["outcome_result"]
+                    .as_str()
+                    .unwrap_or_default()
+                    .to_string(),
+                row["was_used"].as_bool().unwrap_or_default(),
+            )
+        })
+        .collect();
+    records.sort();
+    records
+}
+
+async fn count_outcome_entities(db: &Surreal<Db>, session_id: &str) -> usize {
+    let mut response = db
+        .query(
+            r#"SELECT id FROM entity
+               WHERE entity_type = "outcome" AND attributes.session_id = $sid"#,
+        )
+        .bind(("sid", session_id.to_string()))
+        .await
+        .expect("count outcome entities");
+
+    let rows: Vec<serde_json::Value> = response.take(0).expect("read outcome entities");
+    rows.len()
+}
+
+async fn utility_of(db: &Surreal<Db>, entity_id: &str) -> f64 {
+    utility::get_utility_score(db, entity_id)
+        .await
+        .expect("read utility score")
+}
+
+fn approx(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-9
+}
+
+/// Two entities the session touched, linked passively.
+async fn seed_session(db: &Surreal<Db>) {
+    create_entity(db, "entity:alpha", "Alpha", SESSION).await;
+    create_entity(db, "entity:beta", "Beta", SESSION).await;
+    record_session_use(db).await;
+}
+
+/// Record the passive was-used link for both seeded entities.
+async fn record_session_use(db: &Surreal<Db>) {
+    utility::record_session_use(
+        db,
+        SESSION,
+        &["entity:alpha".to_string(), "entity:beta".to_string()],
+    )
+    .await
+    .expect("record session use");
+}
+
+// ── Passive was-used ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn session_use_records_edges_without_judging_the_session() {
+    let fixture = Fixture::new();
+    let db = fixture.open().await;
+
+    seed_session(&db).await;
+
+    assert_eq!(
+        contribution_records(&db, SESSION).await,
+        vec![
+            ("entity:alpha".to_string(), "pending".to_string(), true),
+            ("entity:beta".to_string(), "pending".to_string(), true),
+        ],
+        "every touched entity gets one unadjudicated was-used record"
+    );
+    assert!(
+        approx(utility_of(&db, "entity:alpha").await, DEFAULT_UTILITY),
+        "an unjudged session is not evidence of usefulness"
+    );
+
+    // The linkage is a set — assert membership, not the store's row order.
+    let session = utility::session_entities(&db, SESSION)
+        .await
+        .expect("resolve session entities");
+    let mut retrieved = session.retrieved.clone();
+    retrieved.sort();
+    let mut used = session.used.clone();
+    used.sort();
+    assert_eq!(retrieved, vec!["entity:alpha", "entity:beta"]);
+    assert_eq!(
+        used, retrieved,
+        "a passively recorded entity counts as used"
+    );
+
+    close(db).await;
+}
+
+#[tokio::test]
+async fn re_recording_a_session_does_not_duplicate_its_records() {
+    let fixture = Fixture::new();
+    let db = fixture.open().await;
+
+    seed_session(&db).await;
+    record_session_use(&db).await;
+
+    assert_eq!(
+        contribution_records(&db, SESSION).await.len(),
+        2,
+        "one record per entity per session, however often ingest re-runs"
+    );
+    assert_eq!(count_outcome_entities(&db, SESSION).await, 1);
+
+    close(db).await;
+}
+
+#[tokio::test]
+async fn sessions_without_records_fall_back_to_authorship() {
+    let fixture = Fixture::new();
+    let db = fixture.open().await;
+
+    // Ingested before passive recording existed: the entities carry the
+    // session as their source, and nothing else links them to it.
+    create_entity(&db, "entity:legacy", "Legacy", SESSION).await;
+
+    let session = utility::session_entities(&db, SESSION)
+        .await
+        .expect("resolve session entities");
+    assert_eq!(session.retrieved, vec!["entity:legacy"]);
+    assert_eq!(session.used, vec!["entity:legacy"]);
+
+    close(db).await;
+}
+
+// ── graph feedback ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn feedback_through_the_daemon_moves_utility_scores() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_session(&db).await;
+    let before = utility_of(&db, "entity:alpha").await;
+    close(db).await;
+
+    // Exactly the request `graph feedback <session> --outcome success` sends.
+    let report = feedback(&fixture.memory_dir, OutcomeKind::Success).await;
+
+    assert_eq!(report.entities_updated, 2, "{:?}", report.errors);
+    assert!(report.errors.is_empty(), "{:?}", report.errors);
+    assert_eq!(report.utilities.len(), 2);
+    assert!(
+        report.utilities.iter().all(|u| u.utility_score > before),
+        "the report shows where every entity landed: {:?}",
+        report.utilities
+    );
+
+    serve_client::stop_daemon(&fixture.memory_dir)
+        .await
+        .expect("stop daemon");
+
+    let db = fixture.open().await;
+    let after = utility_of(&db, "entity:alpha").await;
+    assert!(
+        after > before,
+        "a successful session raises utility: {before} -> {after}"
+    );
+    assert_eq!(
+        contribution_records(&db, SESSION).await,
+        vec![
+            ("entity:alpha".to_string(), "success".to_string(), true),
+            ("entity:beta".to_string(), "success".to_string(), true),
+        ],
+        "the pending records are resolved, not duplicated"
+    );
+    assert_eq!(
+        count_outcome_entities(&db, SESSION).await,
+        1,
+        "one outcome record per session"
+    );
+    close(db).await;
+}
+
+#[tokio::test]
+async fn failure_feedback_lowers_utility() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_session(&db).await;
+    let before = utility_of(&db, "entity:beta").await;
+    close(db).await;
+
+    let report = feedback(&fixture.memory_dir, OutcomeKind::Failed).await;
+    assert_eq!(report.entities_updated, 2, "{:?}", report.errors);
+
+    serve_client::stop_daemon(&fixture.memory_dir)
+        .await
+        .expect("stop daemon");
+
+    let db = fixture.open().await;
+    let after = utility_of(&db, "entity:beta").await;
+    assert!(
+        after < before,
+        "a failed session lowers utility: {before} -> {after}"
+    );
+    close(db).await;
+}
+
+#[tokio::test]
+async fn feedback_for_an_unknown_session_changes_nothing() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_session(&db).await;
+    close(db).await;
+
+    let report = feedback_for(&fixture.memory_dir, "no-such-session", OutcomeKind::Success).await;
+    assert_eq!(report.entities_updated, 0);
+    assert!(report.utilities.is_empty());
+    assert!(report.outcome_entity_id.is_empty());
+
+    serve_client::stop_daemon(&fixture.memory_dir)
+        .await
+        .expect("stop daemon");
+
+    let db = fixture.open().await;
+    assert!(
+        approx(utility_of(&db, "entity:alpha").await, DEFAULT_UTILITY),
+        "an outcome for a session we know nothing about touches nothing"
+    );
+    close(db).await;
+}
+
+async fn feedback(memory_dir: &Path, outcome: OutcomeKind) -> FeedbackReport {
+    feedback_for(memory_dir, SESSION, outcome).await
+}
+
+/// Run the feedback verb's request through the daemon and decode its report.
+async fn feedback_for(memory_dir: &Path, session_id: &str, outcome: OutcomeKind) -> FeedbackReport {
+    let request = Request::Feedback(FeedbackArgs {
+        session_id: session_id.to_string(),
+        outcome,
+    });
+    let data = serve_client::execute(memory_dir, &request)
+        .await
+        .expect("feedback request");
+    serde_json::from_value(data).expect("decode feedback report")
+}

--- a/tests/graph_confidence.rs
+++ b/tests/graph_confidence.rs
@@ -9,31 +9,45 @@ fn approx(a: f64, b: f64) -> bool {
     (a - b).abs() < 0.01
 }
 
-// ── Bayesian Update ────────────────────────────────────────────────
+// ── Evidence accumulation ──────────────────────────────────────────
+
+/// Evidence at the prior for `mean`, after `observations` corroborations
+/// (positive count) or contradictions (negative count).
+fn accumulate(mean: f64, observations: i32) -> Evidence {
+    let mut evidence = Evidence::from_prior(mean);
+    for _ in 0..observations.abs() {
+        if observations > 0 {
+            evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+        } else {
+            evidence.contradict(DEFAULT_EVIDENCE_WEIGHT);
+        }
+    }
+    evidence
+}
 
 #[test]
-fn bayesian_update_all_priors() {
+fn single_corroboration_from_all_priors() {
     // Authoritative (1.0): alpha=10, beta=0 -> corroborate: 11/11=1.0
-    let auth = bayesian_update(1.0, true);
+    let auth = accumulate(1.0, 1).mean();
     assert!(auth > 0.99, "authoritative corroborate: {auth}");
 
     // Explicit (0.9): alpha=9, beta=1 -> corroborate: 10/11≈0.909
-    let expl = bayesian_update(0.9, true);
+    let expl = accumulate(0.9, 1).mean();
     assert!(approx(expl, 0.909), "explicit corroborate: {expl}");
 
     // Inferred (0.6): alpha=6, beta=4 -> corroborate: 7/11≈0.636
-    let inf = bayesian_update(0.6, true);
+    let inf = accumulate(0.6, 1).mean();
     assert!(approx(inf, 0.636), "inferred corroborate: {inf}");
 
     // Speculative (0.3): alpha=3, beta=7 -> corroborate: 4/11≈0.364
-    let spec = bayesian_update(0.3, true);
+    let spec = accumulate(0.3, 1).mean();
     assert!(approx(spec, 0.364), "speculative corroborate: {spec}");
 }
 
 #[test]
-fn bayesian_update_contradiction_reduces() {
+fn contradiction_reduces_the_mean() {
     let before = 0.6;
-    let after = bayesian_update(before, false);
+    let after = accumulate(before, -1).mean();
     assert!(
         after < before,
         "contradiction should reduce: {before} -> {after}"
@@ -41,27 +55,57 @@ fn bayesian_update_contradiction_reduces() {
 }
 
 #[test]
-fn bayesian_update_repeated_corroboration_converges() {
-    let mut score = 0.3; // speculative
-    for _ in 0..50 {
-        score = bayesian_update(score, true);
-    }
+fn repeated_corroboration_converges_upward() {
+    // Speculative prior (alpha=3, beta=7). Corroboration only adds to alpha —
+    // the 7 units of prior doubt are never discarded, so convergence toward
+    // 1.0 is bounded by how much evidence has actually accumulated. (The
+    // pre-Phase-1 stateless update re-derived the counts each time and so
+    // reached 0.95 in 50 steps; that speed was an artifact of forgetting.)
+    let fifty = accumulate(0.3, 50).mean();
+    assert!(fifty > 0.85, "50 corroborations: {fifty}");
+    assert!(fifty < 1.0, "doubt is never fully erased: {fifty}");
+
+    let two_hundred = accumulate(0.3, 200).mean();
     assert!(
-        score > 0.95,
-        "50 corroborations should converge near 1.0: {score}"
+        two_hundred > fifty,
+        "more evidence must move further: {two_hundred} vs {fifty}"
     );
+    assert!(two_hundred > 0.95, "200 corroborations: {two_hundred}");
 }
 
 #[test]
-fn bayesian_update_repeated_contradiction_converges() {
-    let mut score = 0.9; // explicit
-    for _ in 0..50 {
-        score = bayesian_update(score, false);
-    }
+fn repeated_contradiction_converges_downward() {
+    let fifty = accumulate(0.9, -50).mean();
+    assert!(fifty < 0.2, "50 contradictions: {fifty}");
+
+    let two_hundred = accumulate(0.9, -200).mean();
     assert!(
-        score < 0.05,
-        "50 contradictions should converge near 0.0: {score}"
+        two_hundred < fifty,
+        "more evidence must move further: {two_hundred} vs {fifty}"
     );
+    assert!(two_hundred < 0.05, "200 contradictions: {two_hundred}");
+}
+
+#[test]
+fn accumulated_evidence_narrows_the_posterior() {
+    // AC1: the property the stateless model could not express.
+    let one = accumulate(0.6, 1);
+    let five = accumulate(0.6, 5);
+    let fifty = accumulate(0.6, 50);
+
+    assert!(
+        five.variance() < one.variance(),
+        "5 obs {} vs 1 obs {}",
+        five.variance(),
+        one.variance()
+    );
+    assert!(
+        fifty.variance() < five.variance(),
+        "50 obs {} vs 5 obs {}",
+        fifty.variance(),
+        five.variance()
+    );
+    assert!(fifty.concentration() > five.concentration());
 }
 
 // ── Temporal Decay ────────────────────────────────────────────────

--- a/tests/graph_episode_gc.rs
+++ b/tests/graph_episode_gc.rs
@@ -1,0 +1,261 @@
+//! Episode garbage collection (Phase 1, increment 3 — AC4).
+//!
+//! An episode is collectable only when all four hold: older than the
+//! configured age, never retrieved, self-authored, and cited as `source` by no
+//! surviving entity or relationship. The dry run must name exactly those
+//! episodes; the real run must remove exactly those episodes.
+//!
+//! Fixtures are raw SurrealQL, so no embedding model is involved — episode
+//! collection is arithmetic on timestamps and a set membership test.
+
+use chrono::{Duration, Utc};
+use recall_echo::graph::crud;
+use recall_echo::graph::gc::{self, GcActionKind, GcConfig};
+use recall_echo::graph::store::{self, Db};
+use surrealdb::Surreal;
+use tempfile::TempDir;
+
+/// A store with the current schema, on a directory that lives as long as the
+/// returned `TempDir`.
+async fn open_store() -> (TempDir, Surreal<Db>) {
+    let dir = TempDir::new().expect("temp dir");
+    let graph_path = dir.path().join("graph");
+    std::fs::create_dir_all(&graph_path).expect("graph dir");
+
+    let db = store::open(&graph_path).await.expect("open store");
+    store::init_schema(&db).await.expect("init schema");
+
+    (dir, db)
+}
+
+/// Create an episode with an explicit age and authorship class.
+async fn create_episode(db: &Surreal<Db>, id: &str, session_id: &str, age_days: i64, class: &str) {
+    let timestamp = (Utc::now() - Duration::days(age_days)).to_rfc3339();
+    db.query(
+        r#"CREATE type::record($id) SET
+               session_id = $session_id,
+               timestamp = type::datetime($timestamp),
+               abstract = $session_id,
+               overview = NONE,
+               content = 'chunk text',
+               log_number = NONE,
+               extracted = false,
+               provenance = $provenance"#,
+    )
+    .bind(("id", id.to_string()))
+    .bind(("session_id", session_id.to_string()))
+    .bind(("timestamp", timestamp))
+    .bind(("provenance", class.to_string()))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create episode {id}: {e}"));
+}
+
+/// An episode with no `provenance` field at all — written before the class
+/// existed.
+async fn create_legacy_episode(db: &Surreal<Db>, id: &str, session_id: &str, age_days: i64) {
+    let timestamp = (Utc::now() - Duration::days(age_days)).to_rfc3339();
+    db.query(
+        r#"CREATE type::record($id) SET
+               session_id = $session_id,
+               timestamp = type::datetime($timestamp),
+               abstract = $session_id,
+               content = 'chunk text',
+               extracted = false"#,
+    )
+    .bind(("id", id.to_string()))
+    .bind(("session_id", session_id.to_string()))
+    .bind(("timestamp", timestamp))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create legacy episode {id}: {e}"));
+}
+
+async fn create_entity(db: &Surreal<Db>, id: &str, name: &str, source: &str) {
+    db.query(
+        r#"CREATE type::record($id) SET
+               name = $name,
+               entity_type = 'concept',
+               abstract = $name,
+               overview = '',
+               mutable = true,
+               access_count = 1,
+               created_at = time::now(),
+               updated_at = time::now(),
+               source = $source"#,
+    )
+    .bind(("id", id.to_string()))
+    .bind(("name", name.to_string()))
+    .bind(("source", source.to_string()))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create entity {id}: {e}"));
+}
+
+/// Episode record IDs still in the store, sorted.
+async fn surviving_episode_ids(db: &Surreal<Db>) -> Vec<String> {
+    let mut response = db
+        .query("SELECT type::string(id) AS id FROM episode")
+        .await
+        .expect("list episodes");
+    let rows: Vec<serde_json::Value> = response.take(0).expect("read episode ids");
+
+    let mut ids: Vec<String> = rows
+        .iter()
+        .filter_map(|row| row["id"].as_str().map(String::from))
+        .collect();
+    ids.sort();
+    ids
+}
+
+/// The episodes a report names as collectable, sorted.
+fn named_episodes(report: &gc::GcReport) -> Vec<String> {
+    let mut ids: Vec<String> = report
+        .actions
+        .iter()
+        .filter(|a| a.kind == GcActionKind::SpentEpisode)
+        .map(|a| a.target_id.clone())
+        .collect();
+    ids.sort();
+    ids
+}
+
+fn episode_gc(dry_run: bool) -> GcConfig {
+    GcConfig {
+        collect_episodes: true,
+        dry_run,
+        ..Default::default()
+    }
+}
+
+/// One old self-authored episode per protection class, plus two genuinely
+/// spent ones. Every survivor survives for a different reason.
+async fn seed_mixed_episodes(db: &Surreal<Db>) {
+    create_episode(db, "episode:spent_a", "session-spent-a", 200, "self").await;
+    create_episode(db, "episode:spent_b", "session-spent-b", 900, "self").await;
+    create_legacy_episode(db, "episode:legacy", "session-legacy", 400).await;
+
+    create_episode(db, "episode:young", "session-young", 10, "self").await;
+    create_episode(db, "episode:user", "session-user", 900, "user").await;
+    create_episode(db, "episode:external", "session-external", 900, "external").await;
+    create_episode(db, "episode:evidence", "session-evidence", 900, "self").await;
+    create_episode(db, "episode:read", "session-read", 900, "self").await;
+
+    // The evidence episode's session produced an entity that still exists.
+    create_entity(db, "entity:cited", "Cited", "session-evidence").await;
+    // The read episode has been returned by retrieval at least once.
+    crud::increment_episode_access_counts(db, &["episode:read".to_string()])
+        .await
+        .expect("increment episode access count");
+}
+
+#[tokio::test]
+async fn dry_run_names_exactly_the_spent_episodes_and_deletes_nothing() {
+    let (_dir, db) = open_store().await;
+    seed_mixed_episodes(&db).await;
+
+    let before = surviving_episode_ids(&db).await;
+    let report = gc::run_gc(&db, &episode_gc(true)).await.expect("gc");
+
+    assert_eq!(
+        named_episodes(&report),
+        vec![
+            "episode:legacy".to_string(),
+            "episode:spent_a".to_string(),
+            "episode:spent_b".to_string(),
+        ],
+        "dry run must name exactly the old, unread, self-authored, uncited episodes"
+    );
+    assert_eq!(report.spent_episodes, 3);
+    assert_eq!(report.episodes_scanned, 8);
+    assert!(report.dry_run);
+    assert_eq!(
+        surviving_episode_ids(&db).await,
+        before,
+        "a dry run deletes nothing"
+    );
+}
+
+#[tokio::test]
+async fn execute_removes_only_the_named_episodes() {
+    let (_dir, db) = open_store().await;
+    seed_mixed_episodes(&db).await;
+
+    let report = gc::run_gc(&db, &episode_gc(false)).await.expect("gc");
+
+    assert_eq!(report.spent_episodes, 3);
+    assert!(report.errors.is_empty(), "{:?}", report.errors);
+    assert_eq!(
+        surviving_episode_ids(&db).await,
+        vec![
+            "episode:evidence".to_string(),
+            "episode:external".to_string(),
+            "episode:read".to_string(),
+            "episode:user".to_string(),
+            "episode:young".to_string(),
+        ],
+        "every protected episode survives, every spent one is gone"
+    );
+}
+
+#[tokio::test]
+async fn episodes_are_untouched_unless_collection_is_requested() {
+    let (_dir, db) = open_store().await;
+    seed_mixed_episodes(&db).await;
+
+    let before = surviving_episode_ids(&db).await;
+    let report = gc::run_gc(&db, &GcConfig::default()).await.expect("gc");
+
+    assert_eq!(report.episodes_scanned, 0, "no episode scan without opt-in");
+    assert_eq!(report.spent_episodes, 0);
+    assert!(named_episodes(&report).is_empty());
+    assert_eq!(surviving_episode_ids(&db).await, before);
+}
+
+#[tokio::test]
+async fn an_episode_whose_only_citation_is_itself_swept_becomes_collectable() {
+    // The citing edge is a stale, decayed relationship this same sweep
+    // removes: "evidence for a surviving edge" has to mean surviving.
+    let (_dir, db) = open_store().await;
+
+    create_episode(&db, "episode:orphaned", "session-doomed", 400, "self").await;
+    create_entity(&db, "entity:from", "From", "keep-me").await;
+    create_entity(&db, "entity:to", "To", "keep-me").await;
+
+    let valid_from = (Utc::now() - Duration::days(400)).to_rfc3339();
+    db.query(
+        r#"
+        LET $from = type::record('entity:from');
+        LET $to = type::record('entity:to');
+        RELATE $from -> relates_to -> $to SET
+            rel_type = 'DOOMED',
+            description = 'cites the session, but not for much longer',
+            valid_from = type::datetime($valid_from),
+            valid_until = NONE,
+            confidence = 0.05,
+            alpha = 0.5,
+            beta = 9.5,
+            self_reinforcements = 0,
+            source = 'session-doomed'
+        "#,
+    )
+    .bind(("valid_from", valid_from))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .expect("create doomed edge");
+
+    let report = gc::run_gc(&db, &episode_gc(false)).await.expect("gc");
+
+    assert_eq!(
+        report.stale_relationships + report.dead_relationships,
+        1,
+        "the citing edge is swept: {:?}",
+        report.actions
+    );
+    assert_eq!(
+        named_episodes(&report),
+        vec!["episode:orphaned".to_string()],
+        "with its only citation removed, the episode is spent too"
+    );
+    assert!(surviving_episode_ids(&db).await.is_empty());
+}

--- a/tests/graph_gc.rs
+++ b/tests/graph_gc.rs
@@ -73,6 +73,7 @@ async fn gc_execute_removes_low_confidence_relationship() {
         stale_days: 0,
         stale_confidence: 0.5,
         protect_pipeline: true,
+        ..Default::default()
     };
     let _report = db.graph.run_gc(&config).await.unwrap();
 

--- a/tests/migration.rs
+++ b/tests/migration.rs
@@ -1,0 +1,413 @@
+//! Schema-migration tests for persisted edge evidence (Phase 1, increment 1).
+//!
+//! Three properties are under assertion:
+//!
+//! - **AC3** — opening a pre-Phase-1 store backfills `alpha`/`beta` from the
+//!   stored mean without changing a single mean, and a second open migrates
+//!   nothing.
+//! - **AC10** — a backfill interrupted part-way (the process dies between the
+//!   `UPDATE` and the version marker) completes on the next open, and the
+//!   edges it already reached are not counted twice.
+//! - **AC1 (persistence half)** — evidence accumulated through the write path
+//!   survives a close/reopen cycle, and the posterior keeps narrowing.
+//!
+//! Every fixture here is built with raw SurrealQL rather than `GraphMemory`,
+//! so no embedding model is needed: confidence is arithmetic on edges.
+
+use std::path::Path;
+
+use recall_echo::graph::confidence::{Evidence, DEFAULT_EVIDENCE_WEIGHT, PRIOR_CONCENTRATION};
+use recall_echo::graph::crud;
+use recall_echo::graph::store::{self, Db, MigrationReport, SCHEMA_VERSION};
+use recall_echo::graph::types::{NewRelationship, Relationship};
+use surrealdb::Surreal;
+use tempfile::TempDir;
+
+const ALICE: &str = "entity:alice";
+const BOB: &str = "entity:bob";
+const CARLA: &str = "entity:carla";
+
+const META_RECORD: &str = "meta:schema";
+
+fn approx(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-9
+}
+
+// ── Fixture plumbing ─────────────────────────────────────────────────
+
+/// Open the store at `path` and run schema init + migration, as every
+/// entry point into the graph does.
+async fn open_store(path: &Path) -> (Surreal<Db>, MigrationReport) {
+    let db = store::open(path).await.expect("failed to open store");
+    let report = store::init_schema(&db)
+        .await
+        .expect("failed to init schema");
+    (db, report)
+}
+
+/// Close the store so the embedded backend releases its process lock.
+async fn close(db: Surreal<Db>) {
+    drop(db);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}
+
+async fn create_entity(db: &Surreal<Db>, id: &str, name: &str) {
+    db.query(
+        r#"CREATE type::record($id) SET
+               name = $name,
+               entity_type = 'concept',
+               abstract = $name,
+               overview = '',
+               mutable = true,
+               access_count = 0,
+               created_at = time::now(),
+               updated_at = time::now()"#,
+    )
+    .bind(("id", id.to_string()))
+    .bind(("name", name.to_string()))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create entity {id}: {e}"));
+}
+
+/// Write an edge the way a pre-Phase-1 build did: a bare `confidence` mean,
+/// no evidence counts at all.
+async fn create_legacy_edge(
+    db: &Surreal<Db>,
+    from_id: &str,
+    to_id: &str,
+    rel_type: &str,
+    confidence: f64,
+) {
+    db.query(
+        r#"
+        LET $from = type::record($from_id);
+        LET $to = type::record($to_id);
+        RELATE $from -> relates_to -> $to SET
+            rel_type = $rel_type,
+            description = 'legacy edge',
+            valid_from = time::now(),
+            valid_until = NONE,
+            confidence = $confidence,
+            last_reinforced = time::now(),
+            source = 'fixture'
+        "#,
+    )
+    .bind(("from_id", from_id.to_string()))
+    .bind(("to_id", to_id.to_string()))
+    .bind(("rel_type", rel_type.to_string()))
+    .bind(("confidence", confidence))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create legacy edge {rel_type}: {e}"));
+}
+
+/// Drop the schema-version marker, leaving a store shaped exactly like one
+/// written before versioning existed.
+async fn strip_version_marker(db: &Surreal<Db>) {
+    db.query("DELETE type::record($id)")
+        .bind(("id", META_RECORD.to_string()))
+        .await
+        .and_then(surrealdb::IndexedResults::check)
+        .expect("failed to strip version marker");
+}
+
+/// Apply the backfill formula to one edge by hand — the state a migration
+/// interrupted after touching some rows leaves behind.
+async fn backfill_one_edge(db: &Surreal<Db>, rel_id: &str) {
+    db.query(
+        r#"UPDATE type::record($id) SET
+               alpha = confidence * $concentration,
+               beta = (1 - confidence) * $concentration,
+               self_reinforcements = 0"#,
+    )
+    .bind(("id", rel_id.to_string()))
+    .bind(("concentration", PRIOR_CONCENTRATION))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to pre-backfill {rel_id}: {e}"));
+}
+
+async fn edges_by_type(db: &Surreal<Db>) -> Vec<(String, Relationship)> {
+    let mut rels = crud::list_all_relationships(db)
+        .await
+        .expect("failed to list relationships");
+    rels.sort_by(|a, b| a.rel_type.cmp(&b.rel_type));
+    rels.into_iter().map(|r| (r.rel_type.clone(), r)).collect()
+}
+
+async fn edge(db: &Surreal<Db>, rel_type: &str) -> Relationship {
+    edges_by_type(db)
+        .await
+        .into_iter()
+        .find(|(t, _)| t == rel_type)
+        .unwrap_or_else(|| panic!("no edge of type {rel_type}"))
+        .1
+}
+
+/// An empty graph directory that lives as long as the returned `TempDir`.
+fn new_graph_dir() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let graph_path = dir.path().join("graph");
+    std::fs::create_dir_all(&graph_path).expect("failed to create graph dir");
+    (dir, graph_path)
+}
+
+/// Three entities and three evidence-less edges, spanning the confidence range.
+async fn seed_legacy_edges(db: &Surreal<Db>) {
+    create_entity(db, ALICE, "Alice").await;
+    create_entity(db, BOB, "Bob").await;
+    create_entity(db, CARLA, "Carla").await;
+
+    create_legacy_edge(db, ALICE, BOB, "CERTAIN", 1.0).await;
+    create_legacy_edge(db, ALICE, CARLA, "INFERRED", 0.6).await;
+    create_legacy_edge(db, BOB, CARLA, "SPECULATIVE", 0.3).await;
+}
+
+/// A closed store holding three legacy edges and no version marker — what a
+/// pre-Phase-1 build leaves on disk.
+async fn legacy_store() -> (TempDir, std::path::PathBuf) {
+    let (dir, graph_path) = new_graph_dir();
+
+    let (db, _) = open_store(&graph_path).await;
+    seed_legacy_edges(&db).await;
+    strip_version_marker(&db).await;
+    close(db).await;
+
+    (dir, graph_path)
+}
+
+// ── AC3: idempotent, non-destructive migration ───────────────────────
+
+#[tokio::test]
+async fn legacy_edges_gain_evidence_with_means_preserved() {
+    let (_dir, graph_path) = legacy_store().await;
+
+    let (db, report) = open_store(&graph_path).await;
+
+    assert!(report.ran(), "migration should have run: {report:?}");
+    assert_eq!(report.from_version, 0);
+    assert_eq!(report.to_version, SCHEMA_VERSION);
+    assert_eq!(report.edges_backfilled, 3, "all legacy edges: {report:?}");
+
+    for (rel_type, expected_mean) in [("CERTAIN", 1.0), ("INFERRED", 0.6), ("SPECULATIVE", 0.3)] {
+        let rel = edge(&db, rel_type).await;
+
+        assert_eq!(
+            rel.confidence, expected_mean,
+            "{rel_type}: mean must be preserved exactly"
+        );
+
+        let evidence = rel.evidence();
+        assert!(
+            approx(evidence.concentration(), PRIOR_CONCENTRATION),
+            "{rel_type}: concentration {} != {PRIOR_CONCENTRATION}",
+            evidence.concentration()
+        );
+        assert!(
+            approx(evidence.mean(), expected_mean),
+            "{rel_type}: counts must reproduce the mean, got {}",
+            evidence.mean()
+        );
+        assert_eq!(
+            rel.self_reinforcements,
+            Some(0),
+            "{rel_type}: coherence counter starts empty"
+        );
+    }
+
+    close(db).await;
+}
+
+#[tokio::test]
+async fn reopening_a_migrated_store_migrates_nothing() {
+    let (_dir, graph_path) = legacy_store().await;
+
+    let (db, first) = open_store(&graph_path).await;
+    assert!(first.ran());
+    let before: Vec<_> = edges_by_type(&db)
+        .await
+        .into_iter()
+        .map(|(t, r)| (t, r.confidence, r.alpha, r.beta))
+        .collect();
+    close(db).await;
+
+    let (db, second) = open_store(&graph_path).await;
+
+    assert!(!second.ran(), "second open must be a no-op: {second:?}");
+    assert_eq!(second.from_version, SCHEMA_VERSION);
+    assert_eq!(second.edges_backfilled, 0);
+
+    let after: Vec<_> = edges_by_type(&db)
+        .await
+        .into_iter()
+        .map(|(t, r)| (t, r.confidence, r.alpha, r.beta))
+        .collect();
+    assert_eq!(before, after, "a no-op migration must not touch evidence");
+
+    close(db).await;
+}
+
+#[tokio::test]
+async fn fresh_store_is_current_after_first_open() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let graph_path = dir.path().join("graph");
+    std::fs::create_dir_all(&graph_path).expect("failed to create graph dir");
+
+    let (db, first) = open_store(&graph_path).await;
+    assert_eq!(first.to_version, SCHEMA_VERSION);
+    assert_eq!(
+        first.edges_backfilled, 0,
+        "nothing to backfill on an empty store"
+    );
+    close(db).await;
+
+    let (db, second) = open_store(&graph_path).await;
+    assert!(!second.ran(), "fresh store migrates once: {second:?}");
+    close(db).await;
+}
+
+// ── AC10: interrupted migration ──────────────────────────────────────
+
+#[tokio::test]
+async fn interrupted_backfill_completes_without_double_counting() {
+    // A process killed mid-backfill: one edge already carries evidence, the
+    // rest do not, and the version marker was never written.
+    let (_dir, graph_path) = new_graph_dir();
+
+    let (db, _) = open_store(&graph_path).await;
+    seed_legacy_edges(&db).await;
+    let half_done = edge(&db, "INFERRED").await;
+    backfill_one_edge(&db, &half_done.id_string()).await;
+    strip_version_marker(&db).await;
+    close(db).await;
+
+    let (db, report) = open_store(&graph_path).await;
+
+    assert!(report.ran(), "migration must resume: {report:?}");
+    assert_eq!(
+        report.edges_backfilled, 2,
+        "only the untouched edges are backfilled: {report:?}"
+    );
+
+    let resumed = edge(&db, "INFERRED").await;
+    assert_eq!(resumed.confidence, 0.6, "mean untouched by the second pass");
+    assert!(
+        approx(resumed.evidence().concentration(), PRIOR_CONCENTRATION),
+        "already-migrated edge must not be counted twice, got {}",
+        resumed.evidence().concentration()
+    );
+    assert!(approx(resumed.evidence().alpha(), 6.0));
+    assert!(approx(resumed.evidence().beta(), 4.0));
+
+    let finished = edge(&db, "SPECULATIVE").await;
+    assert!(approx(finished.evidence().alpha(), 3.0));
+    assert!(approx(finished.evidence().beta(), 7.0));
+
+    close(db).await;
+}
+
+// ── AC1: evidence persists across reopen ─────────────────────────────
+
+#[tokio::test]
+async fn accumulated_evidence_survives_reopen_and_keeps_narrowing() {
+    let (_dir, graph_path) = legacy_store().await;
+
+    // Migrate, then corroborate five times through the real write path.
+    let (db, _) = open_store(&graph_path).await;
+    corroborate(&db, "INFERRED", 5).await;
+    close(db).await;
+
+    let (db, _) = open_store(&graph_path).await;
+    let after_five = edge(&db, "INFERRED").await;
+    assert!(
+        approx(after_five.evidence().alpha(), 11.0),
+        "5 observations on top of alpha=6, got {}",
+        after_five.evidence().alpha()
+    );
+    assert!(approx(after_five.evidence().beta(), 4.0));
+    assert!(
+        approx(after_five.confidence, 11.0 / 15.0),
+        "stored mean tracks the counts, got {}",
+        after_five.confidence
+    );
+
+    corroborate(&db, "INFERRED", 45).await;
+    close(db).await;
+
+    let (db, _) = open_store(&graph_path).await;
+    let after_fifty = edge(&db, "INFERRED").await;
+    assert!(approx(after_fifty.evidence().alpha(), 56.0));
+    assert!(
+        after_fifty.evidence().variance() < after_five.evidence().variance(),
+        "50 observations {} must be tighter than 5 {}",
+        after_fifty.evidence().variance(),
+        after_five.evidence().variance()
+    );
+
+    // A store already at the prior concentration is never re-primed.
+    let untouched = edge(&db, "SPECULATIVE").await;
+    assert!(approx(
+        untouched.evidence().concentration(),
+        PRIOR_CONCENTRATION
+    ));
+
+    close(db).await;
+}
+
+/// Record `times` corroborations on an edge through the write path the
+/// ingest pipeline uses.
+async fn corroborate(db: &Surreal<Db>, rel_type: &str, times: usize) {
+    for _ in 0..times {
+        let rel = edge(db, rel_type).await;
+        let mut evidence = rel.evidence();
+        evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+        crud::reinforce_relationship(db, &rel.id_string(), evidence)
+            .await
+            .expect("failed to reinforce");
+    }
+}
+
+// ── New edges are born migrated ──────────────────────────────────────
+
+#[tokio::test]
+async fn new_edges_are_created_with_evidence() {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let graph_path = dir.path().join("graph");
+    std::fs::create_dir_all(&graph_path).expect("failed to create graph dir");
+
+    let (db, _) = open_store(&graph_path).await;
+    create_entity(&db, ALICE, "Alice").await;
+    create_entity(&db, BOB, "Bob").await;
+
+    let requested: f32 = 0.6;
+    crud::add_relationship(
+        &db,
+        NewRelationship {
+            from_entity: "Alice".to_string(),
+            to_entity: "Bob".to_string(),
+            rel_type: "INFERRED".to_string(),
+            description: None,
+            confidence: Some(requested),
+            source: Some("fixture".to_string()),
+        },
+    )
+    .await
+    .expect("failed to create relationship");
+
+    let created = edge(&db, "INFERRED").await;
+    assert_eq!(
+        created.confidence, requested as f64,
+        "creation stores the requested mean unchanged"
+    );
+    assert_eq!(
+        created.evidence(),
+        Evidence::from_prior(requested as f64),
+        "a new edge sits at the prior"
+    );
+    assert_eq!(created.self_reinforcements, Some(0));
+    assert!((created.evidence().alpha() - 6.0).abs() < 1e-6);
+    assert!((created.evidence().beta() - 4.0).abs() < 1e-6);
+
+    close(db).await;
+}

--- a/tests/migration.rs
+++ b/tests/migration.rs
@@ -16,7 +16,9 @@
 
 use std::path::Path;
 
-use recall_echo::graph::confidence::{Evidence, DEFAULT_EVIDENCE_WEIGHT, PRIOR_CONCENTRATION};
+use recall_echo::graph::confidence::{
+    Evidence, Provenance, ProvenanceWeights, DEFAULT_EVIDENCE_WEIGHT, PRIOR_CONCENTRATION,
+};
 use recall_echo::graph::crud;
 use recall_echo::graph::store::{self, Db, MigrationReport, SCHEMA_VERSION};
 use recall_echo::graph::types::{NewRelationship, Relationship};
@@ -356,12 +358,13 @@ async fn accumulated_evidence_survives_reopen_and_keeps_narrowing() {
 }
 
 /// Record `times` corroborations on an edge through the write path the
-/// ingest pipeline uses.
+/// ingest pipeline uses, at the provenance-blind reference weight.
 async fn corroborate(db: &Surreal<Db>, rel_type: &str, times: usize) {
+    let weights = ProvenanceWeights::uniform(DEFAULT_EVIDENCE_WEIGHT);
     for _ in 0..times {
         let rel = edge(db, rel_type).await;
-        let mut evidence = rel.evidence();
-        evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+        let mut evidence = rel.edge_evidence();
+        evidence.corroborate(Provenance::External, &weights);
         crud::reinforce_relationship(db, &rel.id_string(), evidence)
             .await
             .expect("failed to reinforce");

--- a/tests/provenance.rs
+++ b/tests/provenance.rs
@@ -1,0 +1,446 @@
+//! Provenance-weighted evidence tests (Phase 1, increment 2).
+//!
+//! Three properties are under assertion:
+//!
+//! - **AC2** — corroboration authored by the agent moves the mean by no more
+//!   than its weight fraction, lands in the `self_reinforcements` tally, and
+//!   is outweighed by a single independent contradiction.
+//! - **AC7** — an episode with absent or unrecognised provenance reads back as
+//!   `self`, so a legacy store never gains confidence from backfilled data.
+//! - **AC8** — weights of (1, 1, 1) reproduce provenance-blind evidence
+//!   bit-for-bit: the escape hatch, and the differential-testing lever.
+//!
+//! Every fixture here is built with raw SurrealQL rather than `GraphMemory`,
+//! so no embedding model is needed: evidence is arithmetic on edges.
+
+use std::path::Path;
+
+use recall_echo::graph::confidence::{
+    EdgeEvidence, Evidence, Provenance, ProvenanceWeights, DEFAULT_EVIDENCE_WEIGHT,
+    PRIOR_CONCENTRATION,
+};
+use recall_echo::graph::crud;
+use recall_echo::graph::store::{self, Db};
+use recall_echo::graph::types::{Episode, Relationship};
+use surrealdb::Surreal;
+use tempfile::TempDir;
+
+const ALICE: &str = "entity:alice";
+const BOB: &str = "entity:bob";
+
+/// The edge every scenario starts from: an Inferred fact at the prior.
+const CLAIM: &str = "INFERRED";
+const CLAIM_MEAN: f64 = 0.6;
+
+fn approx(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-9
+}
+
+// ── Fixture plumbing ─────────────────────────────────────────────────
+
+async fn open_store(path: &Path) -> Surreal<Db> {
+    let db = store::open(path).await.expect("failed to open store");
+    store::init_schema(&db)
+        .await
+        .expect("failed to init schema");
+    db
+}
+
+/// Close the store so the embedded backend releases its process lock.
+async fn close(db: Surreal<Db>) {
+    drop(db);
+    tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+}
+
+fn new_graph_dir() -> (TempDir, std::path::PathBuf) {
+    let dir = TempDir::new().expect("failed to create temp dir");
+    let graph_path = dir.path().join("graph");
+    std::fs::create_dir_all(&graph_path).expect("failed to create graph dir");
+    (dir, graph_path)
+}
+
+async fn create_entity(db: &Surreal<Db>, id: &str, name: &str) {
+    db.query(
+        r#"CREATE type::record($id) SET
+               name = $name,
+               entity_type = 'concept',
+               abstract = $name,
+               overview = '',
+               mutable = true,
+               access_count = 0,
+               created_at = time::now(),
+               updated_at = time::now()"#,
+    )
+    .bind(("id", id.to_string()))
+    .bind(("name", name.to_string()))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create entity {id}: {e}"));
+}
+
+/// An edge as a current build writes it: mean, counts and an empty coherence
+/// tally.
+async fn create_edge(db: &Surreal<Db>, confidence: f64) {
+    let evidence = Evidence::from_prior(confidence);
+    db.query(
+        r#"
+        LET $from = type::record($from_id);
+        LET $to = type::record($to_id);
+        RELATE $from -> relates_to -> $to SET
+            rel_type = $rel_type,
+            description = 'fixture edge',
+            valid_from = time::now(),
+            valid_until = NONE,
+            confidence = $confidence,
+            alpha = $alpha,
+            beta = $beta,
+            self_reinforcements = 0,
+            last_reinforced = time::now(),
+            source = 'fixture'
+        "#,
+    )
+    .bind(("from_id", ALICE.to_string()))
+    .bind(("to_id", BOB.to_string()))
+    .bind(("rel_type", CLAIM.to_string()))
+    .bind(("confidence", confidence))
+    .bind(("alpha", evidence.alpha()))
+    .bind(("beta", evidence.beta()))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create edge: {e}"));
+}
+
+/// An edge from a store migrated by increment 1 and never observed since: it
+/// has counts but no coherence tally at all.
+async fn create_edge_without_tally(db: &Surreal<Db>, confidence: f64) {
+    create_edge(db, confidence).await;
+    db.query("UPDATE relates_to SET self_reinforcements = NONE")
+        .await
+        .and_then(surrealdb::IndexedResults::check)
+        .expect("failed to clear the coherence tally");
+}
+
+async fn edge(db: &Surreal<Db>) -> Relationship {
+    crud::list_all_relationships(db)
+        .await
+        .expect("failed to list relationships")
+        .into_iter()
+        .find(|r| r.rel_type == CLAIM)
+        .expect("fixture edge missing")
+}
+
+async fn seed_claim(db: &Surreal<Db>) {
+    create_entity(db, ALICE, "Alice").await;
+    create_entity(db, BOB, "Bob").await;
+    create_edge(db, CLAIM_MEAN).await;
+}
+
+/// Apply one observation to the fixture edge through the real write path.
+async fn observe(db: &Surreal<Db>, provenance: Provenance, corroborates: bool) {
+    let weights = ProvenanceWeights::default();
+    let existing = edge(db).await;
+    let mut evidence = existing.edge_evidence();
+    if corroborates {
+        evidence.corroborate(provenance, &weights);
+    } else {
+        evidence.contradict(provenance, &weights);
+    }
+    crud::reinforce_relationship(db, &existing.id_string(), evidence)
+        .await
+        .expect("failed to reinforce");
+}
+
+async fn corroborate(db: &Surreal<Db>, provenance: Provenance, times: usize) {
+    for _ in 0..times {
+        observe(db, provenance, true).await;
+    }
+}
+
+/// Write an episode the way a store of a given vintage holds it: `None` is a
+/// pre-provenance episode, `Some(class)` a stamped one (including classes no
+/// build ever wrote).
+async fn create_episode(db: &Surreal<Db>, session_id: &str, provenance: Option<&str>) {
+    db.query(
+        r#"CREATE episode SET
+               session_id = $session_id,
+               timestamp = time::now(),
+               abstract = $session_id,
+               overview = NONE,
+               content = NONE,
+               log_number = NONE,
+               provenance = $provenance"#,
+    )
+    .bind(("session_id", session_id.to_string()))
+    .bind(("provenance", provenance.map(str::to_string)))
+    .await
+    .and_then(surrealdb::IndexedResults::check)
+    .unwrap_or_else(|e| panic!("failed to create episode {session_id}: {e}"));
+}
+
+async fn episode(db: &Surreal<Db>, session_id: &str) -> Episode {
+    crud::get_episodes_by_session(db, session_id)
+        .await
+        .expect("failed to read episodes")
+        .into_iter()
+        .next()
+        .unwrap_or_else(|| panic!("no episode for session {session_id}"))
+}
+
+// ── AC8: uniform weights are provenance-blind ────────────────────────
+
+/// A scripted run of observations, mixing classes and directions. Applied
+/// once through the provenance-blind path increment 1 shipped, and once
+/// through the provenance-aware path with every class weighted the same.
+const SCRIPT: &[(Provenance, bool)] = &[
+    (Provenance::External, true),
+    (Provenance::SelfGenerated, true),
+    (Provenance::User, true),
+    (Provenance::SelfGenerated, false),
+    (Provenance::External, false),
+    (Provenance::SelfGenerated, true),
+    (Provenance::User, false),
+    (Provenance::SelfGenerated, true),
+];
+
+/// The script replayed without any notion of provenance — one observation,
+/// one count.
+fn provenance_blind_replay() -> Evidence {
+    let mut evidence = Evidence::from_prior(CLAIM_MEAN);
+    for (_, corroborates) in SCRIPT {
+        if *corroborates {
+            evidence.corroborate(DEFAULT_EVIDENCE_WEIGHT);
+        } else {
+            evidence.contradict(DEFAULT_EVIDENCE_WEIGHT);
+        }
+    }
+    evidence
+}
+
+/// The script replayed with provenance, under the given weights.
+fn provenance_aware_replay(weights: &ProvenanceWeights) -> EdgeEvidence {
+    let mut evidence = EdgeEvidence::new(Evidence::from_prior(CLAIM_MEAN), 0);
+    for (provenance, corroborates) in SCRIPT {
+        if *corroborates {
+            evidence.corroborate(*provenance, weights);
+        } else {
+            evidence.contradict(*provenance, weights);
+        }
+    }
+    evidence
+}
+
+#[test]
+fn uniform_weights_reproduce_provenance_blind_evidence_bit_for_bit() {
+    let blind = provenance_blind_replay();
+    let aware = provenance_aware_replay(&ProvenanceWeights::uniform(DEFAULT_EVIDENCE_WEIGHT));
+
+    assert_eq!(
+        aware.evidence().alpha().to_bits(),
+        blind.alpha().to_bits(),
+        "alpha diverged: {} vs {}",
+        aware.evidence().alpha(),
+        blind.alpha()
+    );
+    assert_eq!(
+        aware.evidence().beta().to_bits(),
+        blind.beta().to_bits(),
+        "beta diverged: {} vs {}",
+        aware.evidence().beta(),
+        blind.beta()
+    );
+    assert_eq!(aware.evidence(), blind);
+
+    // The coherence tally is a separate signal, not part of the posterior:
+    // it keeps counting even when the weights stop distinguishing classes.
+    assert_eq!(aware.self_reinforcements(), 3);
+}
+
+#[test]
+fn default_weights_diverge_from_provenance_blind_evidence() {
+    // Guards the differential test above from being vacuous: the same script
+    // under the shipped defaults must *not* reproduce the blind counts.
+    let blind = provenance_blind_replay();
+    let aware = provenance_aware_replay(&ProvenanceWeights::default());
+
+    assert!(
+        aware.evidence().concentration() < blind.concentration(),
+        "self-authored observations must carry less weight: {} vs {}",
+        aware.evidence().concentration(),
+        blind.concentration()
+    );
+}
+
+// ── AC2: self-corroboration is capped, counted, and outweighed ───────
+
+#[tokio::test]
+async fn self_corroboration_is_bounded_by_its_weight_and_tallied() {
+    let (_dir, graph_path) = new_graph_dir();
+    let weights = ProvenanceWeights::default();
+    let runs = 20;
+
+    let db = open_store(&graph_path).await;
+    seed_claim(&db).await;
+    let before = edge(&db).await.confidence;
+    corroborate(&db, Provenance::SelfGenerated, runs).await;
+    close(db).await;
+
+    // Reopening proves the tally and the counts are persisted, not in-memory.
+    let db = open_store(&graph_path).await;
+    let after = edge(&db).await;
+
+    assert_eq!(
+        after.self_reinforcements,
+        Some(runs as i64),
+        "every self-corroboration must stay visible as coherence"
+    );
+
+    let spent = runs as f64 * weights.weight_self;
+    assert!(
+        approx(
+            after.evidence().alpha(),
+            CLAIM_MEAN * PRIOR_CONCENTRATION + spent
+        ),
+        "alpha must grow by the self weight only, got {}",
+        after.evidence().alpha()
+    );
+    assert!(
+        approx(
+            after.evidence().beta(),
+            (1.0 - CLAIM_MEAN) * PRIOR_CONCENTRATION
+        ),
+        "corroboration must not touch beta, got {}",
+        after.evidence().beta()
+    );
+
+    // The weight-fraction bound: twenty self-corroborations buy no more than
+    // the (20 x 0.05 = 1.0) external observations they are worth.
+    let equivalent = {
+        let mut evidence = Evidence::from_prior(CLAIM_MEAN);
+        evidence.corroborate(weights.weight_external);
+        evidence.mean()
+    };
+    assert!(
+        after.confidence > before,
+        "coherence still moves the mean a little: {before} -> {}",
+        after.confidence
+    );
+    assert!(
+        after.confidence <= equivalent + 1e-9,
+        "{runs} self-corroborations moved the mean past their weight fraction: {} > {equivalent}",
+        after.confidence
+    );
+
+    close(db).await;
+}
+
+#[tokio::test]
+async fn one_external_contradiction_outweighs_a_run_of_self_corroboration() {
+    let (_dir, graph_path) = new_graph_dir();
+
+    let db = open_store(&graph_path).await;
+    seed_claim(&db).await;
+    let before = edge(&db).await.confidence;
+
+    corroborate(&db, Provenance::SelfGenerated, 20).await;
+    let after_coherence = edge(&db).await.confidence;
+    assert!(after_coherence > before);
+
+    observe(&db, Provenance::External, false).await;
+    let after_contradiction = edge(&db).await;
+
+    assert!(
+        after_contradiction.confidence < before,
+        "an independent contradiction must undo the whole coherence run: {} vs {before}",
+        after_contradiction.confidence
+    );
+    assert_eq!(
+        after_contradiction.self_reinforcements,
+        Some(20),
+        "contradiction is not coherence — the tally holds"
+    );
+
+    close(db).await;
+}
+
+#[tokio::test]
+async fn external_corroboration_leaves_the_coherence_tally_alone() {
+    let (_dir, graph_path) = new_graph_dir();
+
+    let db = open_store(&graph_path).await;
+    seed_claim(&db).await;
+    corroborate(&db, Provenance::External, 3).await;
+    corroborate(&db, Provenance::User, 2).await;
+    let after = edge(&db).await;
+
+    assert_eq!(after.self_reinforcements, Some(0));
+    let weights = ProvenanceWeights::default();
+    assert!(
+        approx(
+            after.evidence().alpha(),
+            CLAIM_MEAN * PRIOR_CONCENTRATION
+                + 3.0 * weights.weight_external
+                + 2.0 * weights.weight_user
+        ),
+        "alpha must sum the observed weights, got {}",
+        after.evidence().alpha()
+    );
+
+    close(db).await;
+}
+
+#[tokio::test]
+async fn an_edge_without_a_tally_starts_counting_from_zero() {
+    // AC7 on the edge side: increment 1 wrote `self_reinforcements` as an
+    // option, so an untouched edge may still hold NONE.
+    let (_dir, graph_path) = new_graph_dir();
+
+    let db = open_store(&graph_path).await;
+    create_entity(&db, ALICE, "Alice").await;
+    create_entity(&db, BOB, "Bob").await;
+    create_edge_without_tally(&db, CLAIM_MEAN).await;
+
+    let legacy = edge(&db).await;
+    assert_eq!(legacy.self_reinforcements, None);
+    assert_eq!(legacy.edge_evidence().self_reinforcements(), 0);
+
+    corroborate(&db, Provenance::SelfGenerated, 1).await;
+    assert_eq!(edge(&db).await.self_reinforcements, Some(1));
+
+    close(db).await;
+}
+
+// ── AC7: unlabelled episodes are the agent's own ─────────────────────
+
+#[tokio::test]
+async fn stored_episode_provenance_defaults_to_self() {
+    let (_dir, graph_path) = new_graph_dir();
+
+    let db = open_store(&graph_path).await;
+    create_episode(&db, "legacy", None).await;
+    create_episode(&db, "garbled", Some("mostly-true")).await;
+    create_episode(&db, "document", Some("external")).await;
+    create_episode(&db, "human", Some("user")).await;
+    create_episode(&db, "agent", Some("self")).await;
+
+    assert_eq!(
+        episode(&db, "legacy").await.provenance(),
+        Provenance::SelfGenerated,
+        "a pre-provenance episode never earns full weight"
+    );
+    assert_eq!(
+        episode(&db, "garbled").await.provenance(),
+        Provenance::SelfGenerated,
+        "an unrecognised class is treated as unlabelled"
+    );
+    assert_eq!(
+        episode(&db, "document").await.provenance(),
+        Provenance::External
+    );
+    assert_eq!(episode(&db, "human").await.provenance(), Provenance::User);
+    assert_eq!(
+        episode(&db, "agent").await.provenance(),
+        Provenance::SelfGenerated
+    );
+
+    close(db).await;
+}


### PR DESCRIPTION
Makes the confidence score true, in two senses: evidence now accumulates (persisted per-edge α/β with genuinely narrowing variance — the old update was stateless, concentration pinned at 10 forever), and corroboration now requires independence (three provenance classes at write-time: external 1.0 / user 0.8 / self 0.05, with self-reassertion tallied separately as coherence, never laundered into confidence). Implements the source-correlation research by Echo (pulse-null entity): Bovens-Hartmann/Olsson — independence is a load-bearing precondition; an agent re-asserting its own beliefs is the maximum-dependence limit.

Also: crash-safe idempotent schema migration (means preserved bit-for-bit; marker-written-last ordering); episode GC (`graph gc --episodes`, dry-run default, evidence-citing episodes survive); `graph feedback` verb + passive session→entity linkage — which surfaced that `update_utility_score` used SurrealDB 1.x syntax and **every utility write had been silently failing** (now fixed and .check()'d); `docs/bayesian-confidence.md` rewritten so every claim carries a verified code citation, with the provenance section crediting Echo.

Lock bump: surrealdb 3.0.5 → 3.2.4 — `cargo install` ignores Cargo.lock, so installed binaries were writing storage format revision 2 while lock-honoring builds could only read revision 1. Follow-up for release procedure: `--locked`.

AC6 no-regression (same graphs, same models, Phase 1 binary): retrieval bit-identical to the Phase 0 baseline (MRR .778, all recall@k exact); answers within noise; α/β migration exercised on 10 real benchmark stores without incident.

Gate: 389 tests, clippy -D warnings clean.

Refs #31