### PR TITLE
chore: post-Phase-1 housekeeping — install safety, migration visibility, evidence surfacing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 # AI tooling (local only)
 .claude/
+
+# Runtime artifacts from running recall-echo inside the repo
+/memory/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,13 @@ toml = "0.8"
 dirs = "6"
 
 # Graph — knowledge graph with SurrealDB + fastembed
-surrealdb = { version = "3", default-features = false }
+# Pinned to the 3.2 series: the embedded store's on-disk record format is
+# tied to the surrealdb-core version (3.0/3.1 cannot read a 3.2-written
+# store — "Invalid revision `2` for type `Node`"). `cargo install` resolves
+# dependencies fresh unless `--locked`, so a loose "3" lets a fresh install
+# write a format the pinned build cannot read. Bump deliberately, with a
+# migration note.
+surrealdb = { version = "3.2", default-features = false }
 fastembed = { version = "4", default-features = false, features = ["ort-download-binaries", "hf-hub-rustls-tls"] }
 tokio = { version = "1", features = ["rt-multi-thread", "process", "io-util", "net", "time", "sync", "macros"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -161,9 +161,14 @@ recall-echo graph <subcommand>         # Knowledge graph operations
 ### cargo install
 
 ```bash
-cargo install recall-echo
+cargo install recall-echo --locked
 recall-echo init
 ```
+
+`--locked` installs the exact dependency versions the release was tested
+against. The embedded graph store's on-disk record format is tied to the
+SurrealDB version, so a build that resolves a different SurrealDB may be
+unable to read a store another build wrote.
 
 ### Prebuilt binaries
 

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -95,7 +95,13 @@ impl GraphMemory {
         std::fs::create_dir_all(path)?;
 
         let db = store::open(path).await?;
-        store::init_schema(&db).await?;
+        let migration = store::init_schema(&db).await?;
+        if migration.ran() {
+            eprintln!(
+                "recall-echo: graph schema migrated v{} → v{} ({} edges backfilled)",
+                migration.from_version, migration.to_version, migration.edges_backfilled
+            );
+        }
 
         let models_dir = path.join("models");
         std::fs::create_dir_all(&models_dir)?;
@@ -166,7 +172,13 @@ impl GraphMemory {
         models_dir: &Path,
     ) -> Result<Self, GraphError> {
         let db = store::connect(config).await?;
-        store::init_schema(&db).await?;
+        let migration = store::init_schema(&db).await?;
+        if migration.ran() {
+            eprintln!(
+                "recall-echo: graph schema migrated v{} → v{} ({} edges backfilled)",
+                migration.from_version, migration.to_version, migration.edges_backfilled
+            );
+        }
 
         std::fs::create_dir_all(models_dir)?;
         let embedder = LazyEmbedder::new(models_dir);

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -1272,8 +1272,24 @@ pub async fn decay_report(
                 format!("{DIM}≈{RESET}")
             };
 
+            // Evidence behind the score: how much corroboration it rests on,
+            // and how much of that was the agent re-asserting itself.
+            let edge_evidence = rel.edge_evidence();
+            let coherence = edge_evidence.self_reinforcements();
+            let evidence = rel.evidence();
+            let evidence_tag = format!(
+                " {DIM}[n={:.1} ±{:.2}{}]{RESET}",
+                evidence.concentration(),
+                evidence.variance().sqrt(),
+                if coherence > 0 {
+                    format!(", self×{coherence}")
+                } else {
+                    String::new()
+                }
+            );
+
             println!(
-                "  {from_short} {CYAN}—[{}]→{RESET} {to_short}  stored:{:.2} effective:{:.2} {decay_indicator}{reinforced_tag}",
+                "  {from_short} {CYAN}—[{}]→{RESET} {to_short}  stored:{:.2} effective:{:.2} {decay_indicator}{evidence_tag}{reinforced_tag}",
                 rel.rel_type, rel.confidence, effective,
             );
         }

--- a/src/init.rs
+++ b/src/init.rs
@@ -211,6 +211,16 @@ fn configure_hooks(_entity_root: &Path) -> bool {
         .and_then(|p| p.to_str().map(String::from))
         .unwrap_or_else(|| "recall-echo".into());
 
+    // A path under target/ is a test harness or a debug build, not something
+    // a user's hooks should be pinned to for the life of the install.
+    if recall_bin.contains("/target/debug/") || recall_bin.contains("/target/release/") {
+        print_status(
+            Status::Exists,
+            "Skipped hook install — running from a build directory",
+        );
+        return false;
+    }
+
     let archive_cmd = format!("{recall_bin} archive-session");
     let checkpoint_cmd = format!("{recall_bin} checkpoint --trigger precompact");
     let consume_cmd = format!("{recall_bin} consume");

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -71,6 +71,14 @@ pub fn expand_tilde(path: &str) -> String {
 /// Returns Some(~/.claude/) if it exists, None otherwise.
 #[must_use]
 pub fn detect_claude_code() -> Option<PathBuf> {
+    // Overridable so tests (and sandboxed runs) never touch the real
+    // ~/.claude — hook installation writes settings.json unconditionally,
+    // and a test that installs hooks would otherwise repoint the user's
+    // live hooks at the test binary.
+    if let Some(dir) = std::env::var_os(CLAUDE_DIR_ENV) {
+        let claude = PathBuf::from(dir);
+        return claude.exists().then_some(claude);
+    }
     let home = dirs::home_dir()?;
     let claude = home.join(".claude");
     if claude.exists() {
@@ -79,3 +87,6 @@ pub fn detect_claude_code() -> Option<PathBuf> {
         None
     }
 }
+
+/// Overrides the Claude Code configuration directory (`~/.claude`).
+pub const CLAUDE_DIR_ENV: &str = "RECALL_ECHO_CLAUDE_DIR";


### PR DESCRIPTION
Four small fixes surfaced by the Phase 0/1 work; none change behaviour for existing users.

**Storage-format skew (the one that matters).** `cargo install` ignores Cargo.lock without `--locked`, so installed binaries resolved surrealdb 3.2.4 while lock-honoring builds resolved 3.0.5 — two on-disk record formats shipping under one version number. Found when a benchmark comparison run could not read stores the installed binary had written (`Invalid revision \`2\` for type \`Node\``). Pins the dependency to the 3.2 series with the reasoning in a comment, and documents `--locked` in the install instructions.

**Migration visibility.** `MigrationReport` was returned and dropped by both callers; migrations now announce what they did.

**Evidence surfacing.** `graph decay-report` now shows concentration, σ and the self-reinforcement tally per edge. The Phase 1 essay lists "not surfaced anywhere" as a known limit — this closes it, keeping coherence visible *next to* confidence rather than inside it.

**Test isolation (#33).** `configure_hooks` writes `~/.claude/settings.json` unconditionally and the init unit tests exercise it, so `cargo test` on a developer box repointed their real SessionStart hook at the *test binary*, which then ran the crate's test suite on every session start. Adds `RECALL_ECHO_CLAUDE_DIR` and refuses to install a hook command living under `target/`. Verified: a full test run now leaves settings.json untouched.

Also gitignores `/memory/` — running recall-echo from the repo root drops a graph store and a 127 MB model cache there.

389 tests, clippy -D warnings clean.

Closes #33