### PR TITLE
fix: a stock install can no longer ship a graph that cannot gain entities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,11 @@ pulse-system-types = { version = "0.6", optional = true }
 [features]
 # Both storage backends are compiled in by default; the active one is chosen
 # at runtime via the `[graph] mode` config key (embedded | server).
-default = ["embedded", "server"]
+# `llm` is on by default: without it the `graph extract` subcommand does not
+# exist, so a stock install ingests episodes that can never become entities —
+# the knowledge graph's whole point. Extraction still requires a configured
+# provider at run time; it just stops being unreachable at compile time.
+default = ["embedded", "server", "llm"]
 embedded = ["surrealdb/kv-surrealkv"]
 server = ["surrealdb/protocol-ws"]
 llm = ["reqwest"]

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -45,6 +45,15 @@ pub async fn graph_status(memory_dir: &Path) -> Result<(), RecallError> {
     println!("  Relationships: {}", stats.relationship_count);
     println!("  Episodes:      {}", stats.episode_count);
 
+    // Episodes arrive automatically on SessionEnd; turning them into entities
+    // is an explicit, LLM-costing pass. A store with episodes and no entities
+    // is the shape a user gets when nobody told them that.
+    if stats.episode_count > 0 && stats.entity_count == 0 {
+        println!("\n  {YELLOW}No entities yet.{RESET} Episodes are ingested automatically, but");
+        println!("  entity extraction is a separate pass over them:");
+        println!("    {DIM}recall-echo graph extract --all{RESET}");
+    }
+
     if !stats.entity_type_counts.is_empty() {
         println!("\n  {DIM}By type:{RESET}");
         let mut types: Vec<_> = stats.entity_type_counts.iter().collect();

--- a/src/status.rs
+++ b/src/status.rs
@@ -101,6 +101,15 @@ pub fn run_with_base(entity_root: &Path) -> Result<(), RecallError> {
         eprintln!("  Archives        {DIM}not initialized{RESET}");
     }
 
+    // Graph — the flat-file status command deliberately does not open the
+    // store (the daemon may hold it); `graph status` reports real counts.
+    let graph_dir = memory.join("graph");
+    if graph_dir.exists() {
+        eprintln!(
+            "  Graph           {DIM}present — run `recall-echo graph status` for counts{RESET}"
+        );
+    }
+
     // Issues
     eprintln!();
     if issues.is_empty() {


### PR DESCRIPTION
`cargo install recall-echo` shipped a binary with no `graph extract` subcommand — it is gated behind the `llm` feature, which was not in `default`. Hook ingestion wrote episodes; nothing could ever turn them into entities or relationships; and the command was not merely failing, it was absent from `--help`, so there was nothing to discover. The knowledge graph — the reason the project exists — was unreachable in the default build.

**`llm` is now a default feature.** Extraction still requires a configured provider at run time; it just stops being compiled out. `reqwest` is a marginal addition next to the SurrealDB and ONNX dependencies already present.

**`graph status` now names the gap.** A store with episodes and zero entities prints why that happens and the exact command to fix it, rather than reporting the numbers as though they were expected.

**`status` points at `graph status`** for real counts — it deliberately does not open the store, since a running daemon may hold it.

Checked that `--no-default-features --features embedded` still builds, so the feature flags remain honest in the other direction.

389 tests, clippy -D warnings clean. Phase 3 of the v4 roadmap; the MCP server and licensing decision are the remaining items there.