### PR TITLE
Phase 2: answer assembly, dedup cost, retrieval scoring, MCP server, background extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ recall-echo graph add-entity --name <n> --type <t> --abstract <a>   # Add entity
 recall-echo graph relate <from> --rel <type> --target <to>          # Create relationship
 recall-echo graph ingest <archive>              # Ingest single archive (episodes only)
 recall-echo graph ingest-all                    # Ingest all un-ingested archives
-recall-echo graph extract --all                 # LLM entity extraction from archives
+recall-echo graph extract --all                 # LLM entity extraction (the daemon also does this when idle)
 
 # Pipeline & integrations
 recall-echo graph pipeline sync                 # Sync pipeline documents into the graph
@@ -256,7 +256,7 @@ Knowledge graph operations. See the Architecture section above for the full comm
 - `graph relate <from> --rel <type> --target <to>` — Create a relationship between two entities. Supports `--description` and `--source`.
 - `graph ingest <archive>` — Ingest a single archive file (creates episodes, no LLM required).
 - `graph ingest-all` — Scan conversations/ and ingest all un-ingested archives.
-- `graph extract` — LLM-powered entity extraction. Supports `--log <N>` (single archive), `--all` (all un-extracted), `--dry-run`, `--model`, `--provider` (anthropic or openai), `--delay-ms`.
+- `graph extract` — LLM-powered entity extraction. Supports `--log <N>` (single archive), `--all` (all un-extracted), `--dry-run`, `--model`, `--provider` (anthropic or openai), `--delay-ms`. The daemon runs this pass on its own once the machine is quiet (see [Background extraction](#background-extraction)); this command is how you run it *now*, or in `server` mode, or after changing the model.
 
 **Daemon:**
 
@@ -282,7 +282,8 @@ recall-echo serve --dir /path/to/memory --foreground
 ```
 
 `--foreground` logs to stderr as well as `<memory_dir>/graph/daemon.log` and
-disables idle shutdown, leaving lifetime to systemd.
+disables idle shutdown, leaving lifetime to systemd. Background extraction
+still runs — it waits for quiet, not for an idle timeout.
 
 ### `recall-echo mcp`
 
@@ -400,6 +401,11 @@ max_candidates = 3           # Existing entities compared per candidate
 [serve]
 socket_path = ""             # Daemon socket override (default: XDG runtime dir)
 idle_timeout_secs = 3600     # Shut the daemon down after this much inactivity (0 = never)
+
+[extraction]
+background_enabled = true    # Let the daemon extract entities when the machine is quiet
+idle_after_secs = 120        # Quiet period before a background batch starts
+batch_size = 3               # Archives per batch (the next batch is one quiet period later)
 ```
 
 | Section | Key | Default | Description |
@@ -417,6 +423,9 @@ idle_timeout_secs = 3600     # Shut the daemon down after this much inactivity (
 | `graph.dedup` | `max_candidates` | `3` | How many existing entities dedup compares a candidate against |
 | `serve` | `socket_path` | XDG runtime dir | Daemon socket path override |
 | `serve` | `idle_timeout_secs` | `3600` | Daemon idle shutdown timeout (`0` disables) |
+| `extraction` | `background_enabled` | `true` | Extract entities in the daemon once it has been quiet |
+| `extraction` | `idle_after_secs` | `120` | Seconds without a request before a background batch may start (`0` = as soon as no connection is open) |
+| `extraction` | `batch_size` | `3` | Archives per background batch |
 
 All settings have sensible defaults. Missing file or invalid values fall back silently.
 
@@ -464,6 +473,54 @@ If the embedded store is locked by a foreign process, the daemon retries with
 backoff and then fails with a named `store locked` error — never a raw LOCK
 panic. Flat-file layers (MEMORY.md, EPHEMERAL.md, archives) are unaffected by
 any of this.
+
+## Background extraction
+
+Episodes arrive mechanically: the `SessionEnd` hook ingests every conversation
+without anyone remembering to. Turning those episodes into **entities,
+relationships, confidence and provenance** used to be a command a human had to
+type — so semantic search and Bayesian confidence, the features this project is
+actually about, stayed empty for anyone who did not read the docs closely.
+
+The daemon does that pass itself. It already owns the store and already knows
+when nobody is using it, so once the memory directory has been quiet for
+`[extraction] idle_after_secs` (default two minutes) it takes `batch_size`
+un-extracted archives (default three) and runs exactly what
+`recall-echo graph extract` runs. Then it goes back to waiting. A backlog
+drains one batch per quiet period.
+
+- **A client request always wins.** Nothing is locked for the length of a
+  batch: the worker shares the store like any other task, and it stops at the
+  next archive boundary as soon as a connection is open.
+- **Interruption is safe.** The `extracted` flag flips per archive, after that
+  archive succeeded — never per batch. A daemon killed mid-batch simply leaves
+  work to do.
+- **Idle shutdown waits for the batch, not for the backlog.** The daemon will
+  not exit with an archive in flight, and a finished batch restarts the idle
+  clock — so a daemon working through a backlog stays up, and one with nothing
+  left to do exits after `[serve] idle_timeout_secs` as always.
+- **It gives up rather than loops.** An archive that fails twice is written to
+  `graph/extraction-quarantine.txt` and skipped; three failures in a row
+  disable the worker until the daemon restarts. There is no retry storm and no
+  runaway bill.
+- **It says what it did.** Every batch logs its count and duration to
+  `<memory_dir>/graph/daemon.log`, and `graph daemon status` reports whether
+  the worker is on, what it has extracted, and — when it is off — why.
+
+**What it costs.** Extraction calls a model, so this is real money for
+API-key providers. Two things bound it. First, the daemon is started with an
+allowlisted environment that deliberately excludes API keys, so an
+*auto-started* daemon can only ever use the `claude-code` provider, which bills
+nothing beyond a Claude subscription; with `provider = "anthropic"` the worker
+finds no key, disables itself, and says so once in the daemon log. An API
+provider reaches the daemon only if you run `recall-echo serve --foreground`
+with the key exported — an explicit act. Second, `batch_size` bounds any single
+burst. Set `background_enabled = false` to turn the pass off entirely.
+
+**Not in `server` mode.** With `[graph] mode = "server"` clients bypass the
+daemon completely, so a daemon's "quiet" measures a socket nobody connects to
+rather than anything about you, and other processes may be writing to the same
+store. Background extraction stays off there; `graph extract` is the way.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This means the graph handles contradictions, reinforces patterns over time, and 
 
 **Entity types:** person, project, tool, service, preference, decision, event, concept, case, pattern, thread, thought, question, observation, policy, measurement, outcome. Mutable types (person, project, tool, etc.) can be updated; immutable types (decision, event, case, etc.) are append-only.
 
-**Extraction pipeline:** When conversations are archived, an LLM-powered pipeline chunks the text (~500 tokens), extracts entities and relationships in parallel (up to 10 concurrent), then deduplicates sequentially with LLM-assisted skip/create/merge decisions. Re-extracted relationships receive Bayesian corroboration updates weighted by the provenance of the chunk they came from — conversation turn roles are read to tell the human's words from the agent's, and `graph ingest --external` marks genuinely external material — so knowledge confirmed by independent sources gains confidence while the agent repeating itself barely moves the score.
+**Extraction pipeline:** When conversations are archived, an LLM-powered pipeline chunks the text (~500 tokens), extracts entities and relationships in parallel (up to 10 concurrent), then deduplicates sequentially. Dedup escalates to the LLM only for candidates it cannot settle itself: an existing entity of the same name and type is the same entity, a nearest neighbour above `certain_similarity` is the same entity, one below `review_similarity` is a new one, and only the band in between buys an LLM skip/create/merge decision — over a set capped at `max_candidates`. The bands are cut on raw cosine similarity, never on the blended retrieval score, so a popular entity does not read as a likelier duplicate and dedup cost stays flat as the graph grows. Re-extracted relationships receive Bayesian corroboration updates weighted by the provenance of the chunk they came from — conversation turn roles are read to tell the human's words from the agent's, and `graph ingest --external` marks genuinely external material — so knowledge confirmed by independent sources gains confidence while the agent repeating itself barely moves the score.
 
 **Tiered content:** Entities store content at three levels — L0 (abstract, used for embeddings and cheap traversal), L1 (overview, used for reranking), and L2 (full content, pulled on demand). This keeps graph traversal fast.
 
@@ -339,6 +339,11 @@ auto_sync = true               # Auto-sync pipeline docs to graph on archive
 mode = "embedded"            # Storage backend: "embedded" (default) or "server"
 url = "ws://localhost:8787"  # SurrealDB server URL (server mode only)
 
+[graph.dedup]
+certain_similarity = 0.92    # At or above this cosine similarity, the same entity — no model call
+review_similarity = 0.82     # Below this, a new entity — no model call
+max_candidates = 3           # Existing entities compared per candidate
+
 [serve]
 socket_path = ""             # Daemon socket override (default: XDG runtime dir)
 idle_timeout_secs = 3600     # Shut the daemon down after this much inactivity (0 = never)
@@ -354,6 +359,9 @@ idle_timeout_secs = 3600     # Shut the daemon down after this much inactivity (
 | `pipeline` | `auto_sync` | `false` | Sync pipeline documents to the knowledge graph on archive |
 | `graph` | `mode` | `embedded` | Storage backend: `embedded` (single-process SurrealKV) or `server` (shared SurrealDB) |
 | `graph` | `url` | `ws://localhost:8787` | SurrealDB server URL, `server` mode only |
+| `graph.dedup` | `certain_similarity` | `0.92` | Cosine similarity at or above which a candidate is the same entity, resolved without a model call |
+| `graph.dedup` | `review_similarity` | `0.82` | Cosine similarity below which a candidate is a new entity, created without a model call |
+| `graph.dedup` | `max_candidates` | `3` | How many existing entities dedup compares a candidate against |
 | `serve` | `socket_path` | XDG runtime dir | Daemon socket path override |
 | `serve` | `idle_timeout_secs` | `3600` | Daemon idle shutdown timeout (`0` disables) |
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,59 @@ recall-echo serve --dir /path/to/memory --foreground
 `--foreground` logs to stderr as well as `<memory_dir>/graph/daemon.log` and
 disables idle shutdown, leaving lifetime to systemd.
 
+### `recall-echo mcp`
+
+An MCP server over stdio, so an agent can query its own memory mid-conversation.
+
+**Why it exists.** Without it the knowledge graph is effectively write-only.
+`SessionEnd` ingests episodes and `SessionStart` runs `consume`, which only
+prints EPHEMERAL.md — nothing in a normal session ever reads the graph, so the
+Bayesian confidence, semantic search, provenance weighting and temporal decay
+sit behind a command a human has to type by hand. The MCP server is the read
+path: the agent asks memory the actual question, at the moment it matters.
+
+Add it to Claude Code:
+
+```bash
+claude mcp add recall-echo -- recall-echo mcp --entity-root /path/to/entity
+```
+
+Or, equivalently, in a project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "recall-echo": {
+      "command": "recall-echo",
+      "args": ["mcp", "--entity-root", "/path/to/entity"]
+    }
+  }
+}
+```
+
+`--entity-root` defaults to the current directory, so it can be omitted when
+the client is launched from the entity root.
+
+**Tools.** All five are read-only; none can write to the graph.
+
+| Tool | Answers |
+| --- | --- |
+| `recall_query` | The default lookup: semantic search + one hop of graph expansion + the conversation fragments behind it |
+| `recall_search` | Semantic entity search alone — names, types, abstracts, retrieval scores |
+| `recall_episodes` | The raw conversation fragments, for what was actually said |
+| `recall_traverse` | Relationships out of one named entity, as a tree with edge confidence |
+| `recall_status` | Entity, relationship and episode counts — tells an empty memory from a failed lookup |
+
+Every tool runs through the same graph daemon as the CLI, so it inherits the
+daemon's auto-start, locking and concurrency, and starting an MCP client never
+takes the store away from a hook.
+
+**Writing is deliberately absent.** The graph discounts what the agent asserts
+about itself (`[graph.provenance]`), and a tool that let the model create
+entities and edges directly would route around exactly that mechanism. Memory
+is written on the ingest path, where every episode is stamped with its
+authorship.
+
 ## Archive Format
 
 Conversation archives use YAML frontmatter with markdown content:

--- a/docs/bayesian-confidence.md
+++ b/docs/bayesian-confidence.md
@@ -119,18 +119,22 @@ path_confidence([0.8, 0.7, 0.9]) = 0.504
 
 This falls naturally out of treating edges as independent probabilities. The practical effect is that the long tail of weak chains is automatically suppressed. Two hops over 0.9 edges is a stronger signal than four hops over 0.7 edges (`0.81` vs `0.24`) — no special-case pruning needed.
 
-The hybrid query in `src/graph/query.rs` applies this directly: after the semantic phase identifies the top candidates, graph expansion adds neighbors scored as `parent_score · effective_confidence` (`query.rs:83`). The effective confidence is computed with temporal decay at read time (`query.rs:158-163`), and edges below 0.1 effective confidence are filtered out (`query.rs:166-168`).
+The hybrid query in `src/graph/query.rs` applies this directly: after the semantic phase identifies the top candidates, graph expansion adds neighbors whose *relevance* is the parent's, discounted by the edge — `similarity_parent · effective_confidence` (`merge_graph_candidates`). Effective confidence is computed with temporal decay at read time, and edges below 0.1 effective confidence are dropped before scoring (`get_neighbor_details`).
+
+Confidence therefore attenuates the same term for both channels rather than scaling a whole score. A graph-sourced candidate is scored by `score_with_utility` exactly as a semantic one is — hotness and utility read off the neighbor itself — so a decayed edge ranks its target lower without the target having to overcome a base that semantic candidates receive for free:
 
 ```
   semantic                graph expansion
   ─────────               ──────────────
-    [E1: 0.84] ──[0.9]──→ [N1: 0.756]
-       │                      │
-       └───────[0.6]───────→  [N2: 0.504]   ← scored, not pruned
-                                            ← attenuates over hops
-    [E2: 0.71] ──[0.4]──→ [N3: 0.284]       ← below filter floor
-                                              after second hop
+    [E1: sim 0.84] ──[0.9]──→ [N1: sim 0.756]  + own hotness/utility
+       │                          │
+       └───────[0.6]──────────→  [N2: sim 0.504]   ← scored, not pruned
+                                                   ← attenuates over hops
+    [E2: sim 0.71] ──[0.4]──→ [N3: sim 0.284]      ← below filter floor
+                                                     after second hop
 ```
+
+When both channels reach the same entity, the graph corroborates a measurement rather than replacing it: the measured similarity is raised by `1 + corroboration_boost · effective_confidence`, clamped at 1.0. The independence precondition below is why the lift is small, why it is credited once per entity over its strongest path rather than accumulated across the expanded parents — those parents are the top hits of a single query, not independent witnesses — and why a self-edge is skipped rather than counted.
 
 Note the honest asymmetry: the multiplicative rule assumes edge independence, and the provenance machinery below exists precisely because *observations* are frequently not independent. Path independence and observation independence are different assumptions; only the second one is modelled.
 
@@ -267,7 +271,7 @@ A few design choices worth pulling out:
 - The `Evidence` counts are private with accessor methods, so nothing outside the model can write a state where the mean and the counts disagree.
 - Half-life of 90 days is a default; the constant lives at `confidence.rs:382` and the `temporal_decay` signature accepts a per-call value, so per-domain tuning is mechanical.
 - The decay floor at 0.05 is deliberate. Edges below it are still queryable but ranked near the bottom. Hard deletion is a GC concern.
-- The hybrid query filters effective confidence below 0.1 during graph expansion (`query.rs:166`). Below this, the multiplicative chain attenuates results to noise.
+- The hybrid query filters effective confidence below 0.1 during graph expansion (`get_neighbor_details`). Below this, the multiplicative chain attenuates results to noise.
 
 ## Reproducibility
 

--- a/docs/benchmarks/assembly-fixes-2026-08.md
+++ b/docs/benchmarks/assembly-fixes-2026-08.md
@@ -1,0 +1,46 @@
+# Assembly Fixes — Measured Effect (N=10, same stores, no re-ingest)
+
+**Date**: 2026-08-05 · **Branch**: feat/RE-37-answer-assembly
+**Compares**: `baseline-2026-08.md` (the Phase 0 provisional baseline) against the same ten ingested stores answered with the assembly-fixed binary.
+**Cost**: zero. Ingest was not re-run; only answer + judge + retrieval scoring. This isolates the two fixes that act at query time (D1 archive channel, D3 episode top-k) from the one that does not (D2 abstract cap, which only affects newly-ingested stores).
+
+## Result
+
+| Metric | Baseline | After fixes | Δ |
+|---|---|---|---|
+| **Answer accuracy (headline, n=9)** | **0.0%** | **55.6%** | **+55.6** |
+| Abstention (n=1) | 100% | 0% | −100 |
+| Recall@1 | 0.380 | 0.491 | +0.111 |
+| Recall@3 | 0.648 | 0.833 | +0.185 |
+| Recall@5 | 0.676 | 0.861 | +0.185 |
+| Recall@full | 0.676 | **1.000** | +0.324 |
+| MRR | 0.778 | 0.903 | +0.125 |
+
+Per-category answer accuracy after: knowledge-update 100%, single-session-assistant 100%, temporal-reasoning 67%, multi-session 33%, single-session-preference 0%, abstention 0%.
+
+Five of nine answerable questions flipped from wrong to correct: `gpt4_af6db32f`, `9d25d4e0`, `18bc8abd`, `4388e9dd`, `993da5e2`. Assembled context roughly doubled on every question (e.g. 1,424 → 3,077 tokens), which is the intended effect of reviving a channel that was returning nothing and of sampling episode search where its index is stable.
+
+**Recall@full reaching 1.000** is the clearest single signal: every answerable question now retrieves its evidence session. The two questions the context-presence analysis classified as "absent from retrieval" were absent only from the *graph* channel — the archive held them, and the archive channel was dead.
+
+## The regression, stated plainly
+
+`29f2956b_abs` went from **correct to incorrect**. It asks how much time the user spends practising violin; the gold answer is that they never mentioned violin, only guitar. With a starved context the system correctly said it lacked the information. With richer context it answered **"30 minutes"** — the guitar practice duration, attached to the wrong instrument.
+
+This is the predictable cost of more context: additional material creates additional opportunities to construct a plausible but false link. It arrives as a confident false positive rather than a miss, which is the worse failure mode for a memory system, and it should be treated as a first-class problem rather than rounding error at n=1. The likely fix is instruction-level (an explicit licence to answer "you never told me this") rather than retrieval-level, and it needs its own measurement.
+
+## What this does and does not establish
+
+**Establishes**: the Phase 0 conclusion was right. Assembly, not retrieval quality, was the bottleneck — the store already held the answer in 9 of 9 failures, and simply delivering it moved accuracy from nothing to a majority.
+
+**Does not establish**:
+- **D2 (1,000-char abstracts) is untested.** These ten stores still hold 200-character abstracts; the fix only applies to new ingests. `18bc8abd` improved *despite* its rank-1 episode still reading `"...my favourite is Ka..."`.
+- **The dedup cost fix is untested.** It acts at ingest, which was not re-run. Its counters exist so that a re-ingest reports the answer instead of inferring it.
+- **n=9.** One question is 11 percentage points. Treat 55.6% as "clearly better than zero", not as a rank against published figures. For scale only, and not comparable: Zep reports 63.8% on the full 500-question LongMemEval with a different answer stack.
+- Single run, no variance estimate; judge is LongMemEval's official per-type prompt via claude-code/sonnet, as in the baseline.
+
+## Reproduce
+
+```
+scripts/lme-postfix.sh          # answer + judge + retrieval against runs/lme-postfix
+```
+Requires the ten ingested stores under `runs/lme-mini/entities/` and a binary built with `--features bench,llm`.

--- a/docs/benchmarks/context-presence-2026-08.md
+++ b/docs/benchmarks/context-presence-2026-08.md
@@ -1,0 +1,102 @@
+# Context-Presence Analysis — August 2026 (AC1, Phase 2)
+
+**Analysis date**: 2026-08-05 · **Analyses**: `/opt/recall-echo-locomo/runs/lme-mini/` (the N=10 LongMemEval baseline of 2026-08-04, see `baseline-2026-08.md`)
+**Question**: the baseline retrieved the right evidence session 68% of the time (Recall@full 0.676, MRR 0.778) and answered 0 of 9 answerable questions correctly. Where did the gold-supporting facts go?
+**Answer, in one line**: they were retrieved and then thrown away by fixed top-k limits and a 200-character episode cap before the model ever saw them.
+
+## Classification scheme
+
+Each of the 9 answerable questions is assigned exactly one class, by the *earliest blocking cause* in the pipeline:
+
+| Class | Meaning | Operational test |
+|---|---|---|
+| **A** — absent from retrieval | No gold-supporting fact came back from the graph at any depth | Not present in a `graph query --limit 200 --depth 2 --episodes` result for the same question |
+| **B** — dropped in assembly | Retrieved, but never reached the prompt: top-k cutoff, truncation, or ordering | Present in the limit-200 result, absent from the assembled prompt |
+| **C** — present but unused | It was in the assembled prompt and the model still answered wrong | Present in the assembled prompt |
+
+## Result
+
+| Class | n | Share |
+|---|---|---|
+| **A — absent from retrieval** | **2** | 22% |
+| **B — dropped in assembly** | **5** | 56% |
+| **C — present but unused** | **2** | 22% |
+
+Even the two A cases are A only with respect to the *graph* channel. Both facts sit verbatim in the entity's own `conversations/` archive — a channel that is structurally unreachable today (see "The archive channel is dead", below). Counting the archive as a channel that exists but is broken, **9 of 9 failures are cases where the evidence was in the store and the assembly failed to deliver it.**
+
+## Per-question table
+
+| # | id | type | gold | predicted | class | evidence for the call |
+|---|---|---|---|---|---|---|
+| 1 | `9d25d4e0` | multi-session | 3 | *"I don't have enough information to answer."* | **B** | Needs 3 acquisitions. Emerald earrings (fact #11) and engagement ring (fact #9, episode #4 — with its "got it a month ago" anchor) **were** in the prompt. The third, a silver necklace, was not — but the entity `Silver Necklace` sits at **rank 34** of the limit-200 query, i.e. just below the `graph_limit 20` cutoff. |
+| 2 | `0a995998` | multi-session | 3 | "2 items: the exchanged boots from Zara … and the navy blue blazer at the dry cleaner" | **C** | Every gold evidence turn's content was in the prompt: Zara boots (fact #5, episode #1) and navy blazer (fact #13). The model read them correctly and returned 2. See the gold-ambiguity caveat below — the oracle's three evidence turns describe only two distinct items. |
+| 3 | `2ebe6c92` | temporal-reasoning | *'The Nightingale'* by Kristin Hannah | *"I don't have enough information to answer."* | **B** | "Nightingale" appears **nowhere** in the prompt; the 20 facts are dominated by an unrelated European-road-trip cluster and the 5 episodes are all "Song of Achilles" chatter. Yet the entity `The Nightingale` is at **rank 29** (>20) and an episode stating *"'The Nightingale' is an amazing book!"* is at **episode rank 7** (>`archive_top_k` 5). Both gold sessions were "retrieved" per the metric (Recall@full 1.00). |
+| 4 | `88432d0a` | multi-session | 4 | "**3 times**: Pizza … Sourdough … Convection cookies" | **B** | 3 of 4 bakes present (chocolate cake #1, sourdough, convection cookies #7/#12). The whole-wheat baguette is absent from the prompt but present at **episode rank 138** (*"Congratulations on your successful whole wheat baguette!"*). Compounding: **4 of the 20 fact slots** (#2, #8, #9, #18) are near-duplicate "sourdough came out dense on Tuesday" cases — dedup failure spending a fifth of the budget on one fact. The model also substituted a non-gold bake (pizza) for the cake that *was* present. |
+| 5 | `0a34ad58` | single-session-preference | Personalise using the user's *existing* Suica card and TripIt app | Generic Tokyo transit tips: *"**Get a Suica Card** — Load it with at least ¥10,000"*, *"Use TripIt or Google Maps"* | **C** | Suica (facts #2, #3, #12, #19) and TripIt (#5, #19) were both in the prompt, and the model used them — but as generic recommendations ("Get a Suica Card") rather than acknowledging prior preparation, which is exactly what the gold marks as *not* preferred. Retrieval and assembly both did their job. |
+| 6 | `gpt4_af6db32f` | temporal-reasoning | 17 days ago | *"I don't have enough information to answer."* | **B** | No Super Bowl content in the prompt: all 5 assembled episodes are **raw YAML frontmatter** (~1 KB of `log:`/`date:`/`session_id:` metadata, zero content). The decisive episodes are session-41 (*"since I won $20 from my colleague after the Super Bowl"*). **They are the true top-3** — but only at k≥20. See the k-sensitivity bug below. Entity `Super Bowl Bet` also exists, at rank 41. |
+| 7 | `18bc8abd` | knowledge-update | Kansas City Masterpiece | Sweet Baby Ray's *(the stale, superseded value)* | **B** | The single most decisive case. The **rank-1** episode (score 0.79) reads verbatim: `"… Currently, my favourite is Ka..."` — the 200-char episode cap severs the gold answer **mid-word**. The rank-2 episode carries the stale value, also truncated: `"… my favorite BBQ sauce, Sweet..."`. The string "sweet baby" is not in the prompt at all; the model completed the brand from the 5-character fragment "Sweet" and world knowledge. A third episode stating *"While Kansas City Masterpiece BBQ sauce is a great choice"* sits at **episode rank 15**, cut by `archive_top_k 5`. |
+| 8 | `993da5e2` | temporal-reasoning | One week (7–10 days acceptable) | *"I don't have enough information to answer."* | **A** | Needs two anchors: rug acquired "a month ago" and furniture rearranged "three weeks ago". At limit 200: `rearrang*` returns **0 hits**, and no "rug … a month ago" co-occurrence exists. The rug is mentioned (episodes #1, #5) but only as decor context, never with an acquisition date. Both anchors are in the archive (2 and 7 files) — extraction simply never captured them. Retrieval metric says Recall@full **1.00** for this question. |
+| 9 | `4388e9dd` | single-session-assistant | "an untidy, stained white shirt" | *"I don't have enough information to answer."* | **A** | At limit 200: `untidy` **0 hits**, `wears` 0 hits; `shirt` hits only unrelated sessions (an undershirt brand, a diaper-change scene). Extraction condensed the long script-writing turn into Cases about Andy's *behaviour* (exaggerated stories, disabled toilet) and dropped the costume detail entirely. Present in `conversation-003.md`. |
+
+*(The 10th row, `29f2956b_abs`, is the abstention control: correctly answered, excluded from the 9 per the harness convention.)*
+
+## The three mechanisms behind the 5 B's
+
+### 1. The archive channel is dead — 0 hits, all 10 questions
+
+`bench answer` is documented as "top-20 graph facts + **top-5 archive snippets** + MEMORY.md". In this run the archive contributed **zero** snippets to **all ten** prompts, despite 44–55 archive files per entity.
+
+Cause: `src/search.rs::ranked_search` requires **every** whitespace-token of the query to appear in a file (`all_words_present`), and the harness prefixes each question with `[Current date: 2023-05-30T15:43:00Z]`. The tokens `[current` and the ISO timestamp appear in **zero** archive files, so the AND-filter eliminates every candidate before scoring. Replicated exactly in Python across all 10 questions: 0 files survive for every question. Punctuation-attached tokens (`bowl?`, `furniture?`, `wrote`) would kill most of the remainder even without the date prefix.
+
+Consequence: the assembled prompt is graph-only. Both A-class questions, and the full text severed in question 7, are recoverable from the archive.
+
+### 2. Episode abstracts are capped at 200 characters
+
+`src/graph/ingest.rs:424` — `chunk.chars().take(200)`. Every episode in every prompt is ≤203 chars; the 5 episodes together contribute ~1 KB regardless of question. This is a *storage* cap, so the full text is not available to the answer path at any k.
+
+This is what makes session-level retrieval metrics misleading. Recall@full 0.676 measures whether the right **session** appeared in the ranked list — but the assembly carries only a 200-character slice of that session. Questions 3, 7 and 8 all scored **Recall@full 1.00** while the answer-bearing sentence never reached the prompt. **Session-level recall says almost nothing about whether the answer got through.**
+
+### 3. Episode search loses recall at small k
+
+Not a cutoff — a correctness bug. For `gpt4_af6db32f`, the same query returns strictly worse results at k=5 than at k=20:
+
+```
+graph query --limit 5    top-5 episodes:  0.666  0.660  0.660  0.660  0.659   (all frontmatter, session 27/28/34/29/35)
+graph query --limit 20   top-5 episodes:  0.701  0.700  0.690  0.666  0.660   (session-41 x3 — the Super Bowl evidence)
+graph query --limit 200  top-5 episodes:  0.701  0.700  0.690  0.666  0.660   (identical to k=20)
+```
+
+The k=5 call misses three higher-scoring items that k=20 finds, consistent with an HNSW `ef_search` tied to k. Since `answer.rs` calls `search_episodes(question, archive_top_k)` with `archive_top_k = 5`, the answer path runs the episode index at exactly the k where its recall is worst. Note this did not reproduce for `2ebe6c92` (k=5, 20 and 200 gave identical top-5), so it is graph-dependent, not universal.
+
+### Also observed
+
+- **MEMORY.md is empty (0 bytes) in all 10 entity roots** — the "Curated memory" section never appeared in any prompt. Expected for a benchmark ingest that never runs distillation, but it means one of the three documented context sources contributed nothing and was not measured.
+- **Fact-slot redundancy**: question 4 spent 4 of 20 slots on near-duplicate sourdough cases. Raising `graph_limit` without deduplicating will spend the increase on more duplicates.
+
+## What this means for Phase 2
+
+**The spec's ordering assumption is confirmed, but its diagnosis is not.** Phase 2 opens by asserting that the failures are "honest partial assemblies … a reranker cannot fix that", and prioritises **budgeted multi-fact assembly** — raising fact counts, grouping by session, preserving temporal order. The measurement supports keeping work item 1 first, and refutes work item 4 (reranking) as the lever. But the dominant defect is not that the *fact budget* is too small in the abstract. It is that **three plumbing faults silently discard already-retrieved evidence**, and they are all cheap to fix:
+
+1. **Fix `ranked_search`'s all-words AND filter** (and strip the `[Current date: …]` prefix, or match on content tokens only). This restores an entire retrieval channel that is currently contributing zero. It is the only fix that can reach questions 8 and 9 — the two A-class failures — because their evidence exists nowhere else.
+2. **Stop truncating episodes to 200 chars in the answer path.** Question 7 is a correct-rank-1 retrieval that returned the wrong answer purely because the gold string was cut mid-word. This is a one-question-in-nine effect on its own.
+3. **Raise `archive_top_k` above 5 for episodes, and audit the HNSW `ef_search`/k coupling.** Questions 3, 6 and 7 each have decisive evidence at episode rank 7, 1–3 (only visible at k≥20), and 15 respectively.
+
+Only after that does "budgeted multi-fact assembly, grouped and temporally ordered" become the binding constraint — and question 1 (`Silver Necklace` at rank 34) plus question 4 (baguette at rank 138) show it will still bind. **Raise `graph_limit` together with entity dedup**, not alone: a fifth of question 4's budget already went to duplicates.
+
+The 2 C-class failures are the honest floor. One (question 5) is a genuine prompt/instruction problem — the assembly delivered the right facts and the model used them impersonally; it argues for the spec's "what do you know about X across sessions" prompt shape, not for more retrieval. The other (question 2) may not be a system failure at all.
+
+**Expected value of the cheap fixes**: they address the blocking cause in 5 of 9 questions (all B) and are prerequisites for the 2 A's. They do not guarantee 5 correct answers — questions 1 and 4 also require the model to *count* correctly across many small facts, which it did not do even with 3 of 4 facts present. A realistic AC2 target is a measurable improvement over 0/9, not 7/9.
+
+## Caveats
+
+- **n = 9.** Every share in this document is one question ≈ 11 percentage points. Treat A=2 / B=5 / C=2 as a direction, not a rate. Reclassifying a single question moves the headline by 11 points.
+- **No replication divergence in the assembly step.** `predictions.jsonl` stores the serialised `BenchAnswer` including `retrieved_facts` and `retrieved_episodes` verbatim, and `build_user_message` is deterministic given (memory_md, facts, episodes, question). The prompts were reconstructed and verified **byte-exact for all 10 questions** by recomputing `answer.rs`'s `estimate_tokens` (`len().div_ceil(4)` over bytes, system + user) and matching the recorded `tokens_in` exactly. This part of the analysis carries no approximation.
+- **The retrieval-probe step does carry a caveat.** `graph query` (`graph_cli::hybrid_query`) and `bench answer` (`answer.rs::retrieve_facts`) both call `GraphMemory::query` with the same `QueryOptions` shape, and the probe used the same question text, `--depth 2` and `--episodes`. But the probe was run **2026-08-05, one day after the run**, against the same on-disk entity roots with the same binary (verified identical by md5: `/root/.cargo/bin/recall-echo` == `/opt/recall-echo/target/release/recall-echo`). If graph state mutated between the run and the probe — e.g. access-count updates from the original query affecting hotness-weighted scoring — deep ranks could shift. Ranks are used only to distinguish "below cutoff" from "absent", and the margins (rank 29, 34, 41, 138 vs a cutoff of 20; rank 7 and 15 vs a cutoff of 5) are wide enough that small drift does not change any classification.
+- **Semantic-match judgement calls.** Presence was tested by keyword co-occurrence over the prompt's fact+episode sections with the `## Question` block excluded (the question text otherwise produces false positives — it did for "super bowl" and "rearranged" on first pass). Borderline calls, all resolved by reading the surrounding text: question 8's rug *is* mentioned but never with an acquisition date, so the anchor is absent; question 4's "whole wheat" appears in the prompt only as a *future* baking plan, not the past baguette; question 5's Suica/TripIt are present and used, so it is C despite scoring 0.
+- **Gold-label ambiguity on question 2.** The oracle's three evidence turns for `0a995998` describe only two distinguishable items (the Zara boots appear in two sessions; the blazer in one), yet gold is 3. The model's "2" may be defensible. Classified C because all retrievable evidence reached the prompt, but this question is weak grounds for any design decision.
+- **Question-type counts differ from `baseline-2026-08.md`.** The oracle types for this subset are 3 temporal-reasoning, 3 multi-session, 1 knowledge-update, 3 single-session (assistant/preference/user-abstention) — matching `retrieval_metrics.json`. The baseline document's "2 multi-session, 2 knowledge-update" is a miscount and should be corrected there.
+- **Single run.** No re-run was performed and no LLM answer calls were made for this analysis; the classification rests on stored artifacts plus no-LLM retrieval probes. Whether fixing the B mechanisms actually converts to correct answers is AC2's job, not this document's.
+
+---
+
+*Method and throwaway scripts: prompts reconstructed from `predictions.jsonl`, verified against recorded `tokens_in`; deep-retrieval probes via `recall-echo graph --entity-root <root> query "<question>" --limit 200 --depth 2 --episodes` (no LLM calls); archive behaviour replicated from `src/search.rs::ranked_search`. No product code was modified.*

--- a/docs/benchmarks/phase2-final-2026-08.md
+++ b/docs/benchmarks/phase2-final-2026-08.md
@@ -1,0 +1,59 @@
+# Phase 2 Final — LongMemEval, N=10
+
+**Date**: 2026-08-05 · **Branch**: feat/RE-37-answer-assembly
+**Dataset**: LongMemEval-S, deterministic stratified 10-question subset (seed 42): 9 answerable + 1 abstention.
+**Judge**: LongMemEval's official per-type prompts, verbatim (upstream `d6dc8b5`), via claude-code/sonnet.
+**Retrieval metrics** computed independently of the judge, against `answer_session_ids` from the oracle file.
+
+## Three measurement points
+
+| Metric | Baseline | + assembly fixes | + re-ingest |
+|---|---|---|---|
+| **Answer accuracy (n=9)** | **0.0%** | 55.6% | **77.8%** |
+| Abstention (n=1) | correct | *incorrect* | correct |
+| Recall@1 | 0.380 | 0.491 | 0.491 |
+| Recall@3 | 0.648 | 0.833 | **0.972** |
+| Recall@full | 0.676 | 1.000 | 1.000 |
+| MRR | 0.778 | 0.903 | 0.944 |
+
+- **Baseline** — v3.13.0 behaviour. See `baseline-2026-08.md`.
+- **+ assembly fixes** — same ingested stores, re-answered with the archive channel revived and episode top-k decoupled. No re-ingest, so zero API cost. See `assembly-fixes-2026-08.md`.
+- **+ re-ingest** — the ten conversations ingested again with the full Phase 2 binary: 1,000-character episode abstracts, similarity-gated dedup, and the corrected retrieval scoring.
+
+Per-category at the final point: temporal-reasoning 100%, knowledge-update 100%, single-session-assistant 100%, abstention 100%, multi-session 67%, single-session-preference 0%.
+
+## What each change contributed
+
+The Phase 0 context-presence analysis classified all nine baseline failures: 2 absent from retrieval, 5 dropped in assembly, 2 present-but-unused — with the store holding the answer in **9 of 9**. Every subsequent change follows from that.
+
+**Assembly (0% → 55.6%).** `ranked_search` required every query token to appear in a file, so natural-language questions eliminated every candidate before scoring: the archive channel contributed nothing to any prompt. Replacing the AND gate with OR-qualification plus a coordination factor, and decoupling `episode_top_k` (20) from `archive_top_k` (5), moved five questions from wrong to right without touching the stores.
+
+**Re-ingest (55.6% → 77.8%).** Episode abstracts were cut at 200 characters, mid-word — one failure severed *Kansas City Masterpiece* into `"...my favourite is Ka..."` and the model answered from the fragment. At 1,000 characters, cut on sentence boundaries, two more questions resolve and Recall@3 rises to 0.972.
+
+**The abstention question is the interesting one.** It regressed at the middle point (correct → incorrect) and recovered at the end. With a starved context the system correctly said it lacked the information; with partial context it confabulated "30 minutes" by attaching the user's *guitar* practice duration to a question about violin; with full-length abstracts it can see enough context to recognise that violin was never mentioned. The confabulation was caused by truncation, not by richness — which inverts the obvious reading and is worth stating, because the obvious reading would have led to a prompt-engineering fix for a data-shape problem.
+
+## Ingest cost
+
+Re-ingest of the ten conversations, measured by counters added for this purpose (`dedup_llm_calls` / `dedup_fast_path`):
+
+- **25,810 dedup decisions; 37.0% required a model call; 16,271 avoided.**
+- Under the previous gate — which filtered on the *blended* retrieval score (similarity + hotness + utility), so a hot entity qualified at ~0.33 actual similarity — sampling a real store put the call rate at **94%**.
+- Per-conversation ingest time clustered at 2,724–3,238 s, against 600–5,665 s previously. The old spread grew with graph size; the new one does not, because the gate no longer moves with access counts.
+
+Extraction, not dedup, remains the dominant cost (~2,500 tokens per chunk vs ~600 per dedup call). This removed the growth term, not the baseline.
+
+## Honest limitations
+
+- **n=9.** One question is 11 percentage points. 77.8% means "seven of nine", not a rank.
+- **Single run per point**, no variance estimate, no cross-validation.
+- **Not comparable to published figures.** Zep reports 63.8% on the full 500-question LongMemEval with a different answer stack; this is a 10-question subset. It is a before/after on identical questions, which is what it is designed to be, and nothing more.
+- **The 50-question run remains unrun.** Specced, scripted, deterministic subset selection shared with this one; deferred on cost.
+- **Full-context and grep baselines not measured** — required before any published comparison against other systems.
+- The two remaining failures are **not retrieval failures**: Recall@full is 1.000, so evidence was retrieved for all nine. One is cross-session aggregation (counted 2 of 3 items), one is personalization (gave generic advice instead of using known possessions). Both were classified "present but unused" at baseline and remain so.
+
+## Reproduce
+
+```
+scripts/lme-reingest.sh      # ingest (API cost)
+scripts/lme-v2-measure.sh    # answer + judge + retrieval (subscription)
+```

--- a/specs/phase2-answer-and-retrieval.md
+++ b/specs/phase2-answer-and-retrieval.md
@@ -1,0 +1,56 @@
+# Phase 2 — Answer Assembly and Retrieval Quality
+
+**Status**: Todo (re-plotted 2026-08-05 after the Phase 0 baseline)
+**Supersedes**: the Phase 2 section of `/opt/pulse-vault/pulse-null/specs/todo/recall-echo-v4-roadmap-spec.md`, which adopted Echo's retrieval-modernization spec as written. That sequencing was correct given what was known; the baseline changed what is known.
+
+## Why this is re-plotted
+
+The roadmap assumed retrieval quality was the lever. The N=10 LongMemEval baseline (`docs/benchmarks/baseline-2026-08.md`) says otherwise:
+
+```
+retrieval:  MRR 0.778   Recall@3 0.648   Recall@full 0.676     ← the memory finds the evidence
+answers:    0 / 9 headline (abstention 1/1)                    ← and then fails to use it
+```
+
+The failures are honest partial assemblies ("2 items: the boots and the blazer" where gold is 3) and honest give-ups on questions whose evidence *was retrieved*. A reranker cannot fix that. Two further cost/behaviour findings landed alongside it:
+
+- **Dedup escalation**: per-conversation ingest time ranged 600s → 5,400s (9×) as graphs grew — each new entity triggers LLM dedup against an ever-larger candidate set. Ingest cost ran ~5× the estimate (~$3/question), which is what makes the 50-question benchmark expensive enough to defer.
+- **Retrieval is near-semantic-only in practice** (from `tests/query_golden.rs`): graph expansion is inert when the graph is smaller than 2×limit; a candidate found *both* semantically and over a high-confidence edge keeps its semantic score (graph corroboration is discarded on collision); graph-sourced scores lack the hotness/utility floor that semantic scores get, so effective confidence must exceed ~0.8 to compete — confidence is near-binary at retrieval time; and only semantic hits increment access counts, so graph-tail entities can never warm up.
+
+## Work items, in priority order
+
+### 1. Answer-context assembly (the bottleneck)
+`bench answer` builds one prompt from top-20 graph facts + top-5 archive snippets + MEMORY.md. LongMemEval's dominant classes (temporal-reasoning 133/500, multi-session 133/500) need *many* small facts assembled, not one good passage.
+- Measure first: for the 9 answerable baseline questions, determine whether the gold-supporting facts were present in the assembled context at all. That single number splits "retrieval didn't surface it" from "assembly dropped it" from "the model had it and still missed."
+- Then: budgeted multi-fact assembly (raise fact count, group by session/date, preserve temporal ordering), evidence-ordered rather than score-ordered presentation for temporal questions, and an explicit "what do you know about X across sessions" shape for aggregation questions.
+- Exit: measured answer-accuracy delta on the same 10 questions.
+
+### 2. Dedup cost (gates everything downstream)
+- Add an embedding-similarity fast path before any LLM dedup call: identical/near-identical names resolve without a model call; only genuinely ambiguous candidates escalate.
+- Gate on cosine similarity, not the blended hotness/utility score (a "hot" unrelated entity currently triggers dedup comparisons).
+- Cap candidate-set growth (top-k by similarity, not everything above a blended threshold).
+- Exit: per-conversation ingest time flat rather than growing with graph size; measured on a re-ingest of the same 10 conversations.
+
+### 3. The three retrieval bugs (cheap, and they compound with #4)
+- Graph corroboration discarded on collision → boost, don't skip, when an entity is found both semantically and via a high-confidence edge.
+- Graph-score handicap → give graph-sourced candidates a comparable base so confidence stops being effectively binary.
+- Access counts → increment for graph-expanded results too, so the graph tail can warm.
+
+### 4. Echo's retrieval modernization (unchanged, now correctly sequenced last)
+1. Reranker (BGE-reranker-v2) over the fused shortlist.
+2. Hybrid dense+sparse with RRF fusion — restores exact-token precision for codes, versions, names.
+3. BGE-M3 swap (384→1024 re-embed, index rebuild) — verify FastEmbed sparse support and ONNX RAM on the VPS first; the model is ~10× BGE-Small.
+4. Spanish cases in the harness.
+
+## Acceptance criteria
+
+- [ ] AC1: Context-presence analysis published for the baseline's 9 answerable questions — gold-supporting facts classified as absent-from-retrieval / dropped-in-assembly / present-but-unused.
+- [ ] AC2: Answer accuracy on the same 10 questions improves measurably over 0/9, with the run recorded in `docs/benchmarks/`.
+- [ ] AC3: Re-ingesting the 10 baseline conversations shows per-conversation time no longer growing with graph size (compare against the 600s→5,400s spread).
+- [ ] AC4: Golden-set tests updated to pin the corrected behaviours (corroboration boost, comparable graph scoring, access-count symmetry) — the current tests pin today's bugs deliberately, so they must change *deliberately*.
+- [ ] AC5: Each modernization stage (reranker, hybrid, BGE-M3) recorded with a before/after on the same subset; any stage that does not pay for itself is reverted, and the revert is recorded too.
+- [ ] AC6: No regression in retrieval metrics at any stage (MRR/Recall@k vs the Phase 0 baseline).
+
+## Out of scope
+
+MCP server and licensing (Phase 3); publication (Phase 4); the 50-question run — it becomes affordable *because* of work item 2, so it is the natural first beneficiary rather than a prerequisite.

--- a/src/bench/answer.rs
+++ b/src/bench/answer.rs
@@ -19,15 +19,35 @@ use crate::search;
 
 // ── Public types ─────────────────────────────────────────────────────────
 
+/// Share of [`AnswerOpts::episode_char_budget`] reserved for archive snippets,
+/// as a divisor. Graph episodes are assembled first and would otherwise consume
+/// the whole budget, starving a channel that is far cheaper per character.
+const ARCHIVE_BUDGET_DIVISOR: usize = 4;
+
 /// Options for [`answer_question`].
 ///
-/// Defaults mirror the values documented in the benchmark spec:
-/// graph depth 2, graph result limit 20, archive top-K 5, episodes enabled.
+/// Defaults: graph depth 2, graph result limit 20, episode top-K 20, archive
+/// top-K 5, episodes enabled.
 #[derive(Debug, Clone)]
 pub struct AnswerOpts {
     pub graph_depth: usize,
     pub graph_limit: usize,
+    /// How many episodes to pull from graph episode search. Separate from
+    /// [`Self::archive_top_k`]: the two channels have different cost per item
+    /// and different recall curves, and the episode index measurably loses
+    /// results below k=20 (`ef_search` is derived from k).
+    pub episode_top_k: usize,
+    /// How many archive files the ranked keyword search may contribute.
     pub archive_top_k: usize,
+    /// Character ceiling for the assembled `## Recent episodes` section, so
+    /// raising `episode_top_k` cannot grow the prompt without bound.
+    ///
+    /// A backstop, not the operative limit: the default is sized so both
+    /// channels can deliver their full top-K at worst-case item size (20
+    /// episodes at the 1,000-character ingest cap; 5 archive previews at the
+    /// ~1,100 characters measured on the benchmark corpora). It bites only on
+    /// pathologically large items, so `episode_top_k` stays meaningful.
+    pub episode_char_budget: usize,
     pub include_episodes: bool,
     pub provider_override: Option<Provider>,
     pub model_override: Option<String>,
@@ -41,7 +61,9 @@ impl Default for AnswerOpts {
         Self {
             graph_depth: 2,
             graph_limit: 20,
+            episode_top_k: 20,
             archive_top_k: 5,
+            episode_char_budget: 28_000,
             include_episodes: true,
             provider_override: None,
             model_override: None,
@@ -216,50 +238,92 @@ async fn retrieve_episodes(
     question: &str,
     opts: &AnswerOpts,
 ) -> Result<Vec<RetrievedEpisode>, RecallError> {
-    let mut episodes = Vec::new();
+    let archive_budget = opts.episode_char_budget / ARCHIVE_BUDGET_DIVISOR;
+    let graph_budget = opts.episode_char_budget - archive_budget;
 
-    // Graph episodes via semantic search
-    if opts.include_episodes {
-        let graph_dir = memory_dir.join("graph");
-        if graph_dir.exists() {
-            let gm = GraphMemory::open(&graph_dir).await?;
-            let graph_episodes = gm
-                .search_episodes(question, opts.archive_top_k.max(1))
-                .await?;
-            for ep in graph_episodes {
-                episodes.push(RetrievedEpisode {
-                    source: "graph-episode".to_string(),
-                    abstract_text: ep.episode.abstract_text,
-                    session_id: Some(ep.episode.session_id),
-                    log_number: ep.episode.log_number,
-                    score: ep.score,
-                });
-            }
-        }
-    }
-
-    // Archive-level keyword/recency ranked search
-    let conversations_dir = memory_dir.join("conversations");
-    if conversations_dir.exists() {
-        match search::ranked_search(question, memory_dir, opts.archive_top_k) {
-            Ok(ranked) => {
-                for file in ranked {
-                    let preview = file.preview_lines.join(" / ");
-                    episodes.push(RetrievedEpisode {
-                        source: format!("archive:{}", file.file),
-                        abstract_text: preview,
-                        session_id: None,
-                        log_number: None,
-                        score: file.score,
-                    });
-                }
-            }
-            Err(RecallError::NotInitialized(_)) => {}
-            Err(e) => return Err(e),
-        }
-    }
+    let mut episodes = fit_within_budget(
+        search_graph_episodes(memory_dir, question, opts).await?,
+        graph_budget,
+    );
+    episodes.extend(fit_within_budget(
+        search_archive(memory_dir, question, opts)?,
+        archive_budget,
+    ));
 
     Ok(episodes)
+}
+
+async fn search_graph_episodes(
+    memory_dir: &Path,
+    question: &str,
+    opts: &AnswerOpts,
+) -> Result<Vec<RetrievedEpisode>, RecallError> {
+    let graph_dir = memory_dir.join("graph");
+    if !opts.include_episodes || !graph_dir.exists() {
+        return Ok(Vec::new());
+    }
+
+    let gm = GraphMemory::open(&graph_dir).await?;
+    let found = gm
+        .search_episodes(question, opts.episode_top_k.max(1))
+        .await?;
+
+    Ok(found
+        .into_iter()
+        .map(|ep| RetrievedEpisode {
+            source: "graph-episode".to_string(),
+            abstract_text: ep.episode.abstract_text,
+            session_id: Some(ep.episode.session_id),
+            log_number: ep.episode.log_number,
+            score: ep.score,
+        })
+        .collect())
+}
+
+fn search_archive(
+    memory_dir: &Path,
+    question: &str,
+    opts: &AnswerOpts,
+) -> Result<Vec<RetrievedEpisode>, RecallError> {
+    if !memory_dir.join("conversations").exists() {
+        return Ok(Vec::new());
+    }
+
+    let ranked = match search::ranked_search(question, memory_dir, opts.archive_top_k) {
+        Ok(ranked) => ranked,
+        Err(RecallError::NotInitialized(_)) => return Ok(Vec::new()),
+        Err(e) => return Err(e),
+    };
+
+    Ok(ranked
+        .into_iter()
+        .map(|file| RetrievedEpisode {
+            source: format!("archive:{}", file.file),
+            abstract_text: file.preview_lines.join(" / "),
+            session_id: None,
+            log_number: None,
+            score: file.score,
+        })
+        .collect())
+}
+
+/// Keep the highest-ranked episodes that fit `budget` characters of abstract
+/// text, in order. The first item is always kept — an empty section is worse
+/// than one oversized entry, and per-episode size is bounded at ingest.
+pub(super) fn fit_within_budget(
+    episodes: Vec<RetrievedEpisode>,
+    budget: usize,
+) -> Vec<RetrievedEpisode> {
+    let mut spent = 0usize;
+    episodes
+        .into_iter()
+        .enumerate()
+        .take_while(|(index, ep)| {
+            spent += ep.abstract_text.len();
+            *index == 0 || spent <= budget
+        })
+        .map(|(_, ep)| ep)
+        .collect()
 }
 
 fn read_memory_md(memory_dir: &Path) -> String {

--- a/src/bench/ingest.rs
+++ b/src/bench/ingest.rs
@@ -34,6 +34,13 @@ pub struct IngestStats {
     /// Non-fatal warnings surfaced during extraction (passed through from
     /// `IngestionReport.errors`).
     pub warnings: Vec<String>,
+    /// Entity candidates that cost a dedup model call — the cost term that
+    /// used to grow with the size of the graph.
+    #[serde(default)]
+    pub dedup_llm_calls: usize,
+    /// Entity candidates dedup resolved without a model call.
+    #[serde(default)]
+    pub dedup_fast_path: usize,
 }
 
 /// Ingest a LoCoMo conversation into the entity at `entity_root`.
@@ -86,6 +93,8 @@ pub async fn ingest_conversation(
         stats.episodes += report.episodes_created as usize;
         stats.entities_extracted += report.entities_created as usize;
         stats.relations_extracted += report.relationships_created as usize;
+        stats.dedup_llm_calls += report.dedup_llm_calls as usize;
+        stats.dedup_fast_path += report.dedup_fast_path as usize;
         stats.warnings.extend(report.errors);
     }
 

--- a/src/bench/tests.rs
+++ b/src/bench/tests.rs
@@ -112,6 +112,8 @@ fn ingest_stats_serde_roundtrip() {
         episodes: 7,
         log_numbers: vec![1, 2],
         warnings: vec!["dedup warn".to_string()],
+        dedup_llm_calls: 1,
+        dedup_fast_path: 4,
     };
     let json = serde_json::to_string(&stats).unwrap();
     let back: IngestStats = serde_json::from_str(&json).unwrap();

--- a/src/bench/tests.rs
+++ b/src/bench/tests.rs
@@ -18,8 +18,8 @@ use crate::graph::llm::LlmProvider as GraphLlmProvider;
 
 use super::ingest::{ingest_conversation, IngestStats};
 use super::{
-    answer::{answer_with_provider, AnswerOpts, NO_INFO_ANSWER},
-    BenchConversation, BenchSession, BenchTurn,
+    answer::{answer_with_provider, fit_within_budget, AnswerOpts, NO_INFO_ANSWER},
+    BenchConversation, BenchSession, BenchTurn, RetrievedEpisode,
 };
 
 // ── Test fixtures ────────────────────────────────────────────────────────
@@ -127,6 +127,54 @@ fn answer_opts_defaults_match_spec() {
     assert!(opts.include_episodes);
     assert!(opts.provider_override.is_none());
     assert!(opts.model_override.is_none());
+}
+
+/// Episode retrieval must not inherit the archive limit: the measured episode
+/// index loses results below k=20, and `archive_top_k` was 5.
+#[test]
+fn episode_top_k_is_decoupled_from_archive_top_k() {
+    let opts = AnswerOpts::default();
+    assert_eq!(opts.episode_top_k, 20);
+    assert!(opts.episode_top_k > opts.archive_top_k);
+    assert_eq!(opts.episode_char_budget, 28_000);
+}
+
+/// The budget is a backstop, not a second cutoff: at the ingest-time abstract
+/// cap, a full `episode_top_k` of episodes must still fit in the graph share.
+#[test]
+fn budget_admits_a_full_episode_top_k_at_the_abstract_cap() {
+    let opts = AnswerOpts::default();
+    let graph_share = opts.episode_char_budget - opts.episode_char_budget / 4;
+    assert!(graph_share >= opts.episode_top_k * 1_003);
+}
+
+fn episode_of(abstract_text: &str) -> RetrievedEpisode {
+    RetrievedEpisode {
+        source: "graph-episode".to_string(),
+        abstract_text: abstract_text.to_string(),
+        session_id: None,
+        log_number: None,
+        score: 0.5,
+    }
+}
+
+#[test]
+fn budget_keeps_episodes_until_the_ceiling_is_reached() {
+    let episodes = vec![episode_of(&"a".repeat(40)); 5];
+    let kept = fit_within_budget(episodes, 100);
+    assert_eq!(kept.len(), 2);
+}
+
+#[test]
+fn budget_never_returns_an_empty_section_for_a_non_empty_input() {
+    let kept = fit_within_budget(vec![episode_of(&"a".repeat(500))], 100);
+    assert_eq!(kept.len(), 1);
+}
+
+#[test]
+fn budget_leaves_a_section_under_the_ceiling_untouched() {
+    let episodes = vec![episode_of("short"); 4];
+    assert_eq!(fit_within_budget(episodes, 28_000).len(), 4);
 }
 
 #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -184,6 +184,12 @@ pub struct GraphSection {
     /// [`ProvenanceWeights`] for details.
     #[serde(default)]
     pub provenance: ProvenanceWeights,
+    /// Similarity bands that decide when entity dedup pays for a model call.
+    ///
+    /// Maps to the `[graph.dedup]` section of `.recall-echo.toml`. See
+    /// [`GraphDedupConfig`] for the bands and their defaults.
+    #[serde(default)]
+    pub dedup: GraphDedupConfig,
 }
 
 impl Default for GraphSection {
@@ -197,6 +203,7 @@ impl Default for GraphSection {
             password_file: String::new(),
             scoring: GraphScoringConfig::default(),
             provenance: ProvenanceWeights::default(),
+            dedup: GraphDedupConfig::default(),
         }
     }
 }
@@ -263,6 +270,87 @@ impl Default for GraphScoringConfig {
             weight_utility: 0.25,
         }
     }
+}
+
+/// Similarity bands that decide when entity dedup pays for a model call.
+///
+/// Dedup asks one question — *is this the same thing?* — and that is a
+/// question about meaning, so the bands are cut on raw cosine similarity
+/// between the candidate's abstract and an existing entity's, never on the
+/// retrieval score (which folds in hotness and utility: a popular unrelated
+/// entity would otherwise buy a model call, and every entity gets more
+/// popular as the graph grows).
+///
+/// ```text
+/// similarity >= certain_similarity   → the same entity; resolved locally
+/// review_similarity ..< certain      → ambiguous; one model call decides
+/// similarity <  review_similarity    → new entity; created locally
+/// ```
+///
+/// Defaults (`0.92` / `0.82` / `3`) are cut from the similarity distribution of
+/// a LongMemEval baseline store (192 entities, 150 sampled candidates, 750
+/// neighbour pairs). BGE-Small puts every same-language pair in a narrow high
+/// band — median neighbour 0.75, median *nearest* neighbour 0.81 — so the cuts
+/// sit at its tail, not at intuitive-looking round numbers: 0.92 is the 96th
+/// percentile of pairs, where abstracts are paraphrases of each other, and 0.82
+/// the ~78th, below which pairs are merely same-topic. Candidates averaged 1.1
+/// neighbours above 0.82, so a cap of three bounds the worst case without
+/// binding the normal one.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct GraphDedupConfig {
+    /// At or above this cosine similarity the candidate is treated as the same
+    /// entity and resolved without a model call. Default `0.92`.
+    pub certain_similarity: f64,
+    /// Below this cosine similarity the candidate is treated as new and created
+    /// without a model call. Default `0.82`.
+    pub review_similarity: f64,
+    /// How many existing entities, by similarity rank, dedup may fetch and hand
+    /// to the model. Caps prompt size and comparison count so neither can grow
+    /// with the graph. Default `3`.
+    pub max_candidates: usize,
+}
+
+impl Default for GraphDedupConfig {
+    fn default() -> Self {
+        Self {
+            certain_similarity: 0.92,
+            review_similarity: 0.82,
+            max_candidates: 3,
+        }
+    }
+}
+
+impl GraphDedupConfig {
+    /// The band a candidate's nearest neighbour falls in.
+    #[must_use]
+    pub fn band(&self, similarity: f64) -> DedupBand {
+        if similarity >= self.certain_similarity {
+            DedupBand::SameEntity
+        } else if similarity >= self.review_similarity {
+            DedupBand::Ambiguous
+        } else {
+            DedupBand::NewEntity
+        }
+    }
+
+    /// How many candidates to fetch and consider — at least one, whatever the
+    /// config says, or dedup would be blind.
+    #[must_use]
+    pub fn candidate_limit(&self) -> usize {
+        self.max_candidates.max(1)
+    }
+}
+
+/// Which of the three dedup bands a similarity falls in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DedupBand {
+    /// Certainly the same entity — resolve without a model call.
+    SameEntity,
+    /// Genuinely ambiguous — worth a model call.
+    Ambiguous,
+    /// Certainly not the same entity — create without a model call.
+    NewEntity,
 }
 
 fn default_graph_mode() -> String {
@@ -418,6 +506,26 @@ impl Config {
                 self.graph_section().provenance.weight_self = parse_weight(value)?;
                 Ok(())
             }
+            "graph.dedup.certain_similarity" => {
+                self.graph_section().dedup.certain_similarity = parse_similarity(value)?;
+                Ok(())
+            }
+            "graph.dedup.review_similarity" => {
+                self.graph_section().dedup.review_similarity = parse_similarity(value)?;
+                Ok(())
+            }
+            "graph.dedup.max_candidates" => {
+                let n: usize = value
+                    .parse()
+                    .map_err(|_| RecallError::Config(format!("invalid number: {value}")))?;
+                if n == 0 {
+                    return Err(RecallError::Config(
+                        "max_candidates must be at least 1".into(),
+                    ));
+                }
+                self.graph_section().dedup.max_candidates = n;
+                Ok(())
+            }
             other => Err(RecallError::Config(format!("unknown config key: {other}"))),
         }
     }
@@ -442,6 +550,20 @@ fn parse_weight(value: &str) -> Result<f64, crate::error::RecallError> {
         )));
     }
     Ok(weight)
+}
+
+/// Parse a cosine-similarity threshold: a finite number in `0.0..=1.0`.
+fn parse_similarity(value: &str) -> Result<f64, crate::error::RecallError> {
+    use crate::error::RecallError;
+    let similarity: f64 = value
+        .parse()
+        .map_err(|_| RecallError::Config(format!("invalid number: {value}")))?;
+    if !similarity.is_finite() || !(0.0..=1.0).contains(&similarity) {
+        return Err(RecallError::Config(format!(
+            "similarity threshold must be between 0.0 and 1.0, got {value}"
+        )));
+    }
+    Ok(similarity)
 }
 
 #[cfg(test)]
@@ -715,6 +837,69 @@ mod tests {
             parsed.graph.expect("graph section survives").provenance,
             ProvenanceWeights::default()
         );
+    }
+
+    #[test]
+    fn dedup_defaults_leave_a_gap_between_the_bands() {
+        let dedup = GraphDedupConfig::default();
+        assert!((dedup.certain_similarity - 0.92).abs() < f64::EPSILON);
+        assert!((dedup.review_similarity - 0.82).abs() < f64::EPSILON);
+        assert_eq!(dedup.max_candidates, 3);
+        assert!(dedup.review_similarity < dedup.certain_similarity);
+    }
+
+    #[test]
+    fn dedup_bands_are_cut_at_the_thresholds() {
+        let dedup = GraphDedupConfig::default();
+        assert_eq!(dedup.band(0.99), DedupBand::SameEntity);
+        assert_eq!(dedup.band(0.92), DedupBand::SameEntity);
+        assert_eq!(dedup.band(0.9), DedupBand::Ambiguous);
+        assert_eq!(dedup.band(0.82), DedupBand::Ambiguous);
+        assert_eq!(dedup.band(0.8), DedupBand::NewEntity);
+        assert_eq!(dedup.band(0.0), DedupBand::NewEntity);
+    }
+
+    /// A store configured to fetch nothing would resolve every candidate as
+    /// new; the floor of one keeps dedup able to see.
+    #[test]
+    fn dedup_candidate_limit_never_falls_below_one() {
+        let dedup = GraphDedupConfig {
+            max_candidates: 0,
+            ..GraphDedupConfig::default()
+        };
+        assert_eq!(dedup.candidate_limit(), 1);
+    }
+
+    #[test]
+    fn dedup_partial_toml_fills_defaults() {
+        let cfg: Config = toml::from_str("[graph]\n\n[graph.dedup]\ncertain_similarity = 0.95\n")
+            .expect("parse dedup section");
+        let dedup = cfg.graph.expect("graph section present").dedup;
+        assert!((dedup.certain_similarity - 0.95).abs() < f64::EPSILON);
+        assert!((dedup.review_similarity - 0.82).abs() < f64::EPSILON);
+        assert_eq!(dedup.max_candidates, 3);
+    }
+
+    #[test]
+    fn set_key_dedup_thresholds() {
+        let mut cfg = Config::default();
+        cfg.set_key("graph.dedup.certain_similarity", "0.9")
+            .unwrap();
+        cfg.set_key("graph.dedup.review_similarity", "0.6").unwrap();
+        cfg.set_key("graph.dedup.max_candidates", "5").unwrap();
+
+        let dedup = &cfg.graph.as_ref().expect("graph section created").dedup;
+        assert!((dedup.certain_similarity - 0.9).abs() < f64::EPSILON);
+        assert!((dedup.review_similarity - 0.6).abs() < f64::EPSILON);
+        assert_eq!(dedup.max_candidates, 5);
+
+        assert!(cfg
+            .set_key("graph.dedup.certain_similarity", "1.5")
+            .is_err());
+        assert!(cfg
+            .set_key("graph.dedup.review_similarity", "-0.1")
+            .is_err());
+        assert!(cfg.set_key("graph.dedup.max_candidates", "0").is_err());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -251,6 +251,12 @@ impl Default for ServeSection {
 /// Weights are not constrained to sum to 1.0 — the scoring function does not
 /// normalize. Callers that change these should calibrate against their own
 /// retrieval outcomes; see `utility-feedback-loop-spec.md` in pulse-null.
+///
+/// Graph-expanded candidates score through the same three terms; what differs
+/// is where their `similarity` comes from (a parent's similarity discounted by
+/// the edge's effective confidence, rather than a direct measurement against
+/// the query vector). [`GraphScoringConfig::corroboration_boost`] governs the
+/// one case where the two channels meet.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
 pub struct GraphScoringConfig {
@@ -260,6 +266,33 @@ pub struct GraphScoringConfig {
     pub weight_hotness: f64,
     /// Weight applied to the utility score (outcome-feedback EMA). Default `0.25`.
     pub weight_utility: f64,
+    /// How much an entity's measured relevance is raised when the graph
+    /// corroborates a semantic hit — i.e. when the same entity is reached both
+    /// by the query vector and over a surviving edge from one of the expanded
+    /// top hits. Default `0.05`.
+    ///
+    /// ```text
+    /// similarity = min(1.0, similarity * (1 + corroboration_boost * effective_confidence))
+    /// ```
+    ///
+    /// Scaled by the edge's effective (decayed) confidence, so a stale edge
+    /// corroborates weakly, and clamped at the similarity ceiling of `1.0`, so
+    /// no amount of corroboration can push an entity past what a perfect
+    /// direct match would score on the same hotness and utility. `0.0`
+    /// disables corroboration entirely.
+    ///
+    /// The default is cut to the *scale* of the similarity distribution it
+    /// perturbs, measured over four LongMemEval stores (196–1804 entities):
+    /// the top-20 similarity band there is only `0.086` wide, so a boost of
+    /// `0.134` would let corroboration promote an entity from the bottom of
+    /// the band to the top, and structure would outrank similarity outright.
+    /// `0.05` moves a corroborated entity about a third of the band — enough
+    /// to break the near-ties that dominate a dense embedding space (the
+    /// rank-1-to-rank-2 gap in those stores is `0.005`–`0.051`), and not
+    /// enough to overturn a decided ordering. Raise it only with retrieval
+    /// numbers in hand: corroboration amplifies whatever the extractor put in
+    /// the graph, including its mistakes.
+    pub corroboration_boost: f64,
 }
 
 impl Default for GraphScoringConfig {
@@ -268,6 +301,7 @@ impl Default for GraphScoringConfig {
             weight_semantic: 0.45,
             weight_hotness: 0.30,
             weight_utility: 0.25,
+            corroboration_boost: 0.05,
         }
     }
 }
@@ -766,6 +800,7 @@ mod tests {
         assert!((scoring.weight_semantic - 0.45).abs() < f64::EPSILON);
         assert!((scoring.weight_hotness - 0.30).abs() < f64::EPSILON);
         assert!((scoring.weight_utility - 0.25).abs() < f64::EPSILON);
+        assert!((scoring.corroboration_boost - 0.05).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -775,6 +810,15 @@ mod tests {
         assert!((scoring.weight_semantic - 0.45).abs() < f64::EPSILON);
         assert!((scoring.weight_hotness - 0.30).abs() < f64::EPSILON);
         assert!((scoring.weight_utility - 0.5).abs() < f64::EPSILON);
+        assert!((scoring.corroboration_boost - 0.05).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn graph_scoring_corroboration_boost_is_configurable() {
+        let scoring: GraphScoringConfig =
+            toml::from_str("corroboration_boost = 0.0\n").expect("parse corroboration boost");
+        assert!(scoring.corroboration_boost.abs() < f64::EPSILON);
+        assert!((scoring.weight_semantic - 0.45).abs() < f64::EPSILON);
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,15 @@ const DEFAULT_MAX_ENTRIES: usize = 5;
 const DEFAULT_IDLE_TIMEOUT_SECS: u64 = 3600;
 const CONFIG_FILE: &str = ".recall-echo.toml";
 
+/// Seconds of quiet before the daemon starts extracting in the background.
+///
+/// Two minutes: long enough that a session's burst of hooks and queries is
+/// over, short enough that a conversation archived at the end of a working day
+/// has become entities before the next one starts.
+const DEFAULT_EXTRACTION_IDLE_AFTER_SECS: u64 = 120;
+/// Archives one background batch extracts before yielding.
+const DEFAULT_EXTRACTION_BATCH_SIZE: usize = 3;
+
 // ── Provider enum ────────────────────────────────────────────────────────
 
 /// LLM provider for entity extraction.
@@ -78,6 +87,8 @@ pub struct Config {
     pub graph: Option<GraphSection>,
     #[serde(default)]
     pub serve: ServeSection,
+    #[serde(default)]
+    pub extraction: ExtractionSection,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -230,6 +241,62 @@ impl Default for ServeSection {
             socket_path: None,
             idle_timeout_secs: DEFAULT_IDLE_TIMEOUT_SECS,
         }
+    }
+}
+
+/// Background entity extraction inside the graph daemon (`[extraction]`).
+///
+/// Episodes arrive mechanically on `SessionEnd`; turning them into entities,
+/// relationships and confidence used to require a human to run
+/// `recall-echo graph extract`. The daemon already owns the store and knows
+/// when it is unused, so it does that pass itself once the machine is quiet.
+///
+/// Defaults are on, because the alternative is a knowledge graph that stays
+/// empty for everyone who did not read the docs closely. What it costs is
+/// bounded by the provider: the daemon is started with a minimal environment
+/// that deliberately excludes API keys (see `serve_client`), so an
+/// auto-started daemon can only ever use the `claude-code` provider, which
+/// bills nothing on a subscription. An API-key provider reaches the daemon
+/// only when a human runs `recall-echo serve --foreground` with the key
+/// exported — an explicit act. Set `background_enabled = false` to turn the
+/// pass off entirely.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ExtractionSection {
+    /// Run entity extraction in the daemon when the machine is quiet.
+    /// Default `true`.
+    pub background_enabled: bool,
+    /// Seconds without a client request before a background batch may start.
+    /// `0` means "as soon as no connection is open". Default `120`.
+    pub idle_after_secs: u64,
+    /// Archives one batch extracts before going back to waiting. Bounds how
+    /// long a burst of background work lasts and how much it can cost in one
+    /// go; the next batch starts one quiet period later. Default `3`.
+    pub batch_size: usize,
+}
+
+impl Default for ExtractionSection {
+    fn default() -> Self {
+        Self {
+            background_enabled: true,
+            idle_after_secs: DEFAULT_EXTRACTION_IDLE_AFTER_SECS,
+            batch_size: DEFAULT_EXTRACTION_BATCH_SIZE,
+        }
+    }
+}
+
+impl ExtractionSection {
+    /// Quiet period before a batch may start.
+    #[must_use]
+    pub fn idle_after(&self) -> std::time::Duration {
+        std::time::Duration::from_secs(self.idle_after_secs)
+    }
+
+    /// Archives per batch — at least one, whatever the config says, or the
+    /// worker would wake up only to do nothing.
+    #[must_use]
+    pub fn effective_batch_size(&self) -> usize {
+        self.batch_size.max(1)
     }
 }
 
@@ -528,6 +595,28 @@ impl Config {
                 };
                 Ok(())
             }
+            "extraction.background_enabled" => {
+                self.extraction.background_enabled = value
+                    .parse()
+                    .map_err(|_| RecallError::Config(format!("invalid boolean: {value}")))?;
+                Ok(())
+            }
+            "extraction.idle_after_secs" => {
+                self.extraction.idle_after_secs = value
+                    .parse()
+                    .map_err(|_| RecallError::Config(format!("invalid number: {value}")))?;
+                Ok(())
+            }
+            "extraction.batch_size" => {
+                let size: usize = value
+                    .parse()
+                    .map_err(|_| RecallError::Config(format!("invalid number: {value}")))?;
+                if size == 0 {
+                    return Err(RecallError::Config("batch_size must be at least 1".into()));
+                }
+                self.extraction.batch_size = size;
+                Ok(())
+            }
             "graph.provenance.weight_external" => {
                 self.graph_section().provenance.weight_external = parse_weight(value)?;
                 Ok(())
@@ -709,6 +798,7 @@ mod tests {
             pipeline: None,
             graph: None,
             serve: ServeSection::default(),
+            extraction: ExtractionSection::default(),
         };
         let s = toml::to_string_pretty(&cfg).unwrap();
         let parsed: Config = toml::from_str(&s).unwrap();
@@ -768,6 +858,7 @@ mod tests {
             pipeline: None,
             graph: None,
             serve: ServeSection::default(),
+            extraction: ExtractionSection::default(),
         };
         save(tmp.path(), &cfg).unwrap();
         let loaded = load(tmp.path());
@@ -790,6 +881,7 @@ mod tests {
             pipeline: None,
             graph: None,
             serve: ServeSection::default(),
+            extraction: ExtractionSection::default(),
         });
         assert_eq!(cfg.ephemeral.max_entries, 5);
     }

--- a/src/graph/dedup.rs
+++ b/src/graph/dedup.rs
@@ -1,4 +1,10 @@
-//! LLM-powered entity deduplication — skip, create, or merge decisions.
+//! Entity deduplication — skip, create, or merge decisions.
+//!
+//! Most candidates are decided locally: an existing entity with the same name
+//! and type is the same entity, a nearest neighbour far below the review
+//! threshold is a new one. Only the band in between is worth a model call, and
+//! only a bounded number of neighbours are ever shown to it — see
+//! [`crate::config::GraphDedupConfig`].
 
 use std::fmt::Write as _;
 
@@ -6,6 +12,7 @@ use super::error::GraphError;
 use super::llm::LlmProvider;
 use super::types::*;
 use super::GraphMemory;
+use crate::config::DedupBand;
 
 const DEDUP_SYSTEM_PROMPT: &str = r#"You are a deduplication system for a knowledge graph. Given a candidate entity and existing similar entities, decide:
 
@@ -35,66 +42,200 @@ pub enum ResolvedEntity {
     Skipped,
 }
 
-/// Run the full dedup pipeline for one extracted entity.
+/// Which gate decided a candidate — the cost record of one resolution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolutionPath {
+    /// An existing entity carried the same name and type.
+    NameMatch,
+    /// The nearest neighbour was similar enough to be the same entity.
+    SameEntityBand,
+    /// No neighbour was similar enough to be worth comparing.
+    NewEntityBand,
+    /// The ambiguous band — a model call decided it.
+    LlmDecision,
+}
+
+impl ResolutionPath {
+    /// Whether this resolution paid for a model call.
+    #[must_use]
+    pub fn used_llm(self) -> bool {
+        matches!(self, Self::LlmDecision)
+    }
+}
+
+/// What dedup did with a candidate, and what it cost.
+pub struct Resolution {
+    pub entity: ResolvedEntity,
+    pub path: ResolutionPath,
+}
+
+impl Resolution {
+    fn new(entity: ResolvedEntity, path: ResolutionPath) -> Self {
+        Self { entity, path }
+    }
+}
+
+/// Run the dedup pipeline for one extracted entity.
 ///
-/// 1. Vector search for similar entities
-/// 2. If none similar: CREATE directly
-/// 3. If similar found: ask LLM for skip/create/merge decision
-/// 4. For merge on immutable types: fall back to CREATE
+/// Three bands of raw cosine similarity, only one of which costs a model call:
+///
+/// 1. An existing entity of the same name and type — the same entity, resolved
+///    on an index lookup alone.
+/// 2. Nearest neighbour at or above `certain_similarity` — the same entity.
+/// 3. Nearest neighbour below `review_similarity` — a new entity, CREATEd.
+/// 4. Anything left is genuinely ambiguous: the model sees at most
+///    `max_candidates` neighbours and returns skip / create / merge.
+///
+/// Merging into an immutable type falls back to CREATE on every path.
 pub async fn resolve_entity(
     gm: &GraphMemory,
     llm: &dyn LlmProvider,
     candidate: &ExtractedEntity,
     session_id: &str,
-) -> Result<ResolvedEntity, GraphError> {
-    // Search for similar entities
-    let similar = gm.search(&candidate.abstract_text, 5).await?;
+) -> Result<Resolution, GraphError> {
+    let config = gm.dedup_config();
 
-    // Filter to meaningful similarity (> 0.7 blended score)
-    let relevant: Vec<_> = similar.iter().filter(|r| r.score > 0.7).collect();
-
-    if relevant.is_empty() {
-        // No similar entities — create directly
-        let entity = gm.add_entity(candidate.to_new_entity(session_id)).await?;
-        return Ok(ResolvedEntity::Created(entity));
+    if let Some(existing) = same_named_entity(gm, candidate).await? {
+        let resolved = absorb(gm, &existing, candidate, session_id).await?;
+        return Ok(Resolution::new(resolved, ResolutionPath::NameMatch));
     }
 
-    // Ask LLM for dedup decision
-    let user_message = build_dedup_message(candidate, &relevant);
+    // Ordered by distance ascending — nearest first. The limit is the cap:
+    // neither the prompt nor the comparison count can grow with the store.
+    let nearest = gm
+        .search(&candidate.abstract_text, config.candidate_limit())
+        .await?;
+
+    let Some(closest) = nearest.first() else {
+        return Ok(Resolution::new(
+            create(gm, candidate, session_id).await?,
+            ResolutionPath::NewEntityBand,
+        ));
+    };
+
+    match config.band(closest.similarity()) {
+        // Same meaning and same kind of thing: nothing for a model to weigh.
+        DedupBand::SameEntity if closest.entity.entity_type == candidate.entity_type => {
+            let resolved = absorb(gm, &closest.entity, candidate, session_id).await?;
+            Ok(Resolution::new(resolved, ResolutionPath::SameEntityBand))
+        }
+        DedupBand::NewEntity => Ok(Resolution::new(
+            create(gm, candidate, session_id).await?,
+            ResolutionPath::NewEntityBand,
+        )),
+        // Ambiguous, or near-identical text under a different type — the one
+        // case worth paying for.
+        _ => {
+            let resolved = resolve_with_llm(gm, llm, candidate, session_id, &nearest).await?;
+            Ok(Resolution::new(resolved, ResolutionPath::LlmDecision))
+        }
+    }
+}
+
+/// Ask the model to decide between the candidate and its comparable neighbours.
+async fn resolve_with_llm(
+    gm: &GraphMemory,
+    llm: &dyn LlmProvider,
+    candidate: &ExtractedEntity,
+    session_id: &str,
+    nearest: &[SearchResult],
+) -> Result<ResolvedEntity, GraphError> {
+    let config = gm.dedup_config();
+    let comparable: Vec<&SearchResult> = nearest
+        .iter()
+        .filter(|r| config.band(r.similarity()) != DedupBand::NewEntity)
+        .collect();
+
+    let user_message = build_dedup_message(candidate, &comparable);
     let response = llm
         .complete(DEDUP_SYSTEM_PROMPT, &user_message, 300)
         .await?;
 
-    let decision = parse_dedup_response(&response)?;
-
-    match decision {
+    match parse_dedup_response(&response)? {
         DedupDecision::Skip => Ok(ResolvedEntity::Skipped),
 
-        DedupDecision::Create => {
-            let entity = gm.add_entity(candidate.to_new_entity(session_id)).await?;
-            Ok(ResolvedEntity::Created(entity))
-        }
+        DedupDecision::Create => create(gm, candidate, session_id).await,
 
-        DedupDecision::Merge { target } => {
-            // Find the target entity
-            let target_entity = gm.get_entity(&target).await?;
-            let Some(target_entity) = target_entity else {
-                // Target not found — fall back to create
-                let entity = gm.add_entity(candidate.to_new_entity(session_id)).await?;
-                return Ok(ResolvedEntity::Created(entity));
-            };
-
-            // Check mutability
-            if !target_entity.mutable {
-                // Immutable — can't merge, create instead
-                let entity = gm.add_entity(candidate.to_new_entity(session_id)).await?;
-                return Ok(ResolvedEntity::Created(entity));
-            }
-
-            let merged = merge_entity(gm, &target_entity, candidate).await?;
-            Ok(ResolvedEntity::Merged(merged))
-        }
+        DedupDecision::Merge { target } => match gm.get_entity(&target).await? {
+            Some(target_entity) => absorb(gm, &target_entity, candidate, session_id).await,
+            // Hallucinated target — create rather than lose the candidate.
+            None => create(gm, candidate, session_id).await,
+        },
     }
+}
+
+/// An existing entity with the same name and type as the candidate.
+///
+/// Exact match on the indexed `name` field: an index lookup, not a scan, so it
+/// stays flat as the store grows. Case and spacing variants ("ElevenLabs" /
+/// "Eleven Labs") are left to the similarity bands — SurrealDB has no
+/// case-insensitive index here, and normalising in the query would turn every
+/// dedup into a full table scan. A same-name entity of a *different* type is
+/// not the same thing (the event "Release" is not the project "Release"), so it
+/// falls through to the bands too.
+async fn same_named_entity(
+    gm: &GraphMemory,
+    candidate: &ExtractedEntity,
+) -> Result<Option<Entity>, GraphError> {
+    let Some(existing) = gm.get_entity(candidate.name.trim()).await? else {
+        return Ok(None);
+    };
+    Ok((existing.entity_type == candidate.entity_type).then_some(existing))
+}
+
+/// Fold a candidate into an entity already known to be the same thing.
+///
+/// Immutable types cannot absorb — a decision or an event records one moment —
+/// so the candidate becomes its own entity, exactly as a model-issued merge
+/// onto an immutable target already did. A candidate that carries nothing new
+/// is skipped rather than appended: re-reading the same archive must not grow
+/// the entity it describes.
+async fn absorb(
+    gm: &GraphMemory,
+    target: &Entity,
+    candidate: &ExtractedEntity,
+    session_id: &str,
+) -> Result<ResolvedEntity, GraphError> {
+    if !target.mutable {
+        return create(gm, candidate, session_id).await;
+    }
+    if !adds_information(target, candidate) {
+        return Ok(ResolvedEntity::Skipped);
+    }
+    Ok(ResolvedEntity::Merged(
+        merge_entity(gm, target, candidate).await?,
+    ))
+}
+
+/// Whether the candidate carries anything the target does not already hold —
+/// the deterministic half of the prompt's "candidate is less detailed: skip".
+fn adds_information(target: &Entity, candidate: &ExtractedEntity) -> bool {
+    let longer_abstract = candidate.abstract_text.len() > target.abstract_text.len();
+    let new_overview = candidate
+        .overview
+        .as_ref()
+        .is_some_and(|overview| !target.overview.contains(overview.as_str()));
+    let new_content = candidate.content.as_ref().is_some_and(|content| {
+        target
+            .content
+            .as_ref()
+            .is_none_or(|held| !held.contains(content.as_str()))
+    });
+    let new_attributes = candidate
+        .attributes
+        .as_ref()
+        .is_some_and(|attrs| target.attributes.as_ref() != Some(attrs));
+
+    longer_abstract || new_overview || new_content || new_attributes
+}
+
+async fn create(
+    gm: &GraphMemory,
+    candidate: &ExtractedEntity,
+    session_id: &str,
+) -> Result<ResolvedEntity, GraphError> {
+    let entity = gm.add_entity(candidate.to_new_entity(session_id)).await?;
+    Ok(ResolvedEntity::Created(entity))
 }
 
 /// Merge candidate data into an existing entity.
@@ -152,12 +293,14 @@ fn build_dedup_message(candidate: &ExtractedEntity, similar: &[&SearchResult]) -
         candidate.name, candidate.entity_type, candidate.abstract_text
     );
     for (i, r) in similar.iter().enumerate() {
+        // Similarity, not the blended retrieval score: how popular an entity is
+        // says nothing about whether it is this one.
         let _ = write!(
             msg,
-            "\n{}. Name: {} (score: {:.3})\n   Type: {}\n   Abstract: {}\n",
+            "\n{}. Name: {} (similarity: {:.3})\n   Type: {}\n   Abstract: {}\n",
             i + 1,
             r.entity.name,
-            r.score,
+            r.similarity(),
             r.entity.entity_type,
             r.entity.abstract_text
         );
@@ -243,6 +386,92 @@ mod tests {
         let json = "```json\n{\"decision\": \"skip\", \"reason\": \"dup\"}\n```";
         let decision = parse_dedup_response(json).unwrap();
         assert_eq!(decision, DedupDecision::Skip);
+    }
+
+    fn stored(abstract_text: &str, overview: &str, content: Option<&str>) -> Entity {
+        Entity {
+            id: serde_json::json!("entity:one"),
+            name: "Biscuit".into(),
+            entity_type: EntityType::Person,
+            abstract_text: abstract_text.into(),
+            overview: overview.into(),
+            content: content.map(String::from),
+            attributes: None,
+            embedding: None,
+            mutable: true,
+            access_count: 0,
+            utility_score: 0.5,
+            utility_updates: 0,
+            created_at: serde_json::json!("2026-01-01T00:00:00Z"),
+            updated_at: serde_json::json!("2026-01-01T00:00:00Z"),
+            source: None,
+        }
+    }
+
+    fn extracted(abstract_text: &str, overview: Option<&str>) -> ExtractedEntity {
+        ExtractedEntity {
+            name: "Biscuit".into(),
+            entity_type: EntityType::Person,
+            abstract_text: abstract_text.into(),
+            overview: overview.map(String::from),
+            content: None,
+            attributes: None,
+        }
+    }
+
+    /// Re-reading the same archive must not append the same text again.
+    #[test]
+    fn a_candidate_repeating_what_is_stored_adds_nothing() {
+        let target = stored("A golden retriever", "Adopted in May 2023", None);
+        let candidate = extracted("A golden retriever", Some("Adopted in May 2023"));
+        assert!(!adds_information(&target, &candidate));
+    }
+
+    #[test]
+    fn a_longer_abstract_is_information() {
+        let target = stored("A dog", "", None);
+        let candidate = extracted("A golden retriever named Biscuit", None);
+        assert!(adds_information(&target, &candidate));
+    }
+
+    #[test]
+    fn an_unseen_overview_is_information() {
+        let target = stored("A golden retriever", "Adopted in May 2023", None);
+        let candidate = extracted("A golden retriever", Some("Finished puppy class"));
+        assert!(adds_information(&target, &candidate));
+    }
+
+    #[test]
+    fn content_the_target_already_holds_is_not_information() {
+        let target = stored("A golden retriever", "", Some("Session 1\n\nSession 2"));
+        let mut candidate = extracted("A golden retriever", None);
+        candidate.content = Some("Session 2".into());
+        assert!(!adds_information(&target, &candidate));
+
+        candidate.content = Some("Session 3".into());
+        assert!(adds_information(&target, &candidate));
+    }
+
+    #[test]
+    fn only_the_llm_path_counts_as_a_model_call() {
+        assert!(ResolutionPath::LlmDecision.used_llm());
+        assert!(!ResolutionPath::NameMatch.used_llm());
+        assert!(!ResolutionPath::SameEntityBand.used_llm());
+        assert!(!ResolutionPath::NewEntityBand.used_llm());
+    }
+
+    /// The model must weigh meaning, not popularity: the prompt carries raw
+    /// similarity so a hot entity does not read as a likelier duplicate.
+    #[test]
+    fn the_dedup_prompt_shows_similarity_not_the_blended_score() {
+        let result = SearchResult {
+            entity: stored("A golden retriever", "", None),
+            score: 0.71,
+            distance: 0.2,
+        };
+        let msg = build_dedup_message(&extracted("A dog", None), &[&result]);
+        assert!(msg.contains("similarity: 0.800"), "{msg}");
+        assert!(!msg.contains("0.710"), "{msg}");
     }
 
     #[test]

--- a/src/graph/ingest.rs
+++ b/src/graph/ingest.rs
@@ -6,7 +6,7 @@ use futures::stream::{self, StreamExt};
 
 use super::confidence::{ExtractionContext, Provenance};
 use super::crud;
-use super::dedup::{self, ResolvedEntity};
+use super::dedup::{self, Resolution, ResolvedEntity};
 use super::error::GraphError;
 use super::extract;
 use super::llm::LlmProvider;
@@ -278,23 +278,8 @@ async fn process_extraction(
     let mut name_map: HashMap<String, String> = HashMap::new();
 
     for candidate in &deduplicated {
-        // Estimate ~600 tokens per dedup call (vector search + LLM decision)
-        report.estimated_tokens += 600;
         match dedup::resolve_entity(gm, llm, candidate, session_id).await {
-            Ok(ResolvedEntity::Created(entity)) => {
-                name_map.insert(candidate.name.clone(), entity.name.clone());
-                report.entity_ids.push(entity.id_string());
-                report.entities_created += 1;
-            }
-            Ok(ResolvedEntity::Merged(entity)) => {
-                name_map.insert(candidate.name.clone(), entity.name.clone());
-                report.entity_ids.push(entity.id_string());
-                report.entities_merged += 1;
-            }
-            Ok(ResolvedEntity::Skipped) => {
-                name_map.insert(candidate.name.clone(), candidate.name.clone());
-                report.entities_skipped += 1;
-            }
+            Ok(resolution) => record_resolution(report, &mut name_map, candidate, resolution),
             Err(e) => {
                 report
                     .errors
@@ -365,6 +350,41 @@ async fn process_extraction(
     }
 
     Ok(())
+}
+
+/// Fold one dedup resolution into the run's report: what it decided, and what
+/// deciding it cost.
+fn record_resolution(
+    report: &mut IngestionReport,
+    name_map: &mut HashMap<String, String>,
+    candidate: &ExtractedEntity,
+    resolution: Resolution,
+) {
+    if resolution.path.used_llm() {
+        // Estimate ~600 tokens per dedup call (prompt + decision). The fast
+        // paths make no call, so they add nothing to the bill.
+        report.dedup_llm_calls += 1;
+        report.estimated_tokens += 600;
+    } else {
+        report.dedup_fast_path += 1;
+    }
+
+    match resolution.entity {
+        ResolvedEntity::Created(entity) => {
+            name_map.insert(candidate.name.clone(), entity.name.clone());
+            report.entity_ids.push(entity.id_string());
+            report.entities_created += 1;
+        }
+        ResolvedEntity::Merged(entity) => {
+            name_map.insert(candidate.name.clone(), entity.name.clone());
+            report.entity_ids.push(entity.id_string());
+            report.entities_merged += 1;
+        }
+        ResolvedEntity::Skipped => {
+            name_map.insert(candidate.name.clone(), candidate.name.clone());
+            report.entities_skipped += 1;
+        }
+    }
 }
 
 /// Merge extracted entities that share the same name (case-insensitive).

--- a/src/graph/ingest.rs
+++ b/src/graph/ingest.rs
@@ -419,14 +419,55 @@ fn local_merge_entities(entities: Vec<ExtractedEntity>) -> Vec<ExtractedEntity> 
 
 use super::util::merge_json_objects as merge_json;
 
-/// Build a short abstract for an episode chunk.
+/// Maximum length of an episode abstract, in characters.
+///
+/// The abstract is not a label: it is the text that gets embedded, the text
+/// episode search returns, and the text that reaches an answer prompt. The
+/// previous 200 severed facts mid-word and used a tenth of BGE-Small's 512-token
+/// window. 1,000 characters is half the 500-token ingest chunk — still a
+/// summary rather than a copy of the chunk — and about 250 tokens, so the whole
+/// abstract is inside the embedding window instead of being truncated by it.
+const EPISODE_ABSTRACT_MAX_CHARS: usize = 1_000;
+
+/// A boundary earlier than this share of the window discards more text than the
+/// tidiness is worth; fall back to a coarser boundary instead.
+const MIN_BOUNDARY_FRACTION: f64 = 0.6;
+
+/// Build a short abstract for an episode chunk, cut at a sentence or word
+/// boundary so a fact is never severed mid-word.
 fn build_episode_abstract(chunk: &str) -> String {
-    let chars: String = chunk.chars().take(200).collect();
-    if chars.len() < chunk.len() {
-        format!("{}...", chars.trim())
-    } else {
-        chars.trim().to_string()
+    let trimmed = chunk.trim();
+    if trimmed.chars().count() <= EPISODE_ABSTRACT_MAX_CHARS {
+        return trimmed.to_string();
     }
+
+    let window: String = trimmed.chars().take(EPISODE_ABSTRACT_MAX_CHARS).collect();
+    let cut = truncation_point(&window);
+    format!("{}...", window[..cut].trim_end())
+}
+
+/// Byte offset to cut `window` at: just past the last sentence terminator if
+/// one falls late enough to keep most of the window, else the last word
+/// boundary, else the whole window.
+fn truncation_point(window: &str) -> usize {
+    let floor = (window.len() as f64 * MIN_BOUNDARY_FRACTION) as usize;
+
+    let after_sentence = window
+        .char_indices()
+        .rev()
+        .find(|(_, c)| matches!(c, '.' | '!' | '?' | '\n'))
+        .map(|(i, c)| i + c.len_utf8());
+    if let Some(cut) = after_sentence.filter(|&cut| cut >= floor) {
+        return cut;
+    }
+
+    window
+        .char_indices()
+        .rev()
+        .find(|(_, c)| c.is_whitespace())
+        .map(|(i, _)| i)
+        .filter(|&cut| cut >= floor)
+        .unwrap_or(window.len())
 }
 
 /// Find an existing relationship of the same type between two entities.
@@ -460,10 +501,10 @@ mod tests {
     use super::*;
 
     #[test]
-    fn episode_abstract_truncates() {
-        let long = "x".repeat(500);
+    fn episode_abstract_truncates_at_the_cap() {
+        let long = "x".repeat(EPISODE_ABSTRACT_MAX_CHARS * 2);
         let abs = build_episode_abstract(&long);
-        assert!(abs.len() < 210);
+        assert!(abs.chars().count() <= EPISODE_ABSTRACT_MAX_CHARS + 3);
         assert!(abs.ends_with("..."));
     }
 
@@ -472,6 +513,44 @@ mod tests {
         let short = "Hello world";
         let abs = build_episode_abstract(short);
         assert_eq!(abs, "Hello world");
+    }
+
+    /// A chunk that would have been cut at 200 characters now survives whole.
+    #[test]
+    fn episode_abstract_keeps_text_the_old_cap_would_have_cut() {
+        let chunk = format!(
+            "{} Currently, my favourite is Kansas City Masterpiece.",
+            "Padding sentence about barbecue. ".repeat(8)
+        );
+        assert!(chunk.chars().count() > 200);
+        let abs = build_episode_abstract(&chunk);
+        assert!(abs.contains("Kansas City Masterpiece"));
+    }
+
+    /// The defect this pins: the old cap severed `Kansas City Masterpiece`
+    /// after `Ka`. Cuts must land on a sentence boundary when one is available.
+    #[test]
+    fn episode_abstract_cuts_at_a_sentence_boundary() {
+        let chunk = format!(
+            "{}My favourite is Kansas City Masterpiece and nothing else comes close at all",
+            "The barbecue discussion continued at length. ".repeat(22)
+        );
+        let abs = build_episode_abstract(&chunk);
+        assert!(abs.ends_with("at length...."), "unexpected tail: {abs:?}");
+        assert!(!abs.contains("Kansas"));
+    }
+
+    /// With no sentence terminator in reach, the cut still lands between words.
+    #[test]
+    fn episode_abstract_never_cuts_mid_word() {
+        let chunk = "barbecue ".repeat(300);
+        let abs = build_episode_abstract(&chunk);
+        let body = abs.strip_suffix("...").expect("truncated");
+        assert!(
+            body.ends_with("barbecue"),
+            "cut landed mid-word: {:?}",
+            &body[body.len().saturating_sub(20)..]
+        );
     }
 
     #[test]

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -65,6 +65,7 @@ pub struct GraphMemory {
     path: PathBuf,
     scoring: crate::config::GraphScoringConfig,
     provenance: confidence::ProvenanceWeights,
+    dedup: crate::config::GraphDedupConfig,
 }
 
 impl GraphMemory {
@@ -115,6 +116,7 @@ impl GraphMemory {
             path: path.to_path_buf(),
             scoring: graph_config.scoring,
             provenance: graph_config.provenance,
+            dedup: graph_config.dedup,
         })
     }
 
@@ -151,6 +153,7 @@ impl GraphMemory {
 
         let scoring = graph_section.scoring.clone();
         let provenance = graph_section.provenance;
+        let dedup = graph_section.dedup.clone();
         let server_config = store::ServerConfig {
             url: graph_section.url,
             username: graph_section.username,
@@ -163,6 +166,7 @@ impl GraphMemory {
         let mut gm = Self::connect(&server_config, &models_dir).await?;
         gm.scoring = scoring;
         gm.provenance = provenance;
+        gm.dedup = dedup;
         Ok(gm)
     }
 
@@ -189,6 +193,7 @@ impl GraphMemory {
             path: models_dir.to_path_buf(),
             scoring: crate::config::GraphScoringConfig::default(),
             provenance: confidence::ProvenanceWeights::default(),
+            dedup: crate::config::GraphDedupConfig::default(),
         })
     }
 
@@ -202,6 +207,13 @@ impl GraphMemory {
     #[must_use]
     pub fn provenance_weights(&self) -> &confidence::ProvenanceWeights {
         &self.provenance
+    }
+
+    /// Similarity bands this store applies when deduplicating entities
+    /// (`[graph.dedup]`) — which candidates are worth a model call.
+    #[must_use]
+    pub fn dedup_config(&self) -> &crate::config::GraphDedupConfig {
+        &self.dedup
     }
 
     /// Internal access to the database handle.

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -2,9 +2,51 @@
 //!
 //! Pipeline:
 //! 1. **Semantic phase**: HNSW KNN with `limit * 2` to gather candidates
-//! 2. **Graph phase**: 1-hop expansion from top-N results, scored as `parent_score * 0.5`
-//! 3. **Merge + deduplicate** by entity ID, keeping highest score
+//! 2. **Graph phase**: 1-hop expansion from the top 3 candidates
+//! 3. **Merge** by entity ID — corroborating an existing candidate or adding a
+//!    new one
 //! 4. **Episode search** (optional) — separate KNN on episodes
+//!
+//! # Scoring
+//!
+//! Both channels score through [`super::search::score_with_utility`]:
+//!
+//! ```text
+//! score = w_semantic * similarity + w_hotness * hotness + w_utility * utility
+//! ```
+//!
+//! The channel decides only where `similarity` comes from. A semantic
+//! candidate measures it against the query vector; a graph candidate
+//! *propagates* it — the parent's similarity discounted by the edge's
+//! effective (decayed) confidence:
+//!
+//! ```text
+//! similarity_graph = similarity_parent * effective_confidence
+//! ```
+//!
+//! Hotness and utility are read off the neighbor itself, exactly as they are
+//! for a semantic hit. Confidence therefore still orders neighbors — a decayed
+//! edge ranks below a fresh one — without a graph candidate having to overcome
+//! a base every semantic candidate gets for free.
+//!
+//! When an entity arrives on **both** channels the graph corroborates the
+//! query, and its measured relevance is raised — bounded, and proportional to
+//! how much the edge is believed:
+//!
+//! ```text
+//! similarity = min(1.0, similarity_semantic
+//!                       * (1 + corroboration_boost * effective_confidence))
+//! ```
+//!
+//! The measurement stays the base: a direct reading of this entity against
+//! this query outranks an estimate propagated from a neighbor, so
+//! corroboration adds to it rather than replacing it. Two clamps keep it from
+//! running away — the similarity ceiling of `1.0`, and a boost default cut to
+//! the width of the similarity band it perturbs (see
+//! [`GraphScoringConfig::corroboration_boost`]). An entity reachable from
+//! several expanded parents is credited once, over its strongest path: the
+//! parents are the top hits of a single query and are not independent
+//! witnesses. Self-edges corroborate nothing and are skipped.
 
 use std::collections::HashMap;
 
@@ -13,6 +55,7 @@ use surrealdb::Surreal;
 use super::confidence;
 use super::embed::Embedder;
 use super::error::GraphError;
+use super::search::{compute_hotness, score_with_utility};
 use super::store::Db;
 use super::types::*;
 use crate::config::GraphScoringConfig;
@@ -47,53 +90,11 @@ pub async fn query(
         entity_map.insert(result.entity.id_string(), result);
     }
 
-    // Phase 2: Graph expansion — 1-hop from top-N semantic results
+    // Phase 2: Graph expansion — 1-hop from the top semantic results
     if options.graph_depth > 0 {
-        let top_n: Vec<(String, f64)> = {
-            let mut entries: Vec<_> = entity_map
-                .values()
-                .map(|e| (e.entity.id_string(), e.score))
-                .collect();
-            entries.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
-            entries.truncate(3); // Expand from top 3
-            entries
-        };
-
-        for (parent_id, parent_score) in &top_n {
-            let parent_name = entity_map
-                .get(parent_id)
-                .map(|e| e.entity.name.clone())
-                .unwrap_or_default();
-
-            let neighbors = get_neighbor_details(db, parent_id).await?;
-
-            for (neighbor, rel_type, confidence) in neighbors {
-                let neighbor_id = neighbor.id_string();
-                if entity_map.contains_key(&neighbor_id) {
-                    continue; // Already in results
-                }
-
-                // Apply type filter
-                if let Some(ref et) = options.entity_type {
-                    if neighbor.entity_type.to_string() != *et {
-                        continue;
-                    }
-                }
-
-                let graph_score = parent_score * confidence;
-                entity_map.insert(
-                    neighbor_id,
-                    ScoredEntity {
-                        entity: neighbor,
-                        score: graph_score,
-                        source: MatchSource::Graph {
-                            parent: parent_name.clone(),
-                            rel_type,
-                        },
-                    },
-                );
-            }
-        }
+        let parents = top_expansion_parents(&entity_map);
+        let reached = collect_graph_candidates(db, &parents, options).await?;
+        merge_graph_candidates(&mut entity_map, reached, scoring);
     }
 
     // Sort by score descending, truncate to limit
@@ -105,6 +106,18 @@ pub async fn query(
     });
     entities.truncate(limit);
 
+    // The semantic phase already counted its own results. Counting only that
+    // channel is what keeps the graph tail permanently cold: an entity that is
+    // only ever reached over an edge can never accumulate the accesses that
+    // feed hotness, so it can never rise. Entities corroborated by the graph
+    // kept `MatchSource::Semantic` and are deliberately not counted twice.
+    let expanded_ids: Vec<String> = entities
+        .iter()
+        .filter(|e| matches!(e.source, MatchSource::Graph { .. }))
+        .map(|e| e.entity.id_string())
+        .collect();
+    super::crud::increment_access_counts(db, &expanded_ids).await?;
+
     // Phase 3: Episode search (optional)
     let episodes = if options.include_episodes {
         super::search::search_episodes(db, embedder, query_text, limit).await?
@@ -113,6 +126,158 @@ pub async fn query(
     };
 
     Ok(QueryResult { entities, episodes })
+}
+
+/// How many semantic hits expansion runs from.
+const EXPANSION_PARENTS: usize = 3;
+
+/// A semantic hit that expansion runs from.
+///
+/// Snapshotted before any merging, so a parent that is itself corroborated
+/// mid-merge cannot change what its own neighbors inherit.
+struct ExpansionParent {
+    id: String,
+    name: String,
+    similarity: f64,
+}
+
+/// A neighbor reached by expansion, over the strongest path that reached it.
+struct GraphCandidate {
+    entity: EntityDetail,
+    parent: String,
+    rel_type: String,
+    effective_confidence: f64,
+    /// The parent's similarity, discounted by `effective_confidence`.
+    similarity: f64,
+}
+
+/// The top semantic hits, best score first.
+///
+/// Ties break on entity id: candidates arrive from a `HashMap`, and which of
+/// two equally scored hits gets expanded must not depend on hash order.
+fn top_expansion_parents(entity_map: &HashMap<String, ScoredEntity>) -> Vec<ExpansionParent> {
+    let mut ranked: Vec<&ScoredEntity> = entity_map.values().collect();
+    ranked.sort_by(|a, b| {
+        b.score
+            .partial_cmp(&a.score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| a.entity.id_string().cmp(&b.entity.id_string()))
+    });
+    ranked.truncate(EXPANSION_PARENTS);
+    ranked
+        .into_iter()
+        .map(|hit| ExpansionParent {
+            id: hit.entity.id_string(),
+            name: hit.entity.name.clone(),
+            similarity: hit.similarity,
+        })
+        .collect()
+}
+
+/// Walk one hop out of every parent, keeping each neighbor's strongest path.
+async fn collect_graph_candidates(
+    db: &Surreal<Db>,
+    parents: &[ExpansionParent],
+    options: &QueryOptions,
+) -> Result<HashMap<String, GraphCandidate>, GraphError> {
+    let mut reached: HashMap<String, GraphCandidate> = HashMap::new();
+
+    for parent in parents {
+        for (entity, rel_type, effective_confidence) in get_neighbor_details(db, &parent.id).await?
+        {
+            if let Some(ref et) = options.entity_type {
+                if entity.entity_type.to_string() != *et {
+                    continue;
+                }
+            }
+
+            let id = entity.id_string();
+            if id == parent.id {
+                continue; // A self-edge is not a second witness.
+            }
+
+            let similarity = parent.similarity * effective_confidence;
+            if reached
+                .get(&id)
+                .is_some_and(|best| best.similarity >= similarity)
+            {
+                continue;
+            }
+
+            reached.insert(
+                id,
+                GraphCandidate {
+                    entity,
+                    parent: parent.name.clone(),
+                    rel_type,
+                    effective_confidence,
+                    similarity,
+                },
+            );
+        }
+    }
+
+    Ok(reached)
+}
+
+/// Fold the expanded neighborhood into the semantic candidates: corroborate
+/// what is already there, add what is not.
+fn merge_graph_candidates(
+    entity_map: &mut HashMap<String, ScoredEntity>,
+    reached: HashMap<String, GraphCandidate>,
+    scoring: &GraphScoringConfig,
+) {
+    let now = chrono::Utc::now();
+
+    for (id, candidate) in reached {
+        match entity_map.get_mut(&id) {
+            Some(existing) => {
+                let corroborated = corroborated_similarity(
+                    scoring,
+                    existing.similarity,
+                    candidate.effective_confidence,
+                );
+                existing.similarity = corroborated;
+                existing.score = score_entity(scoring, &existing.entity, corroborated, &now);
+            }
+            None => {
+                let score = score_entity(scoring, &candidate.entity, candidate.similarity, &now);
+                entity_map.insert(
+                    id,
+                    ScoredEntity {
+                        entity: candidate.entity,
+                        similarity: candidate.similarity,
+                        score,
+                        source: MatchSource::Graph {
+                            parent: candidate.parent,
+                            rel_type: candidate.rel_type,
+                        },
+                    },
+                );
+            }
+        }
+    }
+}
+
+/// Raise a measured relevance that the graph agrees with, bounded by the
+/// similarity ceiling so corroboration can never outrank a perfect match.
+fn corroborated_similarity(
+    scoring: &GraphScoringConfig,
+    similarity: f64,
+    effective_confidence: f64,
+) -> f64 {
+    (similarity * (1.0 + scoring.corroboration_boost * effective_confidence)).min(1.0)
+}
+
+/// Score an entity from a relevance term plus its own hotness and utility.
+fn score_entity(
+    scoring: &GraphScoringConfig,
+    entity: &EntityDetail,
+    similarity: f64,
+    now: &chrono::DateTime<chrono::Utc>,
+) -> f64 {
+    let hotness = compute_hotness(entity.access_count, &entity.updated_at_string(), now);
+    score_with_utility(scoring, similarity, hotness, entity.utility_score)
 }
 
 /// Get 1-hop neighbors as L1 (EntityDetail) with the relationship type and effective confidence.

--- a/src/graph/search.rs
+++ b/src/graph/search.rs
@@ -148,6 +148,7 @@ pub async fn search_with_options(
 
             ScoredEntity {
                 entity: row.entity,
+                similarity,
                 score,
                 source: MatchSource::Semantic,
             }
@@ -238,7 +239,11 @@ struct EpisodeWithDistance {
 /// Linear combination of similarity, hotness, and utility using weights
 /// from `scoring`. Defaults (0.45 / 0.30 / 0.25) preserve legacy behavior
 /// so deployments without a `[graph.scoring]` TOML section see no change.
-fn score_with_utility(
+///
+/// Graph expansion scores through this same function (see
+/// [`crate::graph::query`]), so a candidate's channel decides only how its
+/// `similarity` is obtained, never which terms it is allowed to earn.
+pub(crate) fn score_with_utility(
     scoring: &GraphScoringConfig,
     similarity: f64,
     hotness: f64,
@@ -297,11 +302,13 @@ mod tests {
             weight_semantic: 0.45,
             weight_hotness: 0.30,
             weight_utility: 0.25,
+            ..GraphScoringConfig::default()
         };
         let high = GraphScoringConfig {
             weight_semantic: 0.25,
             weight_hotness: 0.25,
             weight_utility: 0.5,
+            ..GraphScoringConfig::default()
         };
         let high_utility = 0.9;
         let low_score = score_with_utility(&low, SIMILARITY, HOTNESS, high_utility);
@@ -319,6 +326,7 @@ mod tests {
             weight_semantic: 0.0,
             weight_hotness: 0.0,
             weight_utility: 0.0,
+            ..GraphScoringConfig::default()
         };
         let score = score_with_utility(&scoring, SIMILARITY, HOTNESS, UTILITY);
         assert!((score - 0.0).abs() < f64::EPSILON);
@@ -330,6 +338,7 @@ mod tests {
             weight_semantic: 0.5,
             weight_hotness: 0.2,
             weight_utility: 0.3,
+            ..GraphScoringConfig::default()
         };
         let expected = 0.5 * SIMILARITY + 0.2 * HOTNESS + 0.3 * UTILITY;
         let actual = score_with_utility(&scoring, SIMILARITY, HOTNESS, UTILITY);

--- a/src/graph/store.rs
+++ b/src/graph/store.rs
@@ -114,9 +114,32 @@ pub async fn open(path: &Path) -> Result<Surreal<Db>, GraphError> {
     Ok(db)
 }
 
+/// Accept a server URL with or without a scheme.
+///
+/// Before the runtime-backend change, server mode always used the WebSocket
+/// connector, so configs in the wild carry bare `host:port`. `engine::any`
+/// dispatches on the scheme and rejects those with "Invalid URL", which turns
+/// a working config into a hard failure on upgrade. A schemeless value keeps
+/// meaning what it always meant.
+fn normalize_server_url(url: &str) -> String {
+    const SCHEMES: [&str; 6] = [
+        "ws://",
+        "wss://",
+        "http://",
+        "https://",
+        "surrealkv://",
+        "mem://",
+    ];
+    if SCHEMES.iter().any(|s| url.starts_with(s)) {
+        url.to_string()
+    } else {
+        format!("ws://{url}")
+    }
+}
+
 /// Connect to a SurrealDB server (e.g. `ws://localhost:8787`).
 pub async fn connect(config: &ServerConfig) -> Result<Surreal<Db>, GraphError> {
-    let db = surrealdb::engine::any::connect(&config.url).await?;
+    let db = surrealdb::engine::any::connect(normalize_server_url(&config.url)).await?;
     db.signin(surrealdb::opt::auth::Database {
         namespace: config.namespace.clone(),
         database: config.database.clone(),
@@ -340,5 +363,32 @@ mod tests {
         assert!(!is_lock_message("connection refused"));
         assert!(!is_lock_message("lockstep protocol mismatch")); // 'lock' without already/held
         assert!(!is_lock_message("table entity already exists"));
+    }
+}
+
+#[cfg(test)]
+mod url_compat_tests {
+    use super::normalize_server_url;
+
+    #[test]
+    fn schemeless_urls_keep_meaning_websocket() {
+        assert_eq!(
+            normalize_server_url("127.0.0.1:8787"),
+            "ws://127.0.0.1:8787"
+        );
+        assert_eq!(normalize_server_url("db.local:8000"), "ws://db.local:8000");
+    }
+
+    #[test]
+    fn explicit_schemes_pass_through_untouched() {
+        for url in [
+            "ws://127.0.0.1:8787",
+            "wss://db.example:443",
+            "http://localhost:8000",
+            "surrealkv:///var/lib/store",
+            "mem://",
+        ] {
+            assert_eq!(normalize_server_url(url), url);
+        }
     }
 }

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -352,8 +352,23 @@ pub struct QueryResult {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SearchResult {
     pub entity: Entity,
+    /// Blended retrieval score: semantic similarity plus hotness and utility.
+    /// It answers *how worth returning is this*, not *how alike is this*.
     pub score: f64,
+    /// Cosine distance between the query and the entity's embedding.
     pub distance: f64,
+}
+
+impl SearchResult {
+    /// Raw cosine similarity between the query and this entity — the
+    /// popularity-free half of [`SearchResult::score`].
+    ///
+    /// Callers asking "is this the same thing?" (deduplication) must use this;
+    /// callers asking "is this worth returning?" (retrieval) want the score.
+    #[must_use]
+    pub fn similarity(&self) -> f64 {
+        1.0 - self.distance
+    }
 }
 
 /// A node in a traversal tree.
@@ -659,6 +674,14 @@ pub struct IngestionReport {
     /// applies to. Empty when the run had no LLM to extract with.
     #[serde(default)]
     pub entity_ids: Vec<String>,
+    /// Candidates that reached the ambiguous band and cost one model call each.
+    /// The dedup half of the ingest bill.
+    #[serde(default)]
+    pub dedup_llm_calls: u32,
+    /// Candidates resolved by name match or by a similarity band — decided
+    /// without a model call.
+    #[serde(default)]
+    pub dedup_fast_path: u32,
 }
 
 #[cfg(test)]

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -307,6 +307,16 @@ pub enum MatchSource {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ScoredEntity {
     pub entity: EntityDetail,
+    /// The relevance term that went into `score`, in `[0, 1]`.
+    ///
+    /// For a semantic match this is cosine similarity against the query
+    /// vector. For a graph-expanded match it is the parent's similarity
+    /// discounted by the edge's effective confidence — the same quantity,
+    /// estimated over the graph rather than measured against the query. Kept
+    /// alongside `score` because the blend that produced `score` cannot be
+    /// inverted (any weight may be zero).
+    #[serde(default)]
+    pub similarity: f64,
     pub score: f64,
     pub source: MatchSource,
 }

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -46,11 +46,21 @@ pub async fn graph_status(memory_dir: &Path) -> Result<(), RecallError> {
     println!("  Episodes:      {}", stats.episode_count);
 
     // Episodes arrive automatically on SessionEnd; turning them into entities
-    // is an explicit, LLM-costing pass. A store with episodes and no entities
-    // is the shape a user gets when nobody told them that.
+    // is an LLM-costing pass. The daemon now runs it once the machine is
+    // quiet, but a store with episodes and no entities is still worth
+    // explaining — the wait, or the opt-out, is the answer either way.
     if stats.episode_count > 0 && stats.entity_count == 0 {
-        println!("\n  {YELLOW}No entities yet.{RESET} Episodes are ingested automatically, but");
-        println!("  entity extraction is a separate pass over them:");
+        let extraction = crate::config::load_from_dir(memory_dir).extraction;
+        println!(
+            "\n  {YELLOW}No entities yet.{RESET} Episodes are ingested automatically; turning"
+        );
+        println!("  them into entities is a separate LLM pass.");
+        if extraction.background_enabled {
+            println!(
+                "  The daemon runs it after {}s of quiet. To run it now:",
+                extraction.idle_after_secs
+            );
+        }
         println!("    {DIM}recall-echo graph extract --all{RESET}");
     }
 
@@ -96,6 +106,7 @@ pub async fn daemon_status(memory_dir: &Path) -> Result<(), RecallError> {
             println!("  Pid:    {}", info.pid);
             println!("  Version: {}", info.version);
             println!("  Uptime: {}s", info.uptime_secs);
+            print_extraction_lines(&info.extraction);
         }
         None if serve_client::graph_mode(memory_dir) == "server" => {
             println!("  State:  not used — [graph] mode = server");
@@ -107,6 +118,28 @@ pub async fn daemon_status(memory_dir: &Path) -> Result<(), RecallError> {
         serve_client::daemon_log_path(memory_dir).display()
     );
     Ok(())
+}
+
+/// Report what the daemon's background extraction worker has done.
+fn print_extraction_lines(status: &crate::serve::ExtractionStatus) {
+    if !status.enabled {
+        let reason = status.disabled_reason.as_deref().unwrap_or("not running");
+        println!("  Extraction: {YELLOW}off{RESET} — {DIM}{reason}{RESET}");
+        return;
+    }
+    match status.last_run_secs_ago {
+        Some(secs) => println!(
+            "  Extraction: {GREEN}on{RESET} — {} archives in {} runs, last {}s ago ({}ms)",
+            status.archives,
+            status.runs,
+            secs,
+            status.last_run_ms.unwrap_or(0)
+        ),
+        None => println!("  Extraction: {GREEN}on{RESET} — nothing extracted yet"),
+    }
+    if let Some(error) = &status.last_error {
+        println!("  {DIM}Last extraction error: {error}{RESET}");
+    }
 }
 
 /// Stop the daemon serving this graph, if one is running.
@@ -334,7 +367,7 @@ pub async fn ingest_all(
 }
 
 /// Extract session_id and log_number from a conversation archive's frontmatter.
-fn extract_archive_metadata(content: &str, path: &Path) -> (String, Option<u32>) {
+pub(crate) fn extract_archive_metadata(content: &str, path: &Path) -> (String, Option<u32>) {
     let mut session_id = "unknown".to_string();
     let mut log_number: Option<u32> = None;
 
@@ -994,7 +1027,7 @@ fn shellexpand(path: &str) -> String {
 }
 
 /// Find the conversations directory — checks memory_dir/conversations/ then parent/conversations/.
-fn find_conversations_dir(memory_dir: &Path) -> Result<PathBuf, RecallError> {
+pub(crate) fn find_conversations_dir(memory_dir: &Path) -> Result<PathBuf, RecallError> {
     let conv = memory_dir.join("conversations");
     if conv.exists() {
         return Ok(conv);
@@ -1331,7 +1364,10 @@ pub async fn decay_report(
 
 /// Find the archive file for a given log number.
 #[cfg(feature = "llm")]
-fn find_archive_file(conversations_dir: &Path, log_number: u32) -> Result<PathBuf, RecallError> {
+pub(crate) fn find_archive_file(
+    conversations_dir: &Path,
+    log_number: u32,
+) -> Result<PathBuf, RecallError> {
     // Try both naming conventions
     let patterns = [
         format!("conversation-{log_number:03}.md"),

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -467,6 +467,8 @@ struct ExtractionTotals {
     processed: u32,
     estimated_tokens: u64,
     quarantined: Vec<u32>,
+    dedup_llm_calls: u32,
+    dedup_fast_path: u32,
 }
 
 /// Print a dry-run listing of archives that would be extracted.
@@ -505,6 +507,13 @@ fn print_extract_summary(totals: &ExtractionTotals) {
         "  Estimated tokens: ~{}",
         format_tokens(totals.estimated_tokens)
     );
+    let dedup_total = totals.dedup_llm_calls + totals.dedup_fast_path;
+    if dedup_total > 0 {
+        println!(
+            "  Dedup: {} of {} candidates needed a model call ({} resolved locally)",
+            totals.dedup_llm_calls, dedup_total, totals.dedup_fast_path
+        );
+    }
 
     if !totals.quarantined.is_empty() {
         println!(
@@ -678,6 +687,8 @@ pub async fn extract(
             totals.errors.extend(report.errors);
             totals.processed += 1;
             totals.estimated_tokens += report.estimated_tokens;
+            totals.dedup_llm_calls += report.dedup_llm_calls;
+            totals.dedup_fast_path += report.dedup_fast_path;
 
             // Rate limiting between archives
             if delay_ms > 0 && *ln != *log_numbers.last().unwrap() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,7 @@ pub mod error;
 pub mod frontmatter;
 pub mod init;
 pub mod jsonl;
+pub mod mcp;
 pub mod paths;
 pub mod search;
 pub mod serve;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,8 @@ pub mod paths;
 pub mod search;
 pub mod serve;
 pub mod serve_client;
+#[cfg(feature = "llm")]
+pub mod serve_extract;
 mod serve_security;
 pub mod status;
 pub mod summarize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,6 +91,12 @@ enum Commands {
         #[arg(long)]
         foreground: bool,
     },
+    /// Run the MCP server (stdio) so an agent can query its own memory
+    Mcp {
+        /// Entity root directory (defaults to current directory)
+        #[arg(long)]
+        entity_root: Option<PathBuf>,
+    },
     /// Knowledge graph operations
     Graph {
         #[command(subcommand)]
@@ -473,6 +479,12 @@ fn main() {
         Some(Commands::Serve { dir, foreground }) => {
             let memory_dir = dir.unwrap_or_else(|| resolve_entity_root(None).join("memory"));
             run_serve(&memory_dir, foreground)
+        }
+        Some(Commands::Mcp { entity_root }) => {
+            let memory_dir = resolve_entity_root(entity_root).join("memory");
+            client_runtime()
+                .map_err(recall_echo::error::RecallError::from)
+                .and_then(|rt| rt.block_on(recall_echo::mcp::run(&memory_dir)))
         }
         Some(Commands::Graph {
             command,

--- a/src/main.rs
+++ b/src/main.rs
@@ -154,6 +154,12 @@ enum BenchCommands {
         /// Archive top-K
         #[arg(long, default_value = "5")]
         archive_top_k: usize,
+        /// Graph episode top-K
+        #[arg(long, default_value = "20")]
+        episode_top_k: usize,
+        /// Character ceiling for the assembled episode section
+        #[arg(long, default_value = "28000")]
+        episode_char_budget: usize,
         /// Exclude episode search
         #[arg(long)]
         no_episodes: bool,
@@ -747,6 +753,8 @@ fn run_bench(command: BenchCommands) -> Result<(), recall_echo::error::RecallErr
             graph_depth,
             graph_limit,
             archive_top_k,
+            episode_top_k,
+            episode_char_budget,
             no_episodes,
         } => {
             let question_text = match (question, question_stdin) {
@@ -768,6 +776,8 @@ fn run_bench(command: BenchCommands) -> Result<(), recall_echo::error::RecallErr
                 graph_depth,
                 graph_limit,
                 archive_top_k,
+                episode_top_k,
+                episode_char_budget,
                 include_episodes: !no_episodes,
                 provider_override,
                 model_override: model,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,0 +1,572 @@
+//! MCP server — the read path into the knowledge graph.
+//!
+//! Without this, the graph is write-only in practice. `SessionEnd` ingests
+//! episodes and `SessionStart` runs `consume`, which only prints EPHEMERAL.md;
+//! nothing in a normal session ever queries the store. Bayesian confidence,
+//! HNSW search, provenance weighting and temporal decay all sit behind a
+//! command a human has to type by hand. An MCP server closes that loop: the
+//! agent asks its own memory, with the actual question, at the moment the
+//! question comes up.
+//!
+//! # Shape
+//!
+//! JSON-RPC 2.0 over stdin/stdout, one message per line — the standard local
+//! MCP transport. The surface is small on purpose: `initialize`, `ping`,
+//! `tools/list`, `tools/call`, and notifications, which are consumed
+//! silently. Anything else is a JSON-RPC `method not found`; nothing here
+//! panics on hostile input.
+//!
+//! Every tool runs through [`crate::serve_client::execute`], so the MCP server
+//! is just another daemon client and inherits the daemon's locking discipline,
+//! concurrency and auto-start. It never opens the store itself.
+//!
+//! # Read-only
+//!
+//! No tool writes. The graph's confidence model deliberately discounts what
+//! the agent asserts about itself (see `[graph.provenance]`); a tool that let
+//! the model create entities and edges directly would route around exactly
+//! the mechanism that keeps self-generated claims from becoming evidence.
+//! Writing stays on the ingest path, where every episode is stamped with its
+//! authorship.
+
+pub mod render;
+pub mod tools;
+
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
+
+use crate::error::RecallError;
+use crate::graph::types::{
+    EpisodeSearchResult, GraphStats, QueryResult, ScoredEntity, TraversalNode,
+};
+use crate::serve::Request;
+use crate::serve_client;
+use tools::Tool;
+
+/// MCP revisions this server speaks, newest first.
+///
+/// All of them carry the same `initialize` / `tools/list` / `tools/call`
+/// shapes for a tools-only server, so one implementation serves them all.
+pub const SUPPORTED_PROTOCOL_VERSIONS: &[&str] =
+    &["2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"];
+
+/// The revision offered to a client that asks for one we do not implement.
+pub const PREFERRED_PROTOCOL_VERSION: &str = "2025-11-25";
+
+/// Largest single JSON-RPC message accepted. A tool call is tiny; anything
+/// approaching this is a broken or hostile client trying to make us buffer
+/// without bound.
+const MAX_MESSAGE_BYTES: u64 = 4 * 1024 * 1024;
+
+// JSON-RPC 2.0 error codes.
+const PARSE_ERROR: i64 = -32700;
+const INVALID_REQUEST: i64 = -32600;
+const METHOD_NOT_FOUND: i64 = -32601;
+const INVALID_PARAMS: i64 = -32602;
+
+/// What the client is told this server is for, at handshake time. It is the
+/// only chance to say *when* to reach for memory before the model has to
+/// decide.
+const INSTRUCTIONS: &str = "\
+recall-echo is this agent's own long-term memory: a knowledge graph of entities, \
+relationships and conversation fragments built from previous sessions, with Bayesian \
+confidence on every relationship. None of it is loaded automatically — memory is written \
+when a session ends and read only when one of these tools is called.
+
+Call recall_query before answering anything that depends on earlier sessions: the user's \
+established preferences and setup, decisions already made, projects already discussed, or \
+any reference to \"what we did\" that is not in the current conversation. Prefer asking \
+memory over asking the user to repeat themselves. Every tool here is read-only and cheap; \
+calling one speculatively costs nothing but tokens.";
+
+// ── Backend ──────────────────────────────────────────────────────────────
+
+/// The graph operations this server runs tools against.
+///
+/// One method, one meaning: hand a daemon [`Request`] over, get its JSON back.
+/// The indirection exists so the protocol layer can be exercised without a
+/// store, an embedding model or a daemon.
+#[async_trait::async_trait]
+pub trait GraphBackend: Send + Sync {
+    /// Run a graph operation and return the daemon's `data` payload.
+    async fn execute(&self, request: &Request) -> Result<Value, RecallError>;
+}
+
+/// The real backend: the graph daemon for a memory directory.
+#[derive(Debug, Clone)]
+pub struct DaemonBackend {
+    memory_dir: PathBuf,
+}
+
+impl DaemonBackend {
+    #[must_use]
+    pub fn new(memory_dir: impl Into<PathBuf>) -> Self {
+        Self {
+            memory_dir: memory_dir.into(),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl GraphBackend for DaemonBackend {
+    async fn execute(&self, request: &Request) -> Result<Value, RecallError> {
+        serve_client::execute(&self.memory_dir, request).await
+    }
+}
+
+// ── Wire types ───────────────────────────────────────────────────────────
+
+/// An incoming JSON-RPC message. A message without an `id` is a notification
+/// and is never answered.
+#[derive(Debug, Deserialize)]
+struct RpcMessage {
+    jsonrpc: String,
+    #[serde(default)]
+    id: Option<Value>,
+    method: String,
+    #[serde(default)]
+    params: Option<Value>,
+}
+
+/// A JSON-RPC error, as returned in the `error` member of a response.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RpcError {
+    code: i64,
+    message: String,
+    data: Option<Value>,
+}
+
+impl RpcError {
+    fn new(code: i64, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+        }
+    }
+
+    fn with_data(mut self, data: Value) -> Self {
+        self.data = Some(data);
+        self
+    }
+
+    fn to_value(&self) -> Value {
+        let mut error = json!({ "code": self.code, "message": self.message });
+        if let Some(data) = &self.data {
+            error["data"] = data.clone();
+        }
+        error
+    }
+}
+
+fn success(id: Value, result: Value) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "result": result })
+}
+
+fn failure(id: Value, error: &RpcError) -> Value {
+    json!({ "jsonrpc": "2.0", "id": id, "error": error.to_value() })
+}
+
+// ── Server ───────────────────────────────────────────────────────────────
+
+/// An MCP server over some [`GraphBackend`].
+///
+/// Stateless by design: it does not require `initialize` before answering
+/// `tools/list`, because refusing would only turn a client's ordering bug into
+/// a silent memory outage. Nothing it returns depends on connection state.
+#[derive(Debug, Clone)]
+pub struct McpServer<B> {
+    backend: B,
+    server_version: String,
+}
+
+impl<B: GraphBackend> McpServer<B> {
+    #[must_use]
+    pub fn new(backend: B) -> Self {
+        Self {
+            backend,
+            server_version: env!("CARGO_PKG_VERSION").to_string(),
+        }
+    }
+
+    /// The backend this server runs tools against.
+    #[must_use]
+    pub fn backend(&self) -> &B {
+        &self.backend
+    }
+
+    /// Handle one line of the transport, returning the message to write back.
+    ///
+    /// `None` means "say nothing": a notification, or a batch of them.
+    pub async fn handle_line(&self, line: &str) -> Option<Value> {
+        let incoming: Value = match serde_json::from_str(line) {
+            Ok(value) => value,
+            Err(err) => {
+                return Some(failure(
+                    Value::Null,
+                    &RpcError::new(PARSE_ERROR, format!("invalid JSON: {err}")),
+                ))
+            }
+        };
+
+        match incoming {
+            Value::Array(messages) if messages.is_empty() => Some(failure(
+                Value::Null,
+                &RpcError::new(INVALID_REQUEST, "a batch must not be empty"),
+            )),
+            Value::Array(messages) => {
+                let mut responses = Vec::with_capacity(messages.len());
+                for message in messages {
+                    if let Some(response) = self.handle_message(message).await {
+                        responses.push(response);
+                    }
+                }
+                (!responses.is_empty()).then_some(Value::Array(responses))
+            }
+            other => self.handle_message(other).await,
+        }
+    }
+
+    async fn handle_message(&self, message: Value) -> Option<Value> {
+        // Recovered before parsing so a structurally invalid request can still
+        // be answered against the id the client is waiting on.
+        let id = message.get("id").cloned().unwrap_or(Value::Null);
+
+        // A structurally invalid message is not a notification, even without
+        // an id: JSON-RPC 2.0 answers it against a null id rather than
+        // leaving the client to time out.
+        let request: RpcMessage = match serde_json::from_value(message) {
+            Ok(request) => request,
+            Err(err) => {
+                return Some(failure(
+                    id,
+                    &RpcError::new(INVALID_REQUEST, format!("invalid JSON-RPC request: {err}")),
+                ))
+            }
+        };
+
+        if request.jsonrpc != "2.0" {
+            return Some(failure(
+                id,
+                &RpcError::new(
+                    INVALID_REQUEST,
+                    format!(
+                        "unsupported JSON-RPC version `{}`; this server speaks 2.0",
+                        request.jsonrpc
+                    ),
+                ),
+            ));
+        }
+
+        // A well-formed notification is never answered, whatever it carries.
+        if request.method.starts_with("notifications/") || request.id.is_none() {
+            return None;
+        }
+        let id = request.id.unwrap_or(Value::Null);
+
+        let result = self.dispatch(&request.method, request.params).await;
+        Some(match result {
+            Ok(value) => success(id, value),
+            Err(error) => failure(id, &error),
+        })
+    }
+
+    async fn dispatch(&self, method: &str, params: Option<Value>) -> Result<Value, RpcError> {
+        match method {
+            "initialize" => Ok(self.initialize(params)),
+            "ping" => Ok(json!({})),
+            "tools/list" => self.list_tools(params),
+            "tools/call" => self.call_tool(params).await,
+            other => Err(
+                RpcError::new(METHOD_NOT_FOUND, format!("unknown method `{other}`")).with_data(
+                    json!({
+                        "supported": ["initialize", "ping", "tools/list", "tools/call"]
+                    }),
+                ),
+            ),
+        }
+    }
+
+    fn initialize(&self, params: Option<Value>) -> Value {
+        let requested = params
+            .as_ref()
+            .and_then(|params| params.get("protocolVersion"))
+            .and_then(Value::as_str);
+
+        json!({
+            "protocolVersion": negotiate_protocol_version(requested),
+            "capabilities": { "tools": { "listChanged": false } },
+            "serverInfo": {
+                "name": "recall-echo",
+                "title": "recall-echo memory",
+                "version": self.server_version,
+            },
+            "instructions": INSTRUCTIONS,
+        })
+    }
+
+    fn list_tools(&self, params: Option<Value>) -> Result<Value, RpcError> {
+        // The catalogue is static and fits in one page, so no cursor we could
+        // have issued is ever valid.
+        if let Some(cursor) = params.as_ref().and_then(|params| params.get("cursor")) {
+            if !cursor.is_null() {
+                return Err(RpcError::new(
+                    INVALID_PARAMS,
+                    "the tool list is a single page; no cursor is valid",
+                ));
+            }
+        }
+
+        let catalogue: Vec<Value> = tools::ALL.into_iter().map(Tool::descriptor).collect();
+        Ok(json!({ "tools": catalogue }))
+    }
+
+    async fn call_tool(&self, params: Option<Value>) -> Result<Value, RpcError> {
+        let params = params.unwrap_or(Value::Null);
+        let Some(name) = params.get("name").and_then(Value::as_str) else {
+            return Err(RpcError::new(
+                INVALID_PARAMS,
+                "tools/call requires a `name` naming the tool to run",
+            ));
+        };
+        let Some(tool) = Tool::from_name(name) else {
+            return Err(
+                RpcError::new(INVALID_PARAMS, format!("unknown tool `{name}`")).with_data(json!({
+                    "available": tools::ALL.map(Tool::name),
+                })),
+            );
+        };
+
+        let arguments = params.get("arguments").cloned().unwrap_or(Value::Null);
+        let request = match tool.request(&arguments) {
+            Ok(request) => request,
+            Err(invalid) => return Ok(tool_error(invalid.to_string())),
+        };
+
+        match self.backend.execute(&request).await {
+            Ok(data) => Ok(match render(&request, data) {
+                Ok(text) => tool_success(text),
+                Err(err) => tool_error(format!(
+                    "{} could not read the memory store's answer: {err}",
+                    tool.name()
+                )),
+            }),
+            Err(err) => Ok(tool_error(explain(tool, &err))),
+        }
+    }
+}
+
+/// Echo the client's revision when we speak it, otherwise offer ours.
+#[must_use]
+pub fn negotiate_protocol_version(requested: Option<&str>) -> &str {
+    match requested {
+        Some(version) if SUPPORTED_PROTOCOL_VERSIONS.contains(&version) => version,
+        _ => PREFERRED_PROTOCOL_VERSION,
+    }
+}
+
+fn tool_success(text: String) -> Value {
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": false,
+    })
+}
+
+/// A failure the model can act on: reported in the result, not as a JSON-RPC
+/// error, so the client passes it back to the model instead of swallowing it.
+fn tool_error(text: String) -> Value {
+    json!({
+        "content": [{ "type": "text", "text": text }],
+        "isError": true,
+    })
+}
+
+/// Render a daemon payload as the text its tool promised.
+fn render(request: &Request, data: Value) -> Result<String, serde_json::Error> {
+    let text = match request {
+        Request::Search(args) => {
+            let results: Vec<ScoredEntity> = serde_json::from_value(data)?;
+            render::entities(&args.query, &results)
+        }
+        Request::Query(args) => {
+            let result: QueryResult = serde_json::from_value(data)?;
+            render::query_result(&args.query, &result)
+        }
+        Request::SearchEpisodes(args) => {
+            let results: Vec<EpisodeSearchResult> = serde_json::from_value(data)?;
+            render::episodes(&args.query, &results)
+        }
+        Request::Traverse(args) => {
+            let tree: TraversalNode = serde_json::from_value(data)?;
+            render::traversal(&args.entity, args.depth, &tree)
+        }
+        Request::Status => {
+            let stats: GraphStats = serde_json::from_value(data)?;
+            render::status(&stats)
+        }
+        // No tool builds any other request; a payload we cannot name is
+        // still better returned than dropped.
+        _ => serde_json::to_string_pretty(&data)?,
+    };
+    Ok(text)
+}
+
+/// A tool failure said in terms the model can do something about.
+fn explain(tool: Tool, error: &RecallError) -> String {
+    let mut message = format!("{} failed: {error}", tool.name());
+    if let Some(hint) = hint(error) {
+        message.push(' ');
+        message.push_str(hint);
+    }
+    message
+}
+
+fn hint(error: &RecallError) -> Option<&'static str> {
+    match error {
+        RecallError::Remote { code, .. } => match code.as_str() {
+            "not_found" => Some(
+                "Names must match an existing entity exactly — use recall_search or \
+                 recall_query to find the exact name first.",
+            ),
+            "embedding" => Some(
+                "The embedding model could not be loaded, so semantic recall is unavailable \
+                 until it is; do not retry this session.",
+            ),
+            "locked" => Some(
+                "Another recall-echo operation is holding the memory store; the same call \
+                 should succeed shortly.",
+            ),
+            _ => None,
+        },
+        RecallError::NotInitialized(_) => Some(
+            "Memory is not initialised in this directory; `recall-echo init` creates it. \
+             Do not retry until it is.",
+        ),
+        RecallError::Daemon(_) => Some(
+            "The memory daemon could not be reached, so memory is unavailable — continue \
+             without it rather than retrying.",
+        ),
+        _ => None,
+    }
+}
+
+// ── stdio transport ──────────────────────────────────────────────────────
+
+/// A message reader capped at [`MAX_MESSAGE_BYTES`] per message.
+type MessageLines = tokio::io::Lines<BufReader<tokio::io::Take<tokio::io::Stdin>>>;
+
+/// Serve MCP over stdin/stdout until the client closes the connection.
+///
+/// Messages are handled one at a time. MCP permits interleaved responses, but
+/// the daemon serializes graph work anyway, so concurrency here would buy
+/// nothing and cost an interleaved-write hazard on stdout.
+pub async fn run(memory_dir: &Path) -> Result<(), RecallError> {
+    serve(McpServer::new(DaemonBackend::new(memory_dir))).await
+}
+
+async fn serve<B: GraphBackend>(server: McpServer<B>) -> Result<(), RecallError> {
+    let mut lines = BufReader::new(tokio::io::stdin().take(MAX_MESSAGE_BYTES)).lines();
+    let mut stdout = tokio::io::stdout();
+
+    loop {
+        let line = match lines.next_line().await {
+            Ok(Some(line)) => line,
+            // The client closed stdin: the specified way to shut a stdio
+            // server down.
+            Ok(None) => return Ok(()),
+            Err(err) => return Err(err.into()),
+        };
+
+        if message_cap_reached(&mut lines) {
+            let response = failure(
+                Value::Null,
+                &RpcError::new(
+                    INVALID_REQUEST,
+                    format!("message exceeds the {MAX_MESSAGE_BYTES}-byte limit"),
+                ),
+            );
+            write_message(&mut stdout, &response).await?;
+            return Ok(());
+        }
+        recharge_message_cap(&mut lines);
+
+        if line.trim().is_empty() {
+            continue;
+        }
+        if let Some(response) = server.handle_line(&line).await {
+            write_message(&mut stdout, &response).await?;
+        }
+    }
+}
+
+fn message_cap_reached(lines: &mut MessageLines) -> bool {
+    lines.get_mut().get_mut().limit() == 0
+}
+
+fn recharge_message_cap(lines: &mut MessageLines) {
+    lines.get_mut().get_mut().set_limit(MAX_MESSAGE_BYTES);
+}
+
+async fn write_message(stdout: &mut tokio::io::Stdout, message: &Value) -> Result<(), RecallError> {
+    let mut line = serde_json::to_vec(message)?;
+    line.push(b'\n');
+    stdout.write_all(&line).await?;
+    stdout.flush().await?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_preferred_version_is_one_we_support() {
+        assert!(SUPPORTED_PROTOCOL_VERSIONS.contains(&PREFERRED_PROTOCOL_VERSION));
+        assert_eq!(SUPPORTED_PROTOCOL_VERSIONS[0], PREFERRED_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn a_supported_version_is_echoed_back() {
+        for version in SUPPORTED_PROTOCOL_VERSIONS {
+            assert_eq!(negotiate_protocol_version(Some(version)), *version);
+        }
+    }
+
+    #[test]
+    fn an_unknown_version_falls_back_to_ours() {
+        assert_eq!(
+            negotiate_protocol_version(Some("1900-01-01")),
+            PREFERRED_PROTOCOL_VERSION
+        );
+        assert_eq!(negotiate_protocol_version(None), PREFERRED_PROTOCOL_VERSION);
+    }
+
+    #[test]
+    fn hints_are_attached_only_where_they_help() {
+        let not_found = RecallError::Remote {
+            code: "not_found".into(),
+            message: "entity not found: Rust".into(),
+        };
+        let text = explain(Tool::Traverse, &not_found);
+        assert!(text.starts_with("recall_traverse failed:"), "{text}");
+        assert!(text.contains("recall_search"), "{text}");
+
+        let unknown = RecallError::Remote {
+            code: "db".into(),
+            message: "connection reset".into(),
+        };
+        assert_eq!(
+            explain(Tool::Status, &unknown),
+            "recall_status failed: connection reset"
+        );
+    }
+
+    #[test]
+    fn an_unrenderable_payload_is_dumped_rather_than_dropped() {
+        let text = render(&Request::Hello, json!({ "version": "3.13.0" })).unwrap();
+        assert!(text.contains("3.13.0"), "{text}");
+    }
+}

--- a/src/mcp/render.rs
+++ b/src/mcp/render.rs
@@ -359,6 +359,9 @@ mod tests {
         ScoredEntity {
             entity: entity(name),
             score,
+            // Fixtures only need a self-consistent value; the render layer
+            // shows similarity for episodes, not entities.
+            similarity: score,
             source,
         }
     }

--- a/src/mcp/render.rs
+++ b/src/mcp/render.rs
@@ -1,0 +1,586 @@
+//! Turning retrieval results into text an LLM can use.
+//!
+//! The daemon answers in JSON built for programs: record ids, distances,
+//! nested traversal nodes. Handing that to a model wastes context on syntax
+//! and buries the parts that matter. Everything here renders the same data as
+//! compact prose-with-structure, keeps the numbers a reader would act on
+//! (retrieval score, similarity, edge confidence, utility) and drops the ones
+//! nobody reads.
+//!
+//! Every renderer is total: an empty result set produces guidance about what
+//! to try next, not an empty string.
+
+use std::fmt::Write as _;
+
+use serde_json::Value;
+
+use crate::graph::traverse::format_traversal;
+use crate::graph::types::{
+    EntityDetail, EpisodeSearchResult, GraphStats, MatchSource, QueryResult, ScoredEntity,
+    TraversalNode,
+};
+
+/// Longest abstract kept verbatim.
+const MAX_ABSTRACT_CHARS: usize = 300;
+/// Longest overview kept verbatim. Overviews are the L1 tier — worth showing,
+/// not worth showing whole.
+const MAX_OVERVIEW_CHARS: usize = 400;
+/// Longest verbatim excerpt of one episode's original text.
+const MAX_EPISODE_CHARS: usize = 1_200;
+/// Ceiling on a whole tool result. A memory lookup that eats the context
+/// window defeats its own purpose.
+const MAX_RESULT_CHARS: usize = 24_000;
+/// The neutral utility score an entity carries until outcome feedback moves
+/// it. Reporting it would be reporting the absence of information.
+const NEUTRAL_UTILITY: f64 = 0.5;
+
+/// Entity search results.
+#[must_use]
+pub fn entities(query: &str, results: &[ScoredEntity]) -> String {
+    if results.is_empty() {
+        return format!(
+            "No entities in memory match \"{query}\".\n\
+             Entities are distilled knowledge; the raw conversations may still hold it — try \
+             recall_episodes. If recall_status shows an empty graph, nothing has been ingested \
+             yet."
+        );
+    }
+
+    let mut out = format!(
+        "{} {} in memory for \"{query}\":\n",
+        results.len(),
+        plural(results.len(), "entity", "entities")
+    );
+    for (index, result) in results.iter().enumerate() {
+        write_entity(&mut out, index + 1, result);
+    }
+    budget(out)
+}
+
+/// Hybrid query results: entities, then the episodes behind them.
+#[must_use]
+pub fn query_result(query: &str, result: &QueryResult) -> String {
+    if result.entities.is_empty() && result.episodes.is_empty() {
+        return format!(
+            "Memory holds nothing about \"{query}\".\n\
+             Either it was never discussed, or it has not been ingested yet — recall_status \
+             says which."
+        );
+    }
+
+    let mut out = format!("Memory for \"{query}\":\n");
+
+    if result.entities.is_empty() {
+        out.push_str("\nNo distilled entities matched, but these conversations did.\n");
+    } else {
+        let _ = writeln!(
+            out,
+            "\n{} {}:",
+            result.entities.len(),
+            plural(result.entities.len(), "entity", "entities")
+        );
+        for (index, entity) in result.entities.iter().enumerate() {
+            write_entity(&mut out, index + 1, entity);
+        }
+    }
+
+    if !result.episodes.is_empty() {
+        let _ = writeln!(
+            out,
+            "\n{} conversation {}:",
+            result.episodes.len(),
+            plural(result.episodes.len(), "fragment", "fragments")
+        );
+        for (index, episode) in result.episodes.iter().enumerate() {
+            write_episode(&mut out, index + 1, episode);
+        }
+    }
+
+    budget(out)
+}
+
+/// Episode search results.
+#[must_use]
+pub fn episodes(query: &str, results: &[EpisodeSearchResult]) -> String {
+    if results.is_empty() {
+        return format!(
+            "No past conversation in memory matches \"{query}\".\n\
+             If recall_status shows episodes exist, the topic is genuinely absent; if it shows \
+             none, no sessions have been archived into the graph yet."
+        );
+    }
+
+    let mut out = format!(
+        "{} conversation {} for \"{query}\":\n",
+        results.len(),
+        plural(results.len(), "fragment", "fragments")
+    );
+    for (index, result) in results.iter().enumerate() {
+        write_episode(&mut out, index + 1, result);
+    }
+    budget(out)
+}
+
+/// A traversal tree rooted at one entity.
+#[must_use]
+pub fn traversal(entity: &str, depth: u32, node: &TraversalNode) -> String {
+    if node.edges.is_empty() {
+        return format!(
+            "\"{}\" ({}) exists in memory but has no relationships recorded within {depth} \
+             {}.\nIts own description: {}",
+            node.entity.name,
+            node.entity.entity_type,
+            plural(depth as usize, "hop", "hops"),
+            clip(&node.entity.abstract_text, MAX_ABSTRACT_CHARS)
+        );
+    }
+
+    let tree = format_traversal(node, 0);
+    let mut out = format!(
+        "Relationships from \"{entity}\", up to {depth} {}:\n\n{tree}",
+        plural(depth as usize, "hop", "hops")
+    );
+    if tree.contains('%') || tree.contains("[superseded]") {
+        out.push_str(
+            "\nA percentage is the edge's accumulated confidence (absent means fully \
+             corroborated); [superseded] marks a relationship that was true once and no longer \
+             is.\n",
+        );
+    }
+    budget(out)
+}
+
+/// Graph counts.
+#[must_use]
+pub fn status(stats: &GraphStats) -> String {
+    let mut out = format!(
+        "Memory graph: {} {}, {} {}, {} conversation {}.\n",
+        stats.entity_count,
+        plural(stats.entity_count as usize, "entity", "entities"),
+        stats.relationship_count,
+        plural(
+            stats.relationship_count as usize,
+            "relationship",
+            "relationships"
+        ),
+        stats.episode_count,
+        plural(stats.episode_count as usize, "episode", "episodes"),
+    );
+
+    if !stats.entity_type_counts.is_empty() {
+        let mut types: Vec<_> = stats.entity_type_counts.iter().collect();
+        types.sort_by(|left, right| right.1.cmp(left.1).then_with(|| left.0.cmp(right.0)));
+        let listed: Vec<String> = types
+            .iter()
+            .map(|(name, count)| format!("{name} {count}"))
+            .collect();
+        let _ = writeln!(out, "By type: {}.", listed.join(", "));
+    }
+
+    if stats.entity_count == 0 && stats.episode_count == 0 {
+        out.push_str(
+            "The graph is empty: no sessions have been ingested, so recall tools will find \
+             nothing.\n",
+        );
+    } else if stats.entity_count == 0 {
+        out.push_str(
+            "Conversations have been ingested but never distilled into entities, so \
+             recall_search and recall_query will be thin — recall_episodes still works.\n",
+        );
+    }
+
+    budget(out)
+}
+
+// ── Pieces ───────────────────────────────────────────────────────────────
+
+fn write_entity(out: &mut String, position: usize, result: &ScoredEntity) {
+    let entity = &result.entity;
+    let _ = writeln!(
+        out,
+        "\n{position}. {} [{}] — score {:.2}, {}",
+        entity.name,
+        entity.entity_type,
+        result.score,
+        match_source(&result.source)
+    );
+    let _ = writeln!(
+        out,
+        "   {}",
+        clip(&entity.abstract_text, MAX_ABSTRACT_CHARS)
+    );
+    if adds_detail(entity) {
+        let _ = writeln!(out, "   {}", clip(&entity.overview, MAX_OVERVIEW_CHARS));
+    }
+    if let Some(provenance) = entity_provenance(entity) {
+        let _ = writeln!(out, "   {provenance}");
+    }
+}
+
+/// The overview is worth its tokens only when it says more than the abstract
+/// already did.
+fn adds_detail(entity: &EntityDetail) -> bool {
+    let overview = entity.overview.trim();
+    !overview.is_empty() && overview != entity.abstract_text.trim()
+}
+
+/// The line that says how much to trust this entity and where it came from.
+fn entity_provenance(entity: &EntityDetail) -> Option<String> {
+    let mut parts = Vec::new();
+    let updated = short_time(&entity.updated_at);
+    if !updated.is_empty() {
+        parts.push(format!("updated {updated}"));
+    }
+    if let Some(source) = entity.source.as_deref().filter(|s| !s.trim().is_empty()) {
+        parts.push(format!("from {source}"));
+    }
+    if (entity.utility_score - NEUTRAL_UTILITY).abs() > 0.005 {
+        parts.push(format!("usefulness {:.2}", entity.utility_score));
+    }
+    (!parts.is_empty()).then(|| parts.join(" · "))
+}
+
+fn match_source(source: &MatchSource) -> String {
+    match source {
+        MatchSource::Semantic => "matched directly".to_string(),
+        MatchSource::Keyword => "matched by keyword".to_string(),
+        MatchSource::Graph { parent, rel_type } => {
+            format!("reached from \"{parent}\" via {rel_type}")
+        }
+    }
+}
+
+fn write_episode(out: &mut String, position: usize, result: &EpisodeSearchResult) {
+    let episode = &result.episode;
+    let mut header = format!("\n{position}. session {}", episode.session_id);
+    if let Some(log) = episode.log_number {
+        let _ = write!(header, ", archive log #{log}");
+    }
+    let timestamp = short_time(&episode.timestamp);
+    if !timestamp.is_empty() {
+        let _ = write!(header, ", {timestamp}");
+    }
+    let _ = writeln!(
+        out,
+        "{header} — score {:.2}, similarity {:.2}",
+        result.score,
+        1.0 - result.distance
+    );
+    let _ = writeln!(
+        out,
+        "   {}",
+        clip(&episode.abstract_text, MAX_ABSTRACT_CHARS)
+    );
+
+    // The chunk itself is the reason to call this tool at all: the abstract is
+    // a label, the content is what was said.
+    if let Some(content) = episode.content.as_deref().filter(|c| !c.trim().is_empty()) {
+        let excerpt = clip(content, MAX_EPISODE_CHARS);
+        if excerpt != episode.abstract_text.trim() {
+            let _ = writeln!(out, "   ---\n{}", indent(&excerpt, "   "));
+        }
+    }
+}
+
+// ── Text utilities ───────────────────────────────────────────────────────
+
+/// Trim to `max` characters on a character boundary, marking the cut.
+fn clip(text: &str, max: usize) -> String {
+    let text = text.trim();
+    if text.chars().count() <= max {
+        return text.to_string();
+    }
+    let mut clipped: String = text.chars().take(max).collect();
+    clipped.push_str(" […]");
+    clipped
+}
+
+fn indent(text: &str, prefix: &str) -> String {
+    text.lines()
+        .map(|line| format!("{prefix}{line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Timestamps arrive as JSON scalars. Keep them to seconds — sub-second
+/// precision on a memory from last March is noise.
+fn short_time(value: &Value) -> String {
+    let raw = match value {
+        Value::Null => return String::new(),
+        Value::String(text) => text.clone(),
+        other => other.to_string(),
+    };
+    match raw.find('.') {
+        Some(dot) if raw.contains('T') => raw[..dot].to_string(),
+        _ => raw,
+    }
+}
+
+fn plural(count: usize, one: &'static str, many: &'static str) -> &'static str {
+    if count == 1 {
+        one
+    } else {
+        many
+    }
+}
+
+/// Hold a rendered result inside [`MAX_RESULT_CHARS`], saying so when it cuts.
+fn budget(text: String) -> String {
+    if text.chars().count() <= MAX_RESULT_CHARS {
+        return text;
+    }
+    let mut clipped: String = text.chars().take(MAX_RESULT_CHARS).collect();
+    clipped.push_str("\n\n[result truncated — ask a narrower question or lower `limit`]");
+    clipped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::types::{EntitySummary, EntityType, Episode, TraversalEdge};
+    use serde_json::json;
+
+    fn entity(name: &str) -> EntityDetail {
+        EntityDetail {
+            id: json!(format!("entity:{name}")),
+            name: name.to_string(),
+            entity_type: EntityType::Tool,
+            abstract_text: format!("{name} is a thing."),
+            overview: format!("{name} does something in more words than the abstract."),
+            attributes: None,
+            access_count: 3,
+            utility_score: NEUTRAL_UTILITY,
+            updated_at: json!("2026-05-01T09:15:30.123456Z"),
+            source: Some("archive-log-042".into()),
+        }
+    }
+
+    fn scored(name: &str, score: f64, source: MatchSource) -> ScoredEntity {
+        ScoredEntity {
+            entity: entity(name),
+            score,
+            source,
+        }
+    }
+
+    fn episode(session: &str, content: &str) -> EpisodeSearchResult {
+        EpisodeSearchResult {
+            episode: Episode {
+                id: json!("episode:1"),
+                session_id: session.to_string(),
+                timestamp: json!("2026-04-02T18:00:00Z"),
+                abstract_text: "A chat about deploys.".into(),
+                overview: None,
+                content: Some(content.to_string()),
+                embedding: None,
+                log_number: Some(42),
+                provenance: Some("human".into()),
+                access_count: 0,
+            },
+            score: 0.71,
+            distance: 0.32,
+        }
+    }
+
+    #[test]
+    fn empty_entity_search_points_at_the_next_move() {
+        let text = entities("deploys", &[]);
+        assert!(text.contains("No entities"));
+        assert!(text.contains("recall_episodes"));
+        assert!(text.contains("recall_status"));
+    }
+
+    #[test]
+    fn entities_carry_name_type_score_and_provenance() {
+        let text = entities("rust", &[scored("Rust", 0.812, MatchSource::Semantic)]);
+        assert!(
+            text.contains("1. Rust [tool] — score 0.81, matched directly"),
+            "{text}"
+        );
+        assert!(text.contains("Rust is a thing."), "{text}");
+        assert!(text.contains("updated 2026-05-01T09:15:30"), "{text}");
+        assert!(text.contains("from archive-log-042"), "{text}");
+        // Neutral usefulness is the absence of feedback, not a fact.
+        assert!(!text.contains("usefulness"), "{text}");
+    }
+
+    #[test]
+    fn graph_reached_entities_say_how_they_were_reached() {
+        let text = entities(
+            "rust",
+            &[scored(
+                "Cargo",
+                0.4,
+                MatchSource::Graph {
+                    parent: "Rust".into(),
+                    rel_type: "USES".into(),
+                },
+            )],
+        );
+        assert!(text.contains("reached from \"Rust\" via USES"), "{text}");
+    }
+
+    #[test]
+    fn moved_usefulness_is_reported() {
+        let mut result = scored("Rust", 0.5, MatchSource::Semantic);
+        result.entity.utility_score = 0.82;
+        let text = entities("rust", &[result]);
+        assert!(text.contains("usefulness 0.82"), "{text}");
+    }
+
+    #[test]
+    fn identical_overview_is_not_repeated() {
+        let mut result = scored("Rust", 0.5, MatchSource::Semantic);
+        result.entity.overview = result.entity.abstract_text.clone();
+        let text = entities("rust", &[result]);
+        assert_eq!(text.matches("Rust is a thing.").count(), 1, "{text}");
+    }
+
+    #[test]
+    fn episodes_report_similarity_and_the_original_text() {
+        let text = episodes(
+            "deploys",
+            &[episode("abc123", "We ran cargo dist and it broke.")],
+        );
+        assert!(text.contains("session abc123"), "{text}");
+        assert!(text.contains("archive log #42"), "{text}");
+        assert!(text.contains("similarity 0.68"), "{text}");
+        assert!(text.contains("We ran cargo dist and it broke."), "{text}");
+    }
+
+    #[test]
+    fn long_episode_content_is_clipped() {
+        let long = "x".repeat(MAX_EPISODE_CHARS * 2);
+        let text = episodes("deploys", &[episode("abc123", &long)]);
+        assert!(text.contains("[…]"), "{text}");
+        assert!(text.chars().count() < long.chars().count());
+    }
+
+    #[test]
+    fn query_result_separates_entities_from_fragments() {
+        let result = QueryResult {
+            entities: vec![scored("Rust", 0.9, MatchSource::Semantic)],
+            episodes: vec![episode("abc123", "some talk")],
+        };
+        let text = query_result("rust", &result);
+        assert!(text.contains("1 entity:"), "{text}");
+        assert!(text.contains("1 conversation fragment:"), "{text}");
+    }
+
+    #[test]
+    fn empty_query_result_explains_the_two_possibilities() {
+        let result = QueryResult {
+            entities: Vec::new(),
+            episodes: Vec::new(),
+        };
+        let text = query_result("nothing", &result);
+        assert!(text.contains("recall_status"), "{text}");
+    }
+
+    fn leaf(name: &str) -> TraversalNode {
+        TraversalNode {
+            entity: EntitySummary {
+                id: json!(format!("entity:{name}")),
+                name: name.to_string(),
+                entity_type: EntityType::Tool,
+                abstract_text: format!("{name} is a thing."),
+            },
+            edges: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn a_lone_entity_says_so_instead_of_printing_an_empty_tree() {
+        let text = traversal("Rust", 2, &leaf("Rust"));
+        assert!(text.contains("no relationships recorded"), "{text}");
+        assert!(text.contains("Rust is a thing."), "{text}");
+    }
+
+    #[test]
+    fn uncertain_edges_get_a_legend() {
+        let mut root = leaf("Rust");
+        root.edges.push(TraversalEdge {
+            rel_type: "USES".into(),
+            direction: "->".into(),
+            target: leaf("Cargo"),
+            valid_from: json!("2026-01-01T00:00:00Z"),
+            valid_until: None,
+            confidence: 0.62,
+        });
+        let text = traversal("Rust", 1, &root);
+        assert!(text.contains("[62%]"), "{text}");
+        assert!(text.contains("accumulated confidence"), "{text}");
+    }
+
+    #[test]
+    fn certain_edges_get_no_legend() {
+        let mut root = leaf("Rust");
+        root.edges.push(TraversalEdge {
+            rel_type: "USES".into(),
+            direction: "->".into(),
+            target: leaf("Cargo"),
+            valid_from: json!("2026-01-01T00:00:00Z"),
+            valid_until: None,
+            confidence: 1.0,
+        });
+        let text = traversal("Rust", 1, &root);
+        assert!(!text.contains("accumulated confidence"), "{text}");
+    }
+
+    #[test]
+    fn status_reports_counts_and_flags_an_empty_graph() {
+        let empty = GraphStats {
+            entity_count: 0,
+            relationship_count: 0,
+            episode_count: 0,
+            entity_type_counts: Default::default(),
+        };
+        let text = status(&empty);
+        assert!(text.contains("0 entities"), "{text}");
+        assert!(text.contains("The graph is empty"), "{text}");
+    }
+
+    #[test]
+    fn status_flags_episodes_without_entities() {
+        let stats = GraphStats {
+            entity_count: 0,
+            relationship_count: 0,
+            episode_count: 120,
+            entity_type_counts: Default::default(),
+        };
+        let text = status(&stats);
+        assert!(text.contains("never distilled"), "{text}");
+        assert!(text.contains("recall_episodes"), "{text}");
+    }
+
+    #[test]
+    fn status_lists_types_by_descending_count() {
+        let mut counts = std::collections::HashMap::new();
+        counts.insert("tool".to_string(), 3);
+        counts.insert("project".to_string(), 9);
+        let stats = GraphStats {
+            entity_count: 12,
+            relationship_count: 4,
+            episode_count: 1,
+            entity_type_counts: counts,
+        };
+        let text = status(&stats);
+        assert!(text.contains("By type: project 9, tool 3."), "{text}");
+        assert!(text.contains("1 conversation episode."), "{text}");
+    }
+
+    #[test]
+    fn results_stay_inside_the_character_budget() {
+        let long = "y".repeat(MAX_RESULT_CHARS * 2);
+        let clipped = budget(long);
+        assert!(clipped.contains("result truncated"));
+        assert!(clipped.chars().count() < MAX_RESULT_CHARS + 100);
+    }
+
+    #[test]
+    fn clip_respects_character_boundaries() {
+        let text = "é".repeat(10);
+        assert_eq!(clip(&text, 3), "ééé […]");
+        assert_eq!(clip(&text, 50), text);
+    }
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,0 +1,525 @@
+//! The tool catalogue exposed over MCP.
+//!
+//! Each tool is a thin, well-described face on one daemon operation. The
+//! descriptions are the interface: an agent picks a tool by reading them, so
+//! they say what the tool answers and when to prefer a sibling, not how it is
+//! implemented.
+//!
+//! Nothing here touches the store. A tool turns arguments into a
+//! [`Request`]; [`crate::mcp`] runs it through the daemon.
+
+use serde_json::{json, Value};
+
+use crate::serve::{QueryArgs, Request, SearchArgs, SearchEpisodesArgs, TraverseArgs};
+
+/// Result limits an agent may ask for. The daemon clamps far higher; these
+/// bounds keep a single tool result inside a sane share of the context window.
+const MIN_LIMIT: u64 = 1;
+const MAX_LIMIT: u64 = 50;
+const MAX_EPISODE_LIMIT: u64 = 20;
+/// Deepest traversal a tool may ask for. Expansion is exponential in the
+/// branching factor, and the rendered tree has to stay readable.
+const MAX_TRAVERSE_DEPTH: u64 = 4;
+
+const DEFAULT_ENTITY_LIMIT: u64 = 8;
+const DEFAULT_EPISODE_LIMIT: u64 = 5;
+const DEFAULT_TRAVERSE_DEPTH: u64 = 2;
+/// One hop of graph expansion around the semantic hits — the same default the
+/// `graph query` CLI uses. Deeper expansion buys noise faster than recall.
+const QUERY_GRAPH_DEPTH: u32 = 1;
+
+/// A tool call whose arguments the agent can fix by trying again.
+///
+/// Reported as a tool execution error (`isError: true`), never as a JSON-RPC
+/// error: the model is the one who can correct it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InvalidArguments(pub String);
+
+impl std::fmt::Display for InvalidArguments {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// A memory tool an MCP client can call.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Tool {
+    /// Semantic entity search.
+    Search,
+    /// Hybrid retrieval: semantic + graph expansion + optional episodes.
+    Query,
+    /// Relationships out of one named entity.
+    Traverse,
+    /// Episode (conversation-fragment) search.
+    Episodes,
+    /// Graph counts.
+    Status,
+}
+
+/// Every tool, in the order `tools/list` reports them.
+///
+/// The order is fixed: clients cache the tool list, and a stable order keeps
+/// their prompt caches warm.
+pub const ALL: [Tool; 5] = [
+    Tool::Query,
+    Tool::Search,
+    Tool::Episodes,
+    Tool::Traverse,
+    Tool::Status,
+];
+
+impl Tool {
+    /// Look a tool up by its wire name.
+    #[must_use]
+    pub fn from_name(name: &str) -> Option<Self> {
+        ALL.into_iter().find(|tool| tool.name() == name)
+    }
+
+    /// The name an agent calls this tool by.
+    #[must_use]
+    pub const fn name(self) -> &'static str {
+        match self {
+            Tool::Search => "recall_search",
+            Tool::Query => "recall_query",
+            Tool::Traverse => "recall_traverse",
+            Tool::Episodes => "recall_episodes",
+            Tool::Status => "recall_status",
+        }
+    }
+
+    /// Human-readable name, for client UIs that show one.
+    #[must_use]
+    pub const fn title(self) -> &'static str {
+        match self {
+            Tool::Search => "Search memory for entities",
+            Tool::Query => "Recall from memory",
+            Tool::Traverse => "Explore an entity's relationships",
+            Tool::Episodes => "Search past conversations",
+            Tool::Status => "Memory graph status",
+        }
+    }
+
+    /// What the tool answers, and when to prefer a sibling.
+    #[must_use]
+    pub const fn description(self) -> &'static str {
+        match self {
+            Tool::Query => {
+                "Recall what you already know about something, from your own long-term memory of \
+                 past sessions. This is the default memory lookup and usually the right first \
+                 call. It runs a semantic search over the distilled knowledge graph, expands one \
+                 hop along the relationships around each hit, and (by default) also returns the \
+                 conversation fragments the knowledge came from. Reach for it whenever the user \
+                 refers to something outside this conversation — \"the approach we settled on\", \
+                 \"like we did last time\", \"my usual setup\" — or before asserting that you \
+                 have no prior context. Returns each entity with its type, a one-line abstract, \
+                 a retrieval score, and whether it was matched directly or pulled in through a \
+                 relationship."
+            }
+            Tool::Search => {
+                "Semantic search over the entities in your long-term memory: the people, \
+                 projects, tools, services, decisions, preferences and concepts distilled from \
+                 past conversations. Matching is by meaning, not keywords, so \"how do we ship \
+                 releases\" finds entities about CI, tagging and deployment. Returns names, \
+                 types, abstracts and retrieval scores — a compact map of what is known. Use \
+                 this when you want the inventory of relevant entities and nothing more; use \
+                 recall_query when you also want their relationships and the original \
+                 conversation text."
+            }
+            Tool::Episodes => {
+                "Search the raw conversation fragments (episodes) stored in memory, rather than \
+                 the distilled entities. Each result is a dated chunk of a past session with its \
+                 session id and text. Use it when you need what was actually said — exact \
+                 wording, a command, a number, a snippet of code — instead of a summarised fact, \
+                 or when recall_search and recall_query come back empty because the topic was \
+                 discussed but never distilled into an entity. Episodes are the ground truth the \
+                 entities were derived from."
+            }
+            Tool::Traverse => {
+                "Walk the relationships out of one named entity and show them as a tree, with \
+                 each edge's confidence. Use it after recall_search or recall_query has given \
+                 you an exact entity name, when you need the structure around a fact rather than \
+                 more facts: what a project depends on, who decided what, which choice \
+                 superseded which. The entity name must match an existing entity exactly. Edges \
+                 annotated with a percentage are ones the graph is not fully certain of — that \
+                 number is accumulated Bayesian evidence, not a guess — and edges marked \
+                 [superseded] describe something that was true once and no longer is."
+            }
+            Tool::Status => {
+                "Report the size and shape of the memory graph: how many entities, relationships \
+                 and conversation episodes it holds, plus the entity counts by type. Use it to \
+                 tell an empty memory apart from a failed lookup — if a recall returns nothing, \
+                 this says whether that means \"never discussed\" or \"nothing has been ingested \
+                 yet\". Takes no arguments."
+            }
+        }
+    }
+
+    /// JSON Schema for this tool's arguments (JSON Schema 2020-12).
+    #[must_use]
+    pub fn input_schema(self) -> Value {
+        match self {
+            Tool::Search => object_schema(
+                json!({
+                    "query": {
+                        "type": "string",
+                        "description": "What to look for, in natural language. A question or a \
+                                        topic both work; matching is on meaning, not wording."
+                    },
+                    "limit": limit_schema(
+                        MAX_LIMIT,
+                        DEFAULT_ENTITY_LIMIT,
+                        "Maximum entities to return.",
+                    ),
+                }),
+                &["query"],
+            ),
+            Tool::Query => object_schema(
+                json!({
+                    "query": {
+                        "type": "string",
+                        "description": "What you are trying to remember, in natural language. \
+                                        Phrase it as the actual question — the whole query is \
+                                        embedded, so more context retrieves better."
+                    },
+                    "limit": limit_schema(
+                        MAX_LIMIT,
+                        DEFAULT_ENTITY_LIMIT,
+                        "Maximum entities to return.",
+                    ),
+                    "include_episodes": {
+                        "type": "boolean",
+                        "description": "Also return the conversation fragments behind the \
+                                        entities. Defaults to true; set false when you only \
+                                        need the distilled facts and want a shorter result."
+                    },
+                }),
+                &["query"],
+            ),
+            Tool::Episodes => object_schema(
+                json!({
+                    "query": {
+                        "type": "string",
+                        "description": "What was said, in natural language. Matching is on \
+                                        meaning, so paraphrasing the topic works."
+                    },
+                    "limit": limit_schema(
+                        MAX_EPISODE_LIMIT,
+                        DEFAULT_EPISODE_LIMIT,
+                        "Maximum conversation fragments to return. Fragments are long; ask for \
+                         few.",
+                    ),
+                }),
+                &["query"],
+            ),
+            Tool::Traverse => object_schema(
+                json!({
+                    "entity": {
+                        "type": "string",
+                        "description": "Exact name of the entity to start from, as returned by \
+                                        recall_search or recall_query."
+                    },
+                    "depth": {
+                        "type": "integer",
+                        "minimum": MIN_LIMIT,
+                        "maximum": MAX_TRAVERSE_DEPTH,
+                        "description": "How many relationship hops to follow (1-4). Defaults to \
+                                        2. Each hop multiplies the size of the answer."
+                    },
+                }),
+                &["entity"],
+            ),
+            Tool::Status => json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false
+            }),
+        }
+    }
+
+    /// The full `Tool` object `tools/list` reports.
+    #[must_use]
+    pub fn descriptor(self) -> Value {
+        json!({
+            "name": self.name(),
+            "title": self.title(),
+            "description": self.description(),
+            "inputSchema": self.input_schema(),
+        })
+    }
+
+    /// Turn call arguments into the daemon request that answers them.
+    ///
+    /// `arguments` is whatever the client sent; a missing `arguments` member
+    /// arrives here as [`Value::Null`].
+    pub fn request(self, arguments: &Value) -> Result<Request, InvalidArguments> {
+        let args = normalize(self, arguments)?;
+        let request = match self {
+            Tool::Search => Request::Search(SearchArgs {
+                query: required_text(&args, "query")?,
+                limit: bounded_int(&args, "limit", DEFAULT_ENTITY_LIMIT, MAX_LIMIT)? as usize,
+                entity_type: None,
+                keyword: None,
+            }),
+            Tool::Query => Request::Query(QueryArgs {
+                query: required_text(&args, "query")?,
+                limit: bounded_int(&args, "limit", DEFAULT_ENTITY_LIMIT, MAX_LIMIT)? as usize,
+                entity_type: None,
+                keyword: None,
+                depth: QUERY_GRAPH_DEPTH,
+                episodes: flag(&args, "include_episodes", true)?,
+            }),
+            Tool::Episodes => Request::SearchEpisodes(SearchEpisodesArgs {
+                query: required_text(&args, "query")?,
+                limit: bounded_int(&args, "limit", DEFAULT_EPISODE_LIMIT, MAX_EPISODE_LIMIT)?
+                    as usize,
+            }),
+            Tool::Traverse => Request::Traverse(TraverseArgs {
+                entity: required_text(&args, "entity")?,
+                depth: bounded_int(&args, "depth", DEFAULT_TRAVERSE_DEPTH, MAX_TRAVERSE_DEPTH)?
+                    as u32,
+                type_filter: None,
+            }),
+            Tool::Status => Request::Status,
+        };
+        Ok(request)
+    }
+}
+
+// ── Schema helpers ───────────────────────────────────────────────────────
+
+fn object_schema(properties: Value, required: &[&str]) -> Value {
+    json!({
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": false
+    })
+}
+
+fn limit_schema(max: u64, default: u64, purpose: &str) -> Value {
+    json!({
+        "type": "integer",
+        "minimum": MIN_LIMIT,
+        "maximum": max,
+        "description": format!("{purpose} Between {MIN_LIMIT} and {max}; defaults to {default}."),
+    })
+}
+
+// ── Argument helpers ─────────────────────────────────────────────────────
+
+/// Accept the argument object, an absent one, or the empty one.
+///
+/// Anything else is a shape the agent can fix.
+fn normalize(tool: Tool, arguments: &Value) -> Result<Value, InvalidArguments> {
+    match arguments {
+        Value::Object(_) => Ok(arguments.clone()),
+        Value::Null => Ok(json!({})),
+        other => Err(InvalidArguments(format!(
+            "{}: `arguments` must be a JSON object, got {}",
+            tool.name(),
+            type_name(other)
+        ))),
+    }
+}
+
+fn required_text(args: &Value, field: &str) -> Result<String, InvalidArguments> {
+    match args.get(field) {
+        Some(Value::String(text)) if !text.trim().is_empty() => Ok(text.trim().to_string()),
+        Some(Value::String(_)) => Err(InvalidArguments(format!(
+            "`{field}` must not be empty — say what you are looking for"
+        ))),
+        Some(other) => Err(InvalidArguments(format!(
+            "`{field}` must be a string, got {}",
+            type_name(other)
+        ))),
+        None => Err(InvalidArguments(format!("`{field}` is required"))),
+    }
+}
+
+/// A whole number in `MIN_LIMIT..=max`, defaulting when absent.
+///
+/// Out-of-range numbers are clamped rather than rejected: asking for more
+/// than the ceiling is a preference, not a mistake. A non-integer is a
+/// mistake, and says so.
+fn bounded_int(args: &Value, field: &str, default: u64, max: u64) -> Result<u64, InvalidArguments> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(default),
+        Some(Value::Number(number)) => match number.as_u64() {
+            Some(value) => Ok(value.clamp(MIN_LIMIT, max)),
+            // Negative or fractional: as_i64 catches the negatives, and
+            // anything else is a float the caller meant as a count.
+            None if number.as_i64().is_some() => Ok(MIN_LIMIT),
+            None => Err(InvalidArguments(format!(
+                "`{field}` must be a whole number between {MIN_LIMIT} and {max}"
+            ))),
+        },
+        Some(other) => Err(InvalidArguments(format!(
+            "`{field}` must be a whole number between {MIN_LIMIT} and {max}, got {}",
+            type_name(other)
+        ))),
+    }
+}
+
+fn flag(args: &Value, field: &str, default: bool) -> Result<bool, InvalidArguments> {
+    match args.get(field) {
+        None | Some(Value::Null) => Ok(default),
+        Some(Value::Bool(value)) => Ok(*value),
+        Some(other) => Err(InvalidArguments(format!(
+            "`{field}` must be true or false, got {}",
+            type_name(other)
+        ))),
+    }
+}
+
+fn type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "a boolean",
+        Value::Number(_) => "a number",
+        Value::String(_) => "a string",
+        Value::Array(_) => "an array",
+        Value::Object(_) => "an object",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn every_tool_resolves_from_its_own_name() {
+        for tool in ALL {
+            assert_eq!(Tool::from_name(tool.name()), Some(tool));
+        }
+    }
+
+    #[test]
+    fn unknown_names_do_not_resolve() {
+        assert_eq!(Tool::from_name("recall_forget"), None);
+        assert_eq!(Tool::from_name(""), None);
+    }
+
+    #[test]
+    fn descriptors_carry_a_schema_and_a_description() {
+        for tool in ALL {
+            let descriptor = tool.descriptor();
+            assert_eq!(descriptor["name"], tool.name());
+            assert_eq!(descriptor["inputSchema"]["type"], "object");
+            assert!(
+                descriptor["description"].as_str().unwrap().len() > 80,
+                "{} needs a description an agent can choose from",
+                tool.name()
+            );
+        }
+    }
+
+    #[test]
+    fn search_defaults_the_limit() {
+        let request = Tool::Search.request(&json!({ "query": "rust" })).unwrap();
+        assert_eq!(
+            request,
+            Request::Search(SearchArgs {
+                query: "rust".into(),
+                limit: DEFAULT_ENTITY_LIMIT as usize,
+                entity_type: None,
+                keyword: None,
+            })
+        );
+    }
+
+    #[test]
+    fn query_includes_episodes_unless_told_otherwise() {
+        let Request::Query(args) = Tool::Query.request(&json!({ "query": "deploys" })).unwrap()
+        else {
+            panic!("expected a query request");
+        };
+        assert!(args.episodes);
+        assert_eq!(args.depth, QUERY_GRAPH_DEPTH);
+
+        let Request::Query(args) = Tool::Query
+            .request(&json!({ "query": "deploys", "include_episodes": false }))
+            .unwrap()
+        else {
+            panic!("expected a query request");
+        };
+        assert!(!args.episodes);
+    }
+
+    #[test]
+    fn status_ignores_arguments_and_absent_arguments() {
+        assert_eq!(Tool::Status.request(&Value::Null).unwrap(), Request::Status);
+        assert_eq!(
+            Tool::Status.request(&json!({ "noise": 1 })).unwrap(),
+            Request::Status
+        );
+    }
+
+    #[test]
+    fn oversized_limits_clamp_instead_of_failing() {
+        let Request::Search(args) = Tool::Search
+            .request(&json!({ "query": "rust", "limit": 9_000 }))
+            .unwrap()
+        else {
+            panic!("expected a search request");
+        };
+        assert_eq!(args.limit, MAX_LIMIT as usize);
+
+        let Request::Traverse(args) = Tool::Traverse
+            .request(&json!({ "entity": "Rust", "depth": 0 }))
+            .unwrap()
+        else {
+            panic!("expected a traverse request");
+        };
+        assert_eq!(args.depth, MIN_LIMIT as u32);
+    }
+
+    #[test]
+    fn missing_required_arguments_are_reported_by_name() {
+        let error = Tool::Search.request(&json!({})).unwrap_err();
+        assert!(error.to_string().contains("`query` is required"), "{error}");
+
+        let error = Tool::Traverse.request(&json!({ "depth": 2 })).unwrap_err();
+        assert!(
+            error.to_string().contains("`entity` is required"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn blank_and_mistyped_arguments_are_rejected() {
+        let error = Tool::Search.request(&json!({ "query": "  " })).unwrap_err();
+        assert!(error.to_string().contains("must not be empty"), "{error}");
+
+        let error = Tool::Search.request(&json!({ "query": 12 })).unwrap_err();
+        assert!(error.to_string().contains("must be a string"), "{error}");
+
+        let error = Tool::Search
+            .request(&json!({ "query": "rust", "limit": "many" }))
+            .unwrap_err();
+        assert!(error.to_string().contains("whole number"), "{error}");
+
+        let error = Tool::Query
+            .request(&json!({ "query": "rust", "include_episodes": "yes" }))
+            .unwrap_err();
+        assert!(error.to_string().contains("true or false"), "{error}");
+    }
+
+    #[test]
+    fn non_object_arguments_are_rejected() {
+        let error = Tool::Search.request(&json!([1, 2, 3])).unwrap_err();
+        assert!(
+            error.to_string().contains("must be a JSON object"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn schemas_declare_their_required_arguments() {
+        assert_eq!(Tool::Search.input_schema()["required"], json!(["query"]));
+        assert_eq!(Tool::Traverse.input_schema()["required"], json!(["entity"]));
+        assert_eq!(
+            Tool::Status.input_schema()["additionalProperties"],
+            json!(false)
+        );
+    }
+}

--- a/src/search.rs
+++ b/src/search.rs
@@ -11,6 +11,21 @@ const CYAN: &str = "\x1b[36m";
 const YELLOW: &str = "\x1b[33m";
 const RESET: &str = "\x1b[0m";
 
+/// Query tokens shorter than this never qualify a file on their own. They are
+/// almost always function words, and because matching is substring-based they
+/// also hit inside unrelated words ("i" matches every file ever written).
+const MIN_TOKEN_LEN: usize = 3;
+
+/// A token present in at least this share of the archive cannot tell one
+/// conversation from another, so it neither qualifies a file nor scores.
+/// Chosen above 0.5 so that a genuinely topical token — an entity that talks
+/// about one project in most of its sessions — survives.
+const DOCUMENT_FREQUENCY_CEILING: f64 = 0.8;
+
+/// Document frequency needs a corpus to mean anything: with two files every
+/// token sits at 0.0, 0.5 or 1.0, and the ceiling would discard real terms.
+const MIN_FILES_FOR_FREQUENCY_FILTER: usize = 5;
+
 pub struct SearchResult {
     pub file: String,
     pub line_num: usize,
@@ -23,6 +38,13 @@ pub struct RankedFile {
     pub match_count: usize,
     pub score: f64,
     pub preview_lines: Vec<String>,
+}
+
+/// One archive file, read once so document frequencies can be measured across
+/// the corpus before any file is scored.
+struct ArchiveFile {
+    name: String,
+    text: String,
 }
 
 pub fn run(query: &str, context_lines: usize) -> Result<(), RecallError> {
@@ -53,55 +75,45 @@ pub fn run(query: &str, context_lines: usize) -> Result<(), RecallError> {
 }
 
 /// Ranked search: returns files sorted by relevance score.
+///
+/// A file qualifies if it contains *any* discriminative query token — natural
+/// language questions always carry a token no single archive has, so requiring
+/// all of them returns nothing. Ranking then separates the wheat from the
+/// chaff: files matching more distinct tokens, more often, more recently,
+/// score higher.
 pub fn ranked_search(
     query: &str,
     base: &Path,
     max_results: usize,
 ) -> Result<Vec<RankedFile>, RecallError> {
-    let conversations_dir = base.join("conversations");
-    if !conversations_dir.exists() {
-        return Err(RecallError::NotInitialized(
-            "conversations/ directory not found. Run `recall-echo init` first.".into(),
-        ));
+    let files = read_archive_files(base)?;
+    let lowered: Vec<String> = files.iter().map(|f| f.text.to_lowercase()).collect();
+    let query_lower = query.to_lowercase();
+    let tokens = discriminative_tokens(&query_lower, &lowered);
+    if tokens.is_empty() {
+        return Ok(Vec::new());
     }
 
-    let query_lower = query.to_lowercase();
-    let query_words: Vec<&str> = query_lower.split_whitespace().collect();
+    let total_files = files.len();
     let mut ranked: Vec<RankedFile> = Vec::new();
 
-    let mut files: Vec<_> = fs::read_dir(&conversations_dir)?
-        .filter_map(|e| e.ok())
-        .filter(|e| {
-            let name = e.file_name();
-            let name = name.to_string_lossy();
-            name.starts_with("conversation-") && name.ends_with(".md")
-        })
-        .collect();
-    files.sort_by_key(|e| e.file_name());
-    let total_files = files.len();
-
-    for (idx, entry) in files.iter().enumerate() {
-        let content = match fs::read_to_string(entry.path()) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-        let content_lower = content.to_lowercase();
-        let filename = entry.file_name().to_string_lossy().to_string();
-
-        let all_words_present = query_words.iter().all(|w| content_lower.contains(w));
-        if !all_words_present {
+    for (idx, (file, content_lower)) in files.iter().zip(&lowered).enumerate() {
+        let hits: Vec<usize> = tokens
+            .iter()
+            .map(|t| content_lower.matches(t).count())
+            .collect();
+        let matched_tokens = hits.iter().filter(|&&n| n > 0).count();
+        if matched_tokens == 0 {
             continue;
         }
 
-        let match_count = content_lower.matches(&query_lower).count();
-        let word_match_count: usize = if query_words.len() > 1 {
-            query_words
-                .iter()
-                .map(|w| content_lower.matches(w).count())
-                .sum()
-        } else {
-            match_count
-        };
+        let word_match_count: usize = hits.iter().sum();
+
+        // Lucene's coordination factor: how much of the query this file covers.
+        // Under the old all-words gate every survivor covered the whole query,
+        // so this term is 1.0 for anything the previous implementation would
+        // have returned — it only separates the newly admitted partial matches.
+        let coverage = matched_tokens as f64 / tokens.len() as f64;
 
         let recency = if total_files > 1 {
             0.5 + 0.5 * (idx as f64 / (total_files - 1) as f64)
@@ -118,33 +130,13 @@ pub fn ranked_search(
             1.0
         };
 
-        let score = word_match_count as f64 * recency * content_boost;
-
-        let mut preview_lines = Vec::new();
-        for line in content.lines() {
-            if line.to_lowercase().contains(&query_lower)
-                || (query_words.len() > 1
-                    && query_words.iter().any(|w| line.to_lowercase().contains(w)))
-            {
-                let trimmed = line.trim();
-                if !trimmed.is_empty()
-                    && !trimmed.starts_with('#')
-                    && !trimmed.starts_with("---")
-                    && !trimmed.starts_with("```")
-                {
-                    preview_lines.push(trimmed.to_string());
-                    if preview_lines.len() >= 3 {
-                        break;
-                    }
-                }
-            }
-        }
+        let score = word_match_count as f64 * coverage * recency * content_boost;
 
         ranked.push(RankedFile {
-            file: filename,
+            file: file.name.clone(),
             match_count: word_match_count,
             score,
-            preview_lines,
+            preview_lines: preview_lines(&file.text, &query_lower, &tokens),
         });
     }
 
@@ -156,6 +148,120 @@ pub fn ranked_search(
     ranked.truncate(max_results);
 
     Ok(ranked)
+}
+
+/// Read every `conversation-NNN.md` under `base/conversations`, in filename
+/// order (which is chronological, and is what the recency term assumes).
+fn read_archive_files(base: &Path) -> Result<Vec<ArchiveFile>, RecallError> {
+    let conversations_dir = base.join("conversations");
+    if !conversations_dir.exists() {
+        return Err(RecallError::NotInitialized(
+            "conversations/ directory not found. Run `recall-echo init` first.".into(),
+        ));
+    }
+
+    let mut entries: Vec<_> = fs::read_dir(&conversations_dir)?
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            let name = e.file_name();
+            let name = name.to_string_lossy();
+            name.starts_with("conversation-") && name.ends_with(".md")
+        })
+        .collect();
+    entries.sort_by_key(|e| e.file_name());
+
+    Ok(entries
+        .iter()
+        .filter_map(|entry| {
+            fs::read_to_string(entry.path())
+                .ok()
+                .map(|text| ArchiveFile {
+                    name: entry.file_name().to_string_lossy().to_string(),
+                    text,
+                })
+        })
+        .collect())
+}
+
+/// The query tokens worth searching on, in query order and without duplicates.
+///
+/// Three filters, each falling back to the previous stage if it would leave
+/// nothing to search for:
+/// 1. outer punctuation stripped, so `bowl?` and `[current` match their words;
+/// 2. tokens under [`MIN_TOKEN_LEN`], or with no letter at all, dropped;
+/// 3. tokens above [`DOCUMENT_FREQUENCY_CEILING`] dropped — a corpus-derived
+///    stop list, which needs no hard-coded word list and works in any language.
+///
+/// `lowered` is the archive corpus, already lowercased, one entry per file.
+fn discriminative_tokens<'a>(query_lower: &'a str, lowered: &[String]) -> Vec<&'a str> {
+    let normalized = dedup_preserving_order(
+        query_lower
+            .split_whitespace()
+            .map(|w| w.trim_matches(|c: char| !c.is_alphanumeric()))
+            .filter(|w| !w.is_empty()),
+    );
+
+    let meaningful: Vec<&str> = normalized
+        .iter()
+        .copied()
+        .filter(|w| w.chars().count() >= MIN_TOKEN_LEN && w.chars().any(char::is_alphabetic))
+        .collect();
+    let meaningful = if meaningful.is_empty() {
+        normalized
+    } else {
+        meaningful
+    };
+
+    if lowered.len() < MIN_FILES_FOR_FREQUENCY_FILTER {
+        return meaningful;
+    }
+
+    let ceiling = DOCUMENT_FREQUENCY_CEILING * lowered.len() as f64;
+    let discriminative: Vec<&str> = meaningful
+        .iter()
+        .copied()
+        .filter(|token| {
+            let document_frequency = lowered.iter().filter(|text| text.contains(token)).count();
+            (document_frequency as f64) < ceiling
+        })
+        .collect();
+
+    if discriminative.is_empty() {
+        meaningful
+    } else {
+        discriminative
+    }
+}
+
+fn dedup_preserving_order<'a>(tokens: impl Iterator<Item = &'a str>) -> Vec<&'a str> {
+    let mut seen = std::collections::HashSet::new();
+    tokens.filter(|t| seen.insert(*t)).collect()
+}
+
+/// Up to three prose lines from the file that carry the query phrase or one of
+/// its tokens. Headings, rules and fences are skipped: they are archive
+/// structure, not conversation content.
+fn preview_lines(content: &str, query_lower: &str, tokens: &[&str]) -> Vec<String> {
+    let mut previews = Vec::new();
+    for line in content.lines() {
+        let line_lower = line.to_lowercase();
+        if !line_lower.contains(query_lower) && !tokens.iter().any(|t| line_lower.contains(t)) {
+            continue;
+        }
+        let trimmed = line.trim();
+        if trimmed.is_empty()
+            || trimmed.starts_with('#')
+            || trimmed.starts_with("---")
+            || trimmed.starts_with("```")
+        {
+            continue;
+        }
+        previews.push(trimmed.to_string());
+        if previews.len() >= 3 {
+            break;
+        }
+    }
+    previews
 }
 
 /// Run ranked search and display results.
@@ -351,5 +457,137 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let result = search_with_base("test", tmp.path(), 0);
         assert!(result.is_err());
+    }
+
+    // ── ranked_search ────────────────────────────────────────────────────
+
+    /// Write `contents[i]` as `conversation-{i+1:03}.md` and return the base.
+    fn archive_with(contents: &[&str]) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let conv_dir = tmp.path().join("conversations");
+        fs::create_dir_all(&conv_dir).unwrap();
+        for (i, body) in contents.iter().enumerate() {
+            fs::write(conv_dir.join(format!("conversation-{:03}.md", i + 1)), body).unwrap();
+        }
+        tmp
+    }
+
+    fn ranked_files(results: &[RankedFile]) -> Vec<&str> {
+        results.iter().map(|r| r.file.as_str()).collect()
+    }
+
+    /// The defect this replaces: `ranked_search` required *every* whitespace
+    /// token to be present, so a natural-language question carrying a date
+    /// prefix and punctuation matched nothing at all. Partial matches must now
+    /// come back.
+    #[test]
+    fn ranked_search_admits_partial_token_matches() {
+        let tmp = archive_with(&[
+            "### User\n\nI tried a new barbecue sauce today.\n",
+            "### User\n\nMy favourite barbecue sauce is Kansas City Masterpiece.\n",
+            "### User\n\nWe talked about bicycle maintenance.\n",
+        ]);
+
+        let results = ranked_search(
+            "[Current date: 2023-05-30T15:43:00Z] What is my favourite barbecue sauce?",
+            tmp.path(),
+            5,
+        )
+        .unwrap();
+
+        assert_eq!(
+            ranked_files(&results)[0],
+            "conversation-002.md",
+            "the file covering the most query tokens must rank first"
+        );
+        assert!(
+            ranked_files(&results).contains(&"conversation-001.md"),
+            "a file matching only some tokens must still be returned"
+        );
+    }
+
+    /// Outer punctuation must not be part of the token: `sauce?` has to match
+    /// `sauce`.
+    #[test]
+    fn ranked_search_strips_punctuation_from_tokens() {
+        let tmp = archive_with(&["### User\n\nThe barbecue sauce was excellent.\n"]);
+        let results = ranked_search("barbecue sauce?", tmp.path(), 5).unwrap();
+        assert_eq!(results.len(), 1);
+        assert!(results[0].match_count >= 2);
+    }
+
+    /// Covering more distinct query tokens beats repeating one of them at the
+    /// same raw match count — enough to overcome a recency disadvantage.
+    #[test]
+    fn ranked_search_prefers_broader_token_coverage() {
+        let tmp = archive_with(&[
+            "sourdough baguette convection\n",
+            "sourdough sourdough sourdough\n",
+        ]);
+
+        let results = ranked_search("sourdough baguette convection", tmp.path(), 5).unwrap();
+        assert_eq!(results[0].match_count, results[1].match_count);
+        assert_eq!(ranked_files(&results)[0], "conversation-001.md");
+    }
+
+    /// A token in every archive discriminates nothing, so it must not qualify
+    /// files on its own. Needs at least MIN_FILES_FOR_FREQUENCY_FILTER files
+    /// for document frequency to be measurable.
+    #[test]
+    fn ranked_search_ignores_corpus_wide_tokens() {
+        let mut bodies = vec!["### User\n\nToday the weather was fine.\n"; 5];
+        bodies.push("### User\n\nToday the weather was fine and I bought emerald earrings.\n");
+        let tmp = archive_with(&bodies);
+
+        let results =
+            ranked_search("Today what about the emerald earrings", tmp.path(), 10).unwrap();
+
+        assert_eq!(
+            ranked_files(&results),
+            vec!["conversation-006.md"],
+            "only `emerald`/`earrings` discriminate; `today`, `the` and `about` are everywhere"
+        );
+    }
+
+    /// Nothing shared with the corpus still means no results — OR-matching
+    /// loosens the gate, it does not remove it.
+    #[test]
+    fn ranked_search_returns_nothing_without_a_token_match() {
+        let tmp = archive_with(&["### User\n\nWe discussed rust lifetimes.\n"]);
+        let results = ranked_search("photosynthesis chlorophyll", tmp.path(), 5).unwrap();
+        assert!(results.is_empty());
+    }
+
+    /// A query made entirely of sub-MIN_TOKEN_LEN words must fall back to those
+    /// words rather than degrade to "no discriminative tokens, no results".
+    #[test]
+    fn ranked_search_falls_back_to_short_tokens() {
+        let tmp = archive_with(&["### User\n\nThe ok signal arrived.\n"]);
+        let results = ranked_search("ok", tmp.path(), 5).unwrap();
+        assert_eq!(results.len(), 1);
+    }
+
+    #[test]
+    fn ranked_search_honours_max_results() {
+        let tmp = archive_with(&[
+            "### User\n\nbarbecue one\n",
+            "### User\n\nbarbecue two\n",
+            "### User\n\nbarbecue three\n",
+        ]);
+        let results = ranked_search("barbecue", tmp.path(), 2).unwrap();
+        assert_eq!(results.len(), 2);
+    }
+
+    #[test]
+    fn ranked_search_previews_only_prose() {
+        let tmp = archive_with(&["# Conversation 001\n\n---\n\n### User\n\nbarbecue sauce here\n"]);
+        let results = ranked_search("barbecue", tmp.path(), 5).unwrap();
+        assert_eq!(results[0].preview_lines, vec!["barbecue sauce here"]);
+    }
+
+    #[test]
+    fn ranked_search_missing_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(ranked_search("anything", tmp.path(), 5).is_err());
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -56,6 +56,9 @@ const MAX_DEPTH: u32 = 8;
 const STORE_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
 /// Polling interval while waiting for connection tasks to release the store.
 const STORE_RELEASE_POLL: Duration = Duration::from_millis(10);
+/// How long the daemon waits for the background extraction worker to stop
+/// before abandoning it and closing up anyway.
+const WORKER_STOP_TIMEOUT: Duration = Duration::from_secs(5);
 
 // ── Protocol ─────────────────────────────────────────────────────────────
 
@@ -301,6 +304,9 @@ fn error_code(err: &GraphError) -> &'static str {
 }
 
 /// Identity of a running daemon, returned by [`Request::Hello`].
+///
+/// `extraction` is additive: a client talking to a daemon that predates
+/// background extraction simply sees the default (disabled, nothing done).
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct DaemonInfo {
     pub version: String,
@@ -308,6 +314,28 @@ pub struct DaemonInfo {
     pub memory_dir: String,
     pub socket_path: String,
     pub uptime_secs: u64,
+    #[serde(default)]
+    pub extraction: ExtractionStatus,
+}
+
+/// What this daemon's background extraction worker has done so far.
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct ExtractionStatus {
+    /// Whether background extraction is running in this daemon.
+    pub enabled: bool,
+    /// Why it is not running, when it is not.
+    pub disabled_reason: Option<String>,
+    /// Batches that extracted at least one archive.
+    pub runs: u64,
+    /// Archives extracted since the daemon started.
+    pub archives: u64,
+    /// Seconds since the last batch finished.
+    pub last_run_secs_ago: Option<u64>,
+    /// How long the last batch took.
+    pub last_run_ms: Option<u64>,
+    /// The most recent extraction failure, if any.
+    pub last_error: Option<String>,
 }
 
 // ── Dispatch ─────────────────────────────────────────────────────────────
@@ -441,15 +469,25 @@ async fn execute_graph(
 
 // ── Idle tracking ────────────────────────────────────────────────────────
 
-/// Tracks daemon activity so an unused daemon shuts itself down.
+/// Tracks daemon activity so an unused daemon shuts itself down, and so
+/// background work only runs while nobody is asking for anything.
 ///
-/// A daemon is idle when no connection is open *and* the last completed
-/// request is older than the configured timeout. `None` disables idle
-/// shutdown entirely (`--foreground`, or `idle_timeout_secs = 0`).
+/// Two different questions are asked of the same clock:
+///
+/// - *quiet* — no connection is open and the last request is older than some
+///   period. Background extraction waits for this.
+/// - *idle* — quiet for the configured shutdown timeout, **and** no background
+///   batch in flight. The accept loop exits on this.
+///
+/// A background batch therefore cannot be cut in half by the idle timeout, and
+/// a hot request always makes the daemon un-quiet immediately. `None` disables
+/// idle shutdown entirely (`--foreground`, or `idle_timeout_secs = 0`) without
+/// disabling quiet, which is what keeps a supervised daemon extracting.
 #[derive(Debug)]
 pub struct IdleTracker {
     timeout: Option<Duration>,
     active: AtomicUsize,
+    background: AtomicUsize,
     last_activity: Mutex<Instant>,
 }
 
@@ -465,6 +503,7 @@ impl IdleTracker {
         Self {
             timeout,
             active: AtomicUsize::new(0),
+            background: AtomicUsize::new(0),
             last_activity: Mutex::new(start),
         }
     }
@@ -482,6 +521,18 @@ impl IdleTracker {
         self.touch_at(Instant::now());
     }
 
+    /// Register a background batch as running. Holds off idle shutdown until
+    /// it finishes, without pretending the daemon is being used.
+    pub fn begin_background(&self) {
+        self.background.fetch_add(1, Ordering::SeqCst);
+    }
+
+    /// Register a background batch as finished.
+    pub fn end_background(&self) {
+        let previous = self.background.fetch_sub(1, Ordering::SeqCst);
+        debug_assert!(previous > 0, "IdleTracker::end_background without begin");
+    }
+
     /// Record activity at `now`.
     pub fn touch_at(&self, now: Instant) {
         let mut last = self
@@ -491,20 +542,43 @@ impl IdleTracker {
         *last = now;
     }
 
-    /// True when the daemon has been unused for longer than the timeout.
+    /// True while at least one client connection is open.
     #[must_use]
-    pub fn is_idle_at(&self, now: Instant) -> bool {
-        let Some(timeout) = self.timeout else {
-            return false;
-        };
-        if self.active.load(Ordering::SeqCst) > 0 {
+    pub fn has_connections(&self) -> bool {
+        self.active.load(Ordering::SeqCst) > 0
+    }
+
+    /// True when no connection is open and nothing has been asked of the
+    /// daemon for `quiet`.
+    #[must_use]
+    pub fn is_quiet_at(&self, now: Instant, quiet: Duration) -> bool {
+        if self.has_connections() {
             return false;
         }
         let last = *self
             .last_activity
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
-        now.saturating_duration_since(last) >= timeout
+        now.saturating_duration_since(last) >= quiet
+    }
+
+    /// True when the daemon has been unused for longer than the timeout and no
+    /// background batch is in flight.
+    #[must_use]
+    pub fn is_idle_at(&self, now: Instant) -> bool {
+        let Some(timeout) = self.timeout else {
+            return false;
+        };
+        if self.background.load(Ordering::SeqCst) > 0 {
+            return false;
+        }
+        self.is_quiet_at(now, timeout)
+    }
+
+    /// The configured idle shutdown timeout, if any.
+    #[must_use]
+    pub fn timeout(&self) -> Option<Duration> {
+        self.timeout
     }
 
     /// How often the accept loop should re-check idleness.
@@ -530,6 +604,168 @@ impl ActivityGuard {
 impl Drop for ActivityGuard {
     fn drop(&mut self) {
         self.0.idle.end();
+    }
+}
+
+/// RAII background-batch counter for [`IdleTracker`].
+///
+/// Held for exactly one batch, so an interrupted daemon waits for the unit in
+/// flight rather than for the whole backlog.
+pub struct BackgroundGuard(Arc<IdleTracker>);
+
+impl BackgroundGuard {
+    #[must_use]
+    pub fn new(idle: Arc<IdleTracker>) -> Self {
+        idle.begin_background();
+        Self(idle)
+    }
+}
+
+impl Drop for BackgroundGuard {
+    fn drop(&mut self) {
+        self.0.end_background();
+    }
+}
+
+// ── Shutdown ─────────────────────────────────────────────────────────────
+
+/// One-way "stop now" signal, observable by any number of tasks.
+///
+/// A latched flag rather than a bare [`Notify`]: a task that checks after the
+/// signal fired must still see it, or a worker between two units would sleep
+/// through the daemon's exit and hold the store open.
+#[derive(Debug, Default)]
+pub struct ShutdownSignal {
+    triggered: std::sync::atomic::AtomicBool,
+    notify: Notify,
+}
+
+impl ShutdownSignal {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Ask everything watching to stop. Idempotent.
+    pub fn trigger(&self) {
+        self.triggered.store(true, Ordering::SeqCst);
+        self.notify.notify_waiters();
+    }
+
+    #[must_use]
+    pub fn is_triggered(&self) -> bool {
+        self.triggered.load(Ordering::SeqCst)
+    }
+
+    /// Resolve when shutdown is requested — immediately if it already was.
+    pub async fn wait(&self) {
+        loop {
+            // Register before reading the flag: the reverse order loses a
+            // `trigger` that lands in between, and the waiter never wakes.
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.is_triggered() {
+                return;
+            }
+            notified.await;
+        }
+    }
+
+    /// Run `future` unless shutdown arrives first. `None` means it did.
+    pub async fn guard<F: std::future::Future>(&self, future: F) -> Option<F::Output> {
+        tokio::select! {
+            biased;
+            () = self.wait() => None,
+            output = future => Some(output),
+        }
+    }
+
+    /// Sleep for `duration`. `true` means shutdown cut it short.
+    pub async fn sleep_until_stopped(&self, duration: Duration) -> bool {
+        self.guard(tokio::time::sleep(duration)).await.is_none()
+    }
+}
+
+// ── Background extraction state ──────────────────────────────────────────
+
+/// What the background extraction worker has done, shared with the connection
+/// tasks that answer [`Request::Hello`].
+#[derive(Debug, Default)]
+pub struct ExtractionState {
+    inner: Mutex<ExtractionProgress>,
+}
+
+#[derive(Debug, Default)]
+struct ExtractionProgress {
+    enabled: bool,
+    disabled_reason: Option<String>,
+    runs: u64,
+    archives: u64,
+    last_run: Option<Instant>,
+    last_run_ms: Option<u64>,
+    last_error: Option<String>,
+}
+
+impl ExtractionState {
+    #[must_use]
+    pub fn shared() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn with<T>(&self, apply: impl FnOnce(&mut ExtractionProgress) -> T) -> T {
+        let mut progress = self
+            .inner
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        apply(&mut progress)
+    }
+
+    /// Mark the worker as running.
+    pub fn enable(&self) {
+        self.with(|progress| {
+            progress.enabled = true;
+            progress.disabled_reason = None;
+        });
+    }
+
+    /// Mark the worker as not running, and why.
+    pub fn disable(&self, reason: impl Into<String>) {
+        self.with(|progress| {
+            progress.enabled = false;
+            progress.disabled_reason = Some(reason.into());
+        });
+    }
+
+    /// Record a batch that extracted `archives` archives in `elapsed`.
+    pub fn record_batch(&self, archives: u64, elapsed: Duration, finished_at: Instant) {
+        self.with(|progress| {
+            progress.runs += 1;
+            progress.archives += archives;
+            progress.last_run = Some(finished_at);
+            progress.last_run_ms = Some(elapsed.as_millis() as u64);
+        });
+    }
+
+    /// Record the most recent failure, replacing any earlier one.
+    pub fn record_error(&self, error: impl Into<String>) {
+        self.with(|progress| progress.last_error = Some(error.into()));
+    }
+
+    /// Wire-facing snapshot as of `now`.
+    #[must_use]
+    pub fn snapshot(&self, now: Instant) -> ExtractionStatus {
+        self.with(|progress| ExtractionStatus {
+            enabled: progress.enabled,
+            disabled_reason: progress.disabled_reason.clone(),
+            runs: progress.runs,
+            archives: progress.archives,
+            last_run_secs_ago: progress
+                .last_run
+                .map(|at| now.saturating_duration_since(at).as_secs()),
+            last_run_ms: progress.last_run_ms,
+            last_error: progress.last_error.clone(),
+        })
     }
 }
 
@@ -619,8 +855,9 @@ struct DaemonContext {
     socket_path: PathBuf,
     /// Only this uid may use the socket.
     owner_uid: u32,
-    idle: IdleTracker,
-    shutdown: Notify,
+    idle: Arc<IdleTracker>,
+    shutdown: Arc<ShutdownSignal>,
+    extraction: Arc<ExtractionState>,
 }
 
 impl DaemonContext {
@@ -631,6 +868,7 @@ impl DaemonContext {
             memory_dir: self.memory_dir.display().to_string(),
             socket_path: self.socket_path.display().to_string(),
             uptime_secs: self.started.elapsed().as_secs(),
+            extraction: self.extraction.snapshot(Instant::now()),
         }
     }
 }
@@ -678,15 +916,18 @@ pub async fn run(options: ServeOptions) -> Result<(), RecallError> {
     };
     write_pidfile(&options.socket_path)?;
 
+    let extraction = ExtractionState::shared();
     let context = Arc::new(DaemonContext {
         started: Instant::now(),
         memory_dir: options.memory_dir.clone(),
         socket_path: options.socket_path.clone(),
         owner_uid,
-        idle: IdleTracker::new(options.idle_timeout),
-        shutdown: Notify::new(),
+        idle: Arc::new(IdleTracker::new(options.idle_timeout)),
+        shutdown: Arc::new(ShutdownSignal::new()),
+        extraction: Arc::clone(&extraction),
     });
     warm_embedder(Arc::clone(&graph), Arc::clone(&log));
+    let worker = start_background_extraction(&options, &graph, &context, &log);
     log.log("ready");
 
     accept_loop(
@@ -696,6 +937,12 @@ pub async fn run(options: ServeOptions) -> Result<(), RecallError> {
         Arc::clone(&log),
     )
     .await;
+
+    // Whatever ended the accept loop — a shutdown request, an idle timeout —
+    // ends the background worker too, and it must let go of the store before
+    // we try to close it.
+    context.shutdown.trigger();
+    stop_background_extraction(worker, &log).await;
 
     // Close the store *before* the socket disappears: a client waiting for the
     // socket to go treats that as "the store is free", and would otherwise
@@ -779,6 +1026,58 @@ fn warm_embedder(graph: Arc<GraphMemory>, log: Arc<DaemonLog>) {
     });
 }
 
+/// Start the background extraction worker, when this build and this config
+/// allow one. `None` means no worker runs; the reason is in the log and in
+/// [`ExtractionStatus::disabled_reason`].
+#[cfg(feature = "llm")]
+fn start_background_extraction(
+    options: &ServeOptions,
+    graph: &Arc<GraphMemory>,
+    context: &Arc<DaemonContext>,
+    log: &Arc<DaemonLog>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    crate::serve_extract::spawn(crate::serve_extract::Setup {
+        memory_dir: options.memory_dir.clone(),
+        graph: Arc::clone(graph),
+        idle: Arc::clone(&context.idle),
+        shutdown: Arc::clone(&context.shutdown),
+        state: Arc::clone(&context.extraction),
+        log: Arc::clone(log),
+    })
+}
+
+#[cfg(not(feature = "llm"))]
+fn start_background_extraction(
+    _options: &ServeOptions,
+    _graph: &Arc<GraphMemory>,
+    context: &Arc<DaemonContext>,
+    log: &Arc<DaemonLog>,
+) -> Option<tokio::task::JoinHandle<()>> {
+    context
+        .extraction
+        .disable("this binary was built without the `llm` feature");
+    log.log("background extraction off: built without the `llm` feature");
+    None
+}
+
+/// Wait for the background worker to let go of the store, then take it away.
+///
+/// The worker stops between units on its own; the timeout covers the case
+/// where it is inside a synchronous stretch (the ONNX embedder) that no
+/// cancellation point can interrupt.
+async fn stop_background_extraction(worker: Option<tokio::task::JoinHandle<()>>, log: &DaemonLog) {
+    let Some(mut worker) = worker else {
+        return;
+    };
+    if tokio::time::timeout(WORKER_STOP_TIMEOUT, &mut worker)
+        .await
+        .is_err()
+    {
+        worker.abort();
+        log.log("background extraction did not stop in time — abandoned mid-archive");
+    }
+}
+
 fn has_cached_model(models_dir: &Path) -> bool {
     std::fs::read_dir(models_dir).is_ok_and(|mut entries| entries.next().is_some())
 }
@@ -803,7 +1102,7 @@ async fn accept_loop(
                 }
                 Err(err) => log.log(&format!("accept error: {err}")),
             },
-            () = context.shutdown.notified() => {
+            () = context.shutdown.wait() => {
                 log.log("shutdown requested");
                 break;
             }
@@ -893,10 +1192,10 @@ async fn handle_connection(
         context.idle.touch_at(Instant::now());
 
         if stop {
-            // `notify_one` stores a permit when the accept loop happens to be
-            // between `select!` iterations; `notify_waiters` would be lost
-            // there and the daemon would outlive the shutdown request.
-            context.shutdown.notify_one();
+            // The signal latches, so a wakeup that lands while the accept loop
+            // is between `select!` iterations is still seen on the next one:
+            // the daemon can never outlive its own shutdown request.
+            context.shutdown.trigger();
             break;
         }
     }
@@ -1223,6 +1522,114 @@ mod tests {
         tracker.touch_at(start + Duration::from_secs(9));
         assert!(!tracker.is_idle_at(start + Duration::from_secs(18)));
         assert!(tracker.is_idle_at(start + Duration::from_secs(19)));
+    }
+
+    /// A background batch must not be cut in half by the idle timeout — and
+    /// must not postpone shutdown once it is done, or the daemon would never
+    /// exit again.
+    #[test]
+    fn a_batch_in_flight_defers_idle_shutdown() {
+        let start = Instant::now();
+        let tracker = Arc::new(IdleTracker::new_at(Some(Duration::from_secs(60)), start));
+        let later = start + Duration::from_secs(600);
+        assert!(tracker.is_idle_at(later));
+
+        let guard = BackgroundGuard::new(Arc::clone(&tracker));
+        assert!(!tracker.is_idle_at(later), "idle exit cut a batch in half");
+        // Background work is not activity: the daemon is still unused, which
+        // is what lets the *next* batch start.
+        assert!(tracker.is_quiet_at(later, Duration::from_secs(60)));
+
+        drop(guard);
+        assert!(tracker.is_idle_at(later));
+    }
+
+    /// `--foreground` disables idle shutdown, not background work: a
+    /// supervised daemon still has quiet periods to extract in.
+    #[test]
+    fn quiet_is_independent_of_the_idle_timeout() {
+        let start = Instant::now();
+        let tracker = IdleTracker::new_at(None, start);
+        let later = start + Duration::from_secs(300);
+
+        assert!(!tracker.is_idle_at(later));
+        assert!(tracker.is_quiet_at(later, Duration::from_secs(120)));
+    }
+
+    #[test]
+    fn an_open_connection_is_never_quiet() {
+        let start = Instant::now();
+        let tracker = IdleTracker::new_at(Some(Duration::from_secs(60)), start);
+        let later = start + Duration::from_secs(600);
+
+        tracker.begin();
+        assert!(tracker.has_connections());
+        assert!(!tracker.is_quiet_at(later, Duration::from_secs(1)));
+
+        tracker.end();
+        tracker.touch_at(start);
+        assert!(tracker.is_quiet_at(later, Duration::from_secs(1)));
+    }
+
+    /// The signal latches: a task that checks after it fired still sees it.
+    /// Without that, a worker between two units sleeps through the daemon's
+    /// exit and keeps the store open.
+    #[tokio::test]
+    async fn the_shutdown_signal_latches_for_late_waiters() {
+        let signal = ShutdownSignal::new();
+        assert!(!signal.is_triggered());
+        signal.trigger();
+        assert!(signal.is_triggered());
+
+        tokio::time::timeout(Duration::from_secs(5), signal.wait())
+            .await
+            .expect("a waiter that arrives after the trigger still wakes");
+        assert!(signal.guard(std::future::pending::<()>()).await.is_none());
+        assert!(signal.sleep_until_stopped(Duration::from_secs(600)).await);
+    }
+
+    #[tokio::test]
+    async fn the_shutdown_signal_lets_work_finish_when_it_is_not_triggered() {
+        let signal = ShutdownSignal::new();
+        assert_eq!(signal.guard(async { 7 }).await, Some(7));
+        assert!(!signal.sleep_until_stopped(Duration::from_millis(1)).await);
+    }
+
+    #[test]
+    fn extraction_status_reports_progress_and_refusals() {
+        let state = ExtractionState::shared();
+        let now = Instant::now();
+        assert!(!state.snapshot(now).enabled);
+
+        state.enable();
+        state.record_batch(3, Duration::from_millis(250), now);
+        let status = state.snapshot(now + Duration::from_secs(9));
+        assert!(status.enabled);
+        assert_eq!(status.runs, 1);
+        assert_eq!(status.archives, 3);
+        assert_eq!(status.last_run_secs_ago, Some(9));
+        assert_eq!(status.last_run_ms, Some(250));
+
+        state.disable("no usable LLM provider");
+        let status = state.snapshot(now);
+        assert!(!status.enabled);
+        assert_eq!(
+            status.disabled_reason.as_deref(),
+            Some("no usable LLM provider")
+        );
+        // What it managed to do before it stopped is still worth reporting.
+        assert_eq!(status.archives, 3);
+    }
+
+    /// A client built before background extraction sends no `extraction` field.
+    #[test]
+    fn daemon_info_without_extraction_still_parses() {
+        let info: DaemonInfo = serde_json::from_str(
+            r#"{"version":"3.0.0","pid":1,"memory_dir":"/m","socket_path":"/s","uptime_secs":5}"#,
+        )
+        .expect("older daemon info");
+        assert_eq!(info.extraction, ExtractionStatus::default());
+        assert!(!info.extraction.enabled);
     }
 
     #[test]

--- a/src/serve_extract.rs
+++ b/src/serve_extract.rs
@@ -1,0 +1,616 @@
+//! Background entity extraction inside the graph daemon.
+//!
+//! recall-echo's claim is that the memory lifecycle is mechanical rather than
+//! on the honor system. That was true of episodes — `SessionEnd` ingests them
+//! through a hook — and false of everything built on top of them: entities,
+//! relationships, confidence and provenance only appeared when a human
+//! remembered to run `recall-echo graph extract`. This module closes that gap.
+//!
+//! The daemon is the natural home for the pass: it is already long-lived, it
+//! already owns the embedded store, and it already knows when nobody is using
+//! it. Once the machine has been quiet for `[extraction] idle_after_secs`, the
+//! worker takes a small batch of un-extracted archives and runs the *same*
+//! extraction the CLI runs — this module decides *when* extraction happens,
+//! never *how*.
+//!
+//! Discipline:
+//!
+//! - **No lock is held across a batch.** The worker shares the daemon's
+//!   `Arc<GraphMemory>` like any connection task; a request that arrives is
+//!   served concurrently, and the batch stops at the next unit boundary.
+//! - **Crash-only, per unit.** `extracted` flips one archive at a time, after
+//!   that archive's extraction succeeded, so an interrupted batch leaves a
+//!   store that simply has work left to do.
+//! - **Shutdown wins.** Every wait and every unit runs under
+//!   [`ShutdownSignal`], so an admin operation taking the store never waits for
+//!   a batch to finish.
+
+use std::collections::{HashMap, HashSet};
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+
+use crate::config::ExtractionSection;
+use crate::graph::error::GraphError;
+use crate::graph::llm::LlmProvider;
+use crate::graph::{GraphMemory, IngestContext};
+use crate::serve::{BackgroundGuard, DaemonLog, ExtractionState, IdleTracker, ShutdownSignal};
+
+/// Longest the worker sleeps between quiet checks.
+const MAX_POLL: Duration = Duration::from_secs(30);
+/// Shortest it sleeps, so a short `idle_after_secs` stays responsive without
+/// spinning.
+const MIN_POLL: Duration = Duration::from_millis(100);
+/// Attempts one archive gets before it is quarantined. The CLI uses the same
+/// rule: one retry, then set it aside rather than retry it forever.
+const MAX_UNIT_ATTEMPTS: u32 = 2;
+/// Consecutive failed units before the worker concludes the provider is wedged
+/// and stops for the daemon's remaining life.
+const MAX_CONSECUTIVE_FAILURES: u32 = 3;
+
+// ── Clock ────────────────────────────────────────────────────────────────
+
+/// Source of the current instant. Injectable so scheduling can be tested
+/// without waiting for real time to pass.
+pub trait Clock: Send + Sync {
+    fn now(&self) -> Instant;
+}
+
+/// The real clock.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct SystemClock;
+
+impl Clock for SystemClock {
+    fn now(&self) -> Instant {
+        Instant::now()
+    }
+}
+
+// ── The unit of work ─────────────────────────────────────────────────────
+
+/// What one background batch did to one archive.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct UnitReport {
+    pub entities: u32,
+    pub relationships: u32,
+}
+
+/// One archive's worth of extraction, as the scheduler sees it.
+///
+/// Kept behind a trait so the worker's scheduling — when it waits, when it
+/// yields, when it stops — can be exercised without a store or a model.
+#[async_trait]
+pub trait ExtractionUnit: Send + Sync {
+    /// Log numbers still awaiting extraction, at most `limit` of them.
+    async fn pending(&self, limit: usize) -> Result<Vec<u32>, GraphError>;
+
+    /// Extract one archive and mark it extracted. Marking is the last thing it
+    /// does, so a failure or an interruption leaves the archive pending.
+    async fn extract(&self, log_number: u32) -> Result<UnitReport, GraphError>;
+
+    /// Stop offering this archive: it has failed [`MAX_UNIT_ATTEMPTS`] times.
+    async fn quarantine(&self, log_number: u32, reason: &str);
+}
+
+// ── Schedule ─────────────────────────────────────────────────────────────
+
+/// When and how much the worker extracts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Schedule {
+    /// Quiet period before a batch may start.
+    pub idle_after: Duration,
+    /// Archives per batch.
+    pub batch_size: usize,
+    /// How often the worker re-checks whether the daemon is quiet.
+    pub poll_interval: Duration,
+}
+
+impl Schedule {
+    /// The schedule described by an `[extraction]` section.
+    #[must_use]
+    pub fn from_config(config: &ExtractionSection) -> Self {
+        let idle_after = config.idle_after();
+        Self {
+            idle_after,
+            batch_size: config.effective_batch_size(),
+            poll_interval: (idle_after / 4).clamp(MIN_POLL, MAX_POLL),
+        }
+    }
+}
+
+/// Whether background extraction should run at all in this daemon.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Plan {
+    /// Run, on this schedule.
+    Run(Schedule),
+    /// Do not run, for this reason.
+    Off(String),
+}
+
+/// Decide whether this daemon extracts in the background.
+///
+/// `graph_mode` is the `[graph] mode` of the memory directory. Server mode is
+/// refused deliberately: there, clients talk to SurrealDB directly and never
+/// start or consult a daemon, so a daemon's idea of "quiet" is not a fact
+/// about the user's activity at all — it is a fact about a socket nobody is
+/// connected to. A worker there would extract continuously, against a store
+/// other processes are writing to, on behalf of a user who has no reason to
+/// know the daemon exists. `graph extract` remains the way to extract in
+/// server mode.
+#[must_use]
+pub fn plan(config: &ExtractionSection, graph_mode: &str) -> Plan {
+    if !config.background_enabled {
+        return Plan::Off("[extraction] background_enabled = false".into());
+    }
+    if graph_mode == "server" {
+        return Plan::Off("[graph] mode = \"server\" — use `graph extract`".into());
+    }
+    Plan::Run(Schedule::from_config(config))
+}
+
+// ── Worker ───────────────────────────────────────────────────────────────
+
+/// Everything the worker shares with the rest of the daemon.
+pub struct WorkerContext {
+    pub idle: Arc<IdleTracker>,
+    pub shutdown: Arc<ShutdownSignal>,
+    pub state: Arc<ExtractionState>,
+    pub log: Arc<DaemonLog>,
+    pub clock: Arc<dyn Clock>,
+}
+
+/// How a batch ended.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum BatchOutcome {
+    /// Nothing to extract.
+    NoWork,
+    /// At least one archive was extracted.
+    Worked,
+    /// Shutdown arrived.
+    Stopped,
+    /// The provider has failed too many times in a row.
+    Wedged,
+}
+
+/// The background extraction loop.
+pub struct ExtractionWorker {
+    schedule: Schedule,
+    context: WorkerContext,
+    /// Failed attempts per log number, within this daemon's life.
+    attempts: HashMap<u32, u32>,
+    /// Log numbers this daemon has given up on.
+    skipped: HashSet<u32>,
+    consecutive_failures: u32,
+}
+
+impl ExtractionWorker {
+    #[must_use]
+    pub fn new(schedule: Schedule, context: WorkerContext) -> Self {
+        Self {
+            schedule,
+            context,
+            attempts: HashMap::new(),
+            skipped: HashSet::new(),
+            consecutive_failures: 0,
+        }
+    }
+
+    /// Extract in the background until the daemon shuts down.
+    pub async fn run(mut self, unit: Arc<dyn ExtractionUnit>) {
+        self.context.state.enable();
+        loop {
+            if self
+                .context
+                .shutdown
+                .sleep_until_stopped(self.schedule.poll_interval)
+                .await
+            {
+                break;
+            }
+            if !self.is_quiet() {
+                continue;
+            }
+            match self.run_batch(unit.as_ref()).await {
+                BatchOutcome::NoWork | BatchOutcome::Worked => {}
+                BatchOutcome::Stopped => break,
+                BatchOutcome::Wedged => {
+                    let reason = format!(
+                        "extraction failed {MAX_CONSECUTIVE_FAILURES} times in a row — \
+                         not retrying until the daemon restarts"
+                    );
+                    self.context
+                        .log
+                        .log(&format!("background extraction off: {reason}"));
+                    self.context.state.disable(reason);
+                    return;
+                }
+            }
+        }
+        self.context.state.disable("daemon stopping");
+    }
+
+    fn is_quiet(&self) -> bool {
+        self.context
+            .idle
+            .is_quiet_at(self.context.clock.now(), self.schedule.idle_after)
+    }
+
+    /// Extract up to `batch_size` archives, yielding between each.
+    async fn run_batch(&mut self, unit: &dyn ExtractionUnit) -> BatchOutcome {
+        let pending = match self.take_pending(unit).await {
+            Some(pending) if !pending.is_empty() => pending,
+            Some(_) => return BatchOutcome::NoWork,
+            None => return BatchOutcome::Stopped,
+        };
+
+        // From here on the daemon may not idle-exit: the batch is in flight.
+        let _busy = BackgroundGuard::new(Arc::clone(&self.context.idle));
+        let started = self.context.clock.now();
+        let mut extracted = 0u64;
+        let mut outcome = BatchOutcome::Worked;
+
+        for log_number in pending {
+            if self.context.shutdown.is_triggered() {
+                outcome = BatchOutcome::Stopped;
+                break;
+            }
+            // A hot request beats background work, always. The rest of the
+            // batch waits for the next quiet period.
+            if self.context.idle.has_connections() {
+                break;
+            }
+
+            match self.context.shutdown.guard(unit.extract(log_number)).await {
+                None => {
+                    outcome = BatchOutcome::Stopped;
+                    break;
+                }
+                Some(Ok(report)) => {
+                    extracted += 1;
+                    self.consecutive_failures = 0;
+                    self.attempts.remove(&log_number);
+                    self.context.log.log(&format!(
+                        "extracted log {log_number:03} in the background: \
+                         +{} entities, {} relationships",
+                        report.entities, report.relationships
+                    ));
+                }
+                Some(Err(err)) => {
+                    if self.record_failure(unit, log_number, &err).await {
+                        outcome = BatchOutcome::Wedged;
+                        break;
+                    }
+                }
+            }
+
+            // Hand the runtime back between units so a request that arrived
+            // mid-batch is picked up before the next archive starts.
+            tokio::task::yield_now().await;
+        }
+
+        self.finish_batch(extracted, started);
+        outcome
+    }
+
+    /// Log numbers worth attempting, or `None` when shutdown arrived.
+    async fn take_pending(&mut self, unit: &dyn ExtractionUnit) -> Option<Vec<u32>> {
+        // Over-fetch, then drop what this daemon has given up on, so a
+        // quarantined archive cannot occupy a batch slot forever.
+        let limit = self.schedule.batch_size + self.skipped.len();
+        match self.context.shutdown.guard(unit.pending(limit)).await? {
+            Ok(pending) => Some(
+                pending
+                    .into_iter()
+                    .filter(|log_number| !self.skipped.contains(log_number))
+                    .take(self.schedule.batch_size)
+                    .collect(),
+            ),
+            Err(err) => {
+                self.context
+                    .log
+                    .log(&format!("background extraction: cannot list work: {err}"));
+                self.context.state.record_error(err.to_string());
+                Some(Vec::new())
+            }
+        }
+    }
+
+    /// Account for a failed archive. `true` means the provider looks wedged.
+    async fn record_failure(
+        &mut self,
+        unit: &dyn ExtractionUnit,
+        log_number: u32,
+        err: &GraphError,
+    ) -> bool {
+        self.consecutive_failures += 1;
+        let attempts = self.attempts.entry(log_number).or_insert(0);
+        *attempts += 1;
+
+        self.context.state.record_error(err.to_string());
+        if *attempts >= MAX_UNIT_ATTEMPTS {
+            self.skipped.insert(log_number);
+            unit.quarantine(log_number, &err.to_string()).await;
+            self.context.log.log(&format!(
+                "background extraction quarantined log {log_number:03} after \
+                 {MAX_UNIT_ATTEMPTS} attempts: {err}"
+            ));
+        } else {
+            self.context.log.log(&format!(
+                "background extraction failed on log {log_number:03}: {err}"
+            ));
+        }
+
+        self.consecutive_failures >= MAX_CONSECUTIVE_FAILURES
+    }
+
+    /// Record what the batch did — and only then let the idle clock restart,
+    /// so a daemon with a backlog stays alive and one without it does not.
+    fn finish_batch(&self, extracted: u64, started: Instant) {
+        if extracted == 0 {
+            return;
+        }
+        let finished = self.context.clock.now();
+        let elapsed = finished.saturating_duration_since(started);
+        self.context
+            .state
+            .record_batch(extracted, elapsed, finished);
+        self.context.idle.touch_at(Instant::now());
+        self.context.log.log(&format!(
+            "background extraction: {extracted} archives in {}ms",
+            elapsed.as_millis()
+        ));
+    }
+}
+
+// ── The real unit: an archive on disk, a store, a provider ───────────────
+
+/// Extraction against the daemon's own store, with a provider built from
+/// config. Runs exactly what `recall-echo graph extract` runs.
+pub struct GraphExtractionUnit {
+    graph: Arc<GraphMemory>,
+    llm: Box<dyn LlmProvider>,
+    conversations_dir: PathBuf,
+    quarantine_path: PathBuf,
+}
+
+impl GraphExtractionUnit {
+    #[must_use]
+    pub fn new(
+        graph: Arc<GraphMemory>,
+        llm: Box<dyn LlmProvider>,
+        conversations_dir: PathBuf,
+        quarantine_path: PathBuf,
+    ) -> Self {
+        Self {
+            graph,
+            llm,
+            conversations_dir,
+            quarantine_path,
+        }
+    }
+}
+
+#[async_trait]
+impl ExtractionUnit for GraphExtractionUnit {
+    async fn pending(&self, limit: usize) -> Result<Vec<u32>, GraphError> {
+        let quarantined = read_quarantine(&self.quarantine_path);
+        Ok(self
+            .graph
+            .unextracted_log_numbers()
+            .await?
+            .into_iter()
+            .filter_map(|log_number| u32::try_from(log_number).ok())
+            .filter(|log_number| !quarantined.contains(log_number))
+            .take(limit)
+            .collect())
+    }
+
+    async fn extract(&self, log_number: u32) -> Result<UnitReport, GraphError> {
+        let path = crate::graph_cli::find_archive_file(&self.conversations_dir, log_number)
+            .map_err(|err| GraphError::NotFound(err.to_string()))?;
+        let content = std::fs::read_to_string(&path)?;
+        let (session_id, _) = crate::graph_cli::extract_archive_metadata(&content, &path);
+        let context = IngestContext::new(session_id, Some(log_number));
+
+        let report = self
+            .graph
+            .extract_from_archive(&content, &context, self.llm.as_ref())
+            .await?;
+        self.graph.mark_extracted(log_number).await?;
+
+        Ok(UnitReport {
+            entities: report.entities_created + report.entities_merged,
+            relationships: report.relationships_created,
+        })
+    }
+
+    async fn quarantine(&self, log_number: u32, _reason: &str) {
+        use std::io::Write as _;
+
+        // Best effort. The worker's in-memory skip list already holds for this
+        // daemon's life, so a failed write costs one retry after a restart.
+        let _ = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&self.quarantine_path)
+            .and_then(|mut file| writeln!(file, "{log_number:03}"));
+    }
+}
+
+/// Log numbers a previous run set aside. Absent or unreadable means none.
+fn read_quarantine(path: &Path) -> HashSet<u32> {
+    std::fs::read_to_string(path)
+        .unwrap_or_default()
+        .lines()
+        .filter_map(|line| line.trim().parse().ok())
+        .collect()
+}
+
+// ── Wiring ───────────────────────────────────────────────────────────────
+
+/// Everything [`spawn`] needs from the daemon.
+pub struct Setup {
+    pub memory_dir: PathBuf,
+    pub graph: Arc<GraphMemory>,
+    pub idle: Arc<IdleTracker>,
+    pub shutdown: Arc<ShutdownSignal>,
+    pub state: Arc<ExtractionState>,
+    pub log: Arc<DaemonLog>,
+}
+
+/// Start the background worker for a daemon, if it should have one.
+///
+/// Every refusal is quiet, final and stated once: a missing provider, a
+/// missing key, a missing conversations directory and a config opt-out all
+/// end here, with a line in the daemon log and a reason on the wire — never a
+/// retry loop, and never surprise API spend.
+pub fn spawn(setup: Setup) -> Option<tokio::task::JoinHandle<()>> {
+    let config = crate::config::load_from_dir(&setup.memory_dir);
+    let mode = crate::serve_client::graph_mode(&setup.memory_dir);
+
+    let schedule = match plan(&config.extraction, &mode) {
+        Plan::Run(schedule) => schedule,
+        Plan::Off(reason) => return refuse(&setup, &reason),
+    };
+
+    let conversations_dir = match crate::graph_cli::find_conversations_dir(&setup.memory_dir) {
+        Ok(dir) => dir,
+        Err(err) => return refuse(&setup, &format!("no archives to extract ({err})")),
+    };
+
+    // The daemon is started with an allowlisted environment that deliberately
+    // excludes API keys, so an API-key provider fails here — which is the
+    // point: an auto-started daemon can only spend what a subscription already
+    // covers. Running `serve --foreground` with a key exported is the explicit
+    // way to opt an API provider in.
+    let (llm, model) = match crate::llm_provider::create_provider(&setup.memory_dir, None, None) {
+        Ok(provider) => provider,
+        Err(err) => return refuse(&setup, &format!("no usable LLM provider ({err})")),
+    };
+
+    if let Some(timeout) = setup.idle.timeout() {
+        if schedule.idle_after >= timeout {
+            setup.log.log(&format!(
+                "warning: [extraction] idle_after_secs ({}s) is not shorter than \
+                 [serve] idle_timeout_secs ({}s) — the daemon exits before it extracts",
+                schedule.idle_after.as_secs(),
+                timeout.as_secs()
+            ));
+        }
+    }
+
+    setup.log.log(&format!(
+        "background extraction on: {} provider, model {}, every {}s of quiet, {} archives per batch",
+        config.llm.provider,
+        if model.is_empty() { "default" } else { &model },
+        schedule.idle_after.as_secs(),
+        schedule.batch_size,
+    ));
+
+    let unit: Arc<dyn ExtractionUnit> = Arc::new(GraphExtractionUnit::new(
+        Arc::clone(&setup.graph),
+        llm,
+        conversations_dir,
+        setup
+            .memory_dir
+            .join("graph")
+            .join("extraction-quarantine.txt"),
+    ));
+    let worker = ExtractionWorker::new(
+        schedule,
+        WorkerContext {
+            idle: setup.idle,
+            shutdown: setup.shutdown,
+            state: setup.state,
+            log: setup.log,
+            clock: Arc::new(SystemClock),
+        },
+    );
+    Some(tokio::spawn(worker.run(unit)))
+}
+
+/// Say once why no background extraction runs, and run none.
+fn refuse(setup: &Setup, reason: &str) -> Option<tokio::task::JoinHandle<()>> {
+    setup
+        .log
+        .log(&format!("background extraction off: {reason}"));
+    setup.state.disable(reason);
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(background_enabled: bool) -> ExtractionSection {
+        ExtractionSection {
+            background_enabled,
+            ..ExtractionSection::default()
+        }
+    }
+
+    #[test]
+    fn the_default_plan_runs_on_the_configured_schedule() {
+        let Plan::Run(schedule) = plan(&config(true), "embedded") else {
+            panic!("the default config must run");
+        };
+        assert_eq!(schedule.idle_after, Duration::from_secs(120));
+        assert_eq!(schedule.batch_size, 3);
+        assert_eq!(schedule.poll_interval, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn opting_out_turns_the_worker_off() {
+        let Plan::Off(reason) = plan(&config(false), "embedded") else {
+            panic!("background_enabled = false must be honored");
+        };
+        assert!(reason.contains("background_enabled"), "{reason}");
+    }
+
+    #[test]
+    fn server_mode_never_extracts_in_the_background() {
+        let Plan::Off(reason) = plan(&config(true), "server") else {
+            panic!("server mode has no daemon to schedule against");
+        };
+        assert!(reason.contains("server"), "{reason}");
+    }
+
+    #[test]
+    fn poll_interval_is_bounded_at_both_ends() {
+        let fast = Schedule::from_config(&ExtractionSection {
+            idle_after_secs: 0,
+            ..ExtractionSection::default()
+        });
+        assert_eq!(fast.poll_interval, MIN_POLL);
+
+        let slow = Schedule::from_config(&ExtractionSection {
+            idle_after_secs: 86_400,
+            ..ExtractionSection::default()
+        });
+        assert_eq!(slow.poll_interval, MAX_POLL);
+    }
+
+    #[test]
+    fn a_batch_of_zero_would_never_extract_so_it_is_one() {
+        let schedule = Schedule::from_config(&ExtractionSection {
+            batch_size: 0,
+            ..ExtractionSection::default()
+        });
+        assert_eq!(schedule.batch_size, 1);
+    }
+
+    #[test]
+    fn quarantined_log_numbers_survive_a_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("extraction-quarantine.txt");
+        assert!(read_quarantine(&path).is_empty());
+
+        std::fs::write(&path, "007\n12\nnot-a-number\n").unwrap();
+        let quarantined = read_quarantine(&path);
+        assert!(quarantined.contains(&7));
+        assert!(quarantined.contains(&12));
+        assert_eq!(quarantined.len(), 2);
+    }
+}

--- a/tests/graph_dedup.rs
+++ b/tests/graph_dedup.rs
@@ -1,0 +1,463 @@
+//! Entity dedup: which candidates are worth a model call.
+//!
+//! The property under test is cost. Dedup used to escalate on the *blended*
+//! retrieval score (`0.45·similarity + 0.30·hotness + 0.25·utility`), so a
+//! popular entity bought a model call for any candidate that drifted near it —
+//! and every entity gets more popular as a graph grows, which is why ingest
+//! cost climbed 9× across the LongMemEval baseline. Escalation now happens on
+//! raw cosine similarity, in a band; everything outside the band is decided
+//! locally. Each test below asserts a fast path by making the model provider
+//! fatal: if dedup calls it, the test panics.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+
+use async_trait::async_trait;
+use recall_echo::graph::dedup::{self, ResolutionPath, ResolvedEntity};
+use recall_echo::graph::error::GraphError;
+use recall_echo::graph::llm::LlmProvider;
+use recall_echo::graph::types::{EntityType, ExtractedEntity, NewEntity};
+use recall_echo::graph::{GraphMemory, IngestContext};
+use tempfile::TempDir;
+
+const SESSION: &str = "conversation-001";
+
+// ── Fixture ──────────────────────────────────────────────────────────────
+
+/// A graph store whose `[graph.dedup]` section the test controls.
+struct Fixture {
+    _dir: TempDir,
+    graph: GraphMemory,
+}
+
+impl Fixture {
+    /// A store on the shipped defaults.
+    async fn new() -> Self {
+        Self::with_dedup_config("").await
+    }
+
+    /// A store whose dedup thresholds are pinned by the test, so a band can be
+    /// exercised without seeding a graph large enough to produce one by luck.
+    async fn with_dedup_config(dedup_toml: &str) -> Self {
+        let dir = TempDir::new().expect("temp dir");
+        let graph_dir = dir.path().join("graph");
+        std::fs::create_dir_all(&graph_dir).expect("graph dir");
+
+        if !dedup_toml.is_empty() {
+            std::fs::write(
+                dir.path().join(".recall-echo.toml"),
+                format!("[graph]\n\n[graph.dedup]\n{dedup_toml}"),
+            )
+            .expect("write config");
+        }
+
+        let graph = GraphMemory::open(&graph_dir).await.expect("open graph");
+        Self { _dir: dir, graph }
+    }
+
+    async fn seed(&self, name: &str, entity_type: EntityType, abstract_text: &str) {
+        self.graph
+            .add_entity(NewEntity {
+                name: name.to_string(),
+                entity_type,
+                abstract_text: abstract_text.to_string(),
+                overview: None,
+                content: None,
+                attributes: None,
+                source: Some(SESSION.to_string()),
+            })
+            .await
+            .unwrap_or_else(|e| panic!("seed {name}: {e}"));
+    }
+
+    /// Read an entity's stored abstract back.
+    async fn abstract_of(&self, name: &str) -> String {
+        self.graph
+            .get_entity(name)
+            .await
+            .expect("lookup")
+            .unwrap_or_else(|| panic!("{name} is not in the store"))
+            .abstract_text
+    }
+
+    /// Raise an entity's access count the only way the runtime does: by
+    /// retrieving it. Hotness is what used to drag unrelated candidates over
+    /// the old gate.
+    async fn warm(&self, query: &str, times: usize) {
+        for _ in 0..times {
+            self.graph.search(query, 5).await.expect("search");
+        }
+    }
+}
+
+fn candidate(name: &str, entity_type: EntityType, abstract_text: &str) -> ExtractedEntity {
+    ExtractedEntity {
+        name: name.to_string(),
+        entity_type,
+        abstract_text: abstract_text.to_string(),
+        overview: None,
+        content: None,
+        attributes: None,
+    }
+}
+
+// ── Providers ────────────────────────────────────────────────────────────
+
+/// Fatal on use: the assertion that a fast path is a fast path.
+struct NoModel;
+
+#[async_trait]
+impl LlmProvider for NoModel {
+    async fn complete(&self, _system: &str, user: &str, _max: u32) -> Result<String, GraphError> {
+        panic!("dedup paid for a model call it should have decided locally:\n{user}");
+    }
+}
+
+/// Counts dedup calls and answers with one canned decision.
+struct CountingModel {
+    calls: AtomicUsize,
+    prompts: Mutex<Vec<String>>,
+    decision: String,
+}
+
+impl CountingModel {
+    fn new(decision: &str) -> Self {
+        Self {
+            calls: AtomicUsize::new(0),
+            prompts: Mutex::new(Vec::new()),
+            decision: decision.to_string(),
+        }
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+
+    fn last_prompt(&self) -> String {
+        self.prompts
+            .lock()
+            .unwrap()
+            .last()
+            .cloned()
+            .unwrap_or_default()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for CountingModel {
+    async fn complete(&self, _system: &str, user: &str, _max: u32) -> Result<String, GraphError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        self.prompts.lock().unwrap().push(user.to_string());
+        Ok(self.decision.clone())
+    }
+}
+
+/// Extraction and dedup from one provider, told apart by the system prompt,
+/// counting the dedup half. What an ingest run's model bill looks like.
+struct ScriptedModel {
+    extraction: String,
+    dedup_decision: String,
+    dedup_calls: AtomicUsize,
+}
+
+impl ScriptedModel {
+    fn new(extraction: &str, dedup_decision: &str) -> Self {
+        Self {
+            extraction: extraction.to_string(),
+            dedup_decision: dedup_decision.to_string(),
+            dedup_calls: AtomicUsize::new(0),
+        }
+    }
+
+    fn dedup_calls(&self) -> usize {
+        self.dedup_calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for ScriptedModel {
+    async fn complete(&self, system: &str, _user: &str, _max: u32) -> Result<String, GraphError> {
+        if system.contains("deduplication system") {
+            self.dedup_calls.fetch_add(1, Ordering::SeqCst);
+            return Ok(self.dedup_decision.clone());
+        }
+        Ok(self.extraction.clone())
+    }
+}
+
+// ── The three bands ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn an_empty_graph_creates_without_a_model_call() {
+    let fixture = Fixture::new().await;
+
+    let resolution = dedup::resolve_entity(
+        &fixture.graph,
+        &NoModel,
+        &candidate("Biscuit", EntityType::Person, "A golden retriever"),
+        SESSION,
+    )
+    .await
+    .expect("resolve");
+
+    assert_eq!(resolution.path, ResolutionPath::NewEntityBand);
+    assert!(matches!(resolution.entity, ResolvedEntity::Created(_)));
+}
+
+/// The cheapest duplicate there is: the same string. It never reaches the
+/// embedding search, let alone the model.
+#[tokio::test]
+async fn the_same_name_and_type_merges_without_a_model_call() {
+    let fixture = Fixture::new().await;
+    fixture
+        .seed("Biscuit", EntityType::Person, "A dog Caroline adopted")
+        .await;
+
+    let resolution = dedup::resolve_entity(
+        &fixture.graph,
+        &NoModel,
+        &candidate(
+            "Biscuit",
+            EntityType::Person,
+            "A golden retriever Caroline adopted in May 2023",
+        ),
+        SESSION,
+    )
+    .await
+    .expect("resolve");
+
+    assert_eq!(resolution.path, ResolutionPath::NameMatch);
+    assert!(matches!(resolution.entity, ResolvedEntity::Merged(_)));
+    assert_eq!(
+        fixture.abstract_of("Biscuit").await,
+        "A golden retriever Caroline adopted in May 2023",
+        "the fuller abstract wins the merge"
+    );
+}
+
+/// Re-reading an archive must not grow the entity it describes — and must not
+/// pay a model to say so.
+#[tokio::test]
+async fn a_repeat_of_what_is_stored_is_skipped_without_a_model_call() {
+    let fixture = Fixture::new().await;
+    fixture
+        .seed("Biscuit", EntityType::Person, "A golden retriever")
+        .await;
+
+    let resolution = dedup::resolve_entity(
+        &fixture.graph,
+        &NoModel,
+        &candidate("Biscuit", EntityType::Person, "A golden retriever"),
+        SESSION,
+    )
+    .await
+    .expect("resolve");
+
+    assert_eq!(resolution.path, ResolutionPath::NameMatch);
+    assert!(matches!(resolution.entity, ResolvedEntity::Skipped));
+}
+
+/// A name shared across kinds is not a shared identity: the event is not the
+/// project, so the bands, not the name, decide.
+#[tokio::test]
+async fn the_same_name_under_a_different_type_is_not_a_name_match() {
+    let fixture = Fixture::new().await;
+    fixture
+        .seed(
+            "Launch",
+            EntityType::Event,
+            "The team shipped v1 on 3 June 2023",
+        )
+        .await;
+
+    let resolution = dedup::resolve_entity(
+        &fixture.graph,
+        &NoModel,
+        &candidate(
+            "Launch",
+            EntityType::Project,
+            "A woodworking project: building a canoe over the summer",
+        ),
+        SESSION,
+    )
+    .await
+    .expect("resolve");
+
+    assert_eq!(resolution.path, ResolutionPath::NewEntityBand);
+    assert!(matches!(resolution.entity, ResolvedEntity::Created(_)));
+}
+
+/// The regression this work exists for: a hot entity whose *blended* score
+/// clears the old 0.7 gate, and a candidate that is nothing like it. The old
+/// gate escalated; the similarity band does not.
+#[tokio::test]
+async fn a_hot_but_unrelated_entity_no_longer_buys_a_model_call() {
+    let fixture = Fixture::new().await;
+    fixture
+        .seed(
+            "Espresso machine",
+            EntityType::Tool,
+            "Melanie bought an espresso machine for her kitchen last spring",
+        )
+        .await;
+    fixture.warm("espresso machine kitchen", 60).await;
+
+    let candidate = candidate(
+        "Road bicycle",
+        EntityType::Tool,
+        "Melanie bought a road bicycle for her commute last autumn",
+    );
+
+    let hit = fixture
+        .graph
+        .search(&candidate.abstract_text, 1)
+        .await
+        .expect("search")
+        .remove(0);
+    let review = fixture.graph.dedup_config().review_similarity;
+    assert!(
+        hit.score > 0.7,
+        "fixture must reproduce the old gate: blended score {:.3} on {}",
+        hit.score,
+        hit.entity.name
+    );
+    assert!(
+        hit.similarity() < review,
+        "fixture must be genuinely unalike: similarity {:.3} >= {review}",
+        hit.similarity()
+    );
+
+    let resolution = dedup::resolve_entity(&fixture.graph, &NoModel, &candidate, SESSION)
+        .await
+        .expect("resolve");
+
+    assert_eq!(resolution.path, ResolutionPath::NewEntityBand);
+}
+
+/// The middle band is the one thing worth paying for, and it costs exactly one
+/// call. Thresholds are pinned so every neighbour lands in it.
+#[tokio::test]
+async fn the_ambiguous_band_costs_exactly_one_model_call() {
+    let fixture =
+        Fixture::with_dedup_config("certain_similarity = 1.0\nreview_similarity = 0.0\n").await;
+    fixture
+        .seed("Biscuit", EntityType::Person, "A dog Caroline adopted")
+        .await;
+
+    let model = CountingModel::new(r#"{"decision": "skip", "reason": "duplicate"}"#);
+    let resolution = dedup::resolve_entity(
+        &fixture.graph,
+        &model,
+        &candidate("Biscuit the dog", EntityType::Person, "Caroline's dog"),
+        SESSION,
+    )
+    .await
+    .expect("resolve");
+
+    assert_eq!(resolution.path, ResolutionPath::LlmDecision);
+    assert!(matches!(resolution.entity, ResolvedEntity::Skipped));
+    assert_eq!(model.calls(), 1);
+    assert!(
+        model.last_prompt().contains("similarity:"),
+        "the model weighs meaning, not popularity: {}",
+        model.last_prompt()
+    );
+}
+
+/// However large the store, the prompt stays the same size.
+#[tokio::test]
+async fn the_candidate_set_handed_to_the_model_is_capped() {
+    let fixture = Fixture::with_dedup_config(
+        "certain_similarity = 1.0\nreview_similarity = 0.0\nmax_candidates = 2\n",
+    )
+    .await;
+    for i in 1..=6 {
+        fixture
+            .seed(
+                &format!("Dog {i}"),
+                EntityType::Person,
+                &format!("A dog Caroline adopted, number {i}"),
+            )
+            .await;
+    }
+
+    let model = CountingModel::new(r#"{"decision": "create", "reason": "new"}"#);
+    dedup::resolve_entity(
+        &fixture.graph,
+        &model,
+        &candidate("Biscuit", EntityType::Person, "A dog Caroline adopted"),
+        SESSION,
+    )
+    .await
+    .expect("resolve");
+
+    let prompt = model.last_prompt();
+    assert_eq!(
+        prompt.matches("similarity:").count(),
+        2,
+        "max_candidates = 2 must bound the comparison set:\n{prompt}"
+    );
+}
+
+// ── The counters an ingest run reports ───────────────────────────────────
+
+const ARCHIVE: &str = "### User\n\nI adopted a golden retriever named Biscuit last May.\n";
+
+const EXTRACTION: &str = r#"{"entities": [{"name": "Biscuit", "type": "person",
+    "abstract": "A golden retriever Caroline adopted in May"}], "relationships": []}"#;
+
+/// Ingest reports what dedup cost. Re-ingesting the same archive must cost
+/// nothing at all: every candidate is already in the store under its own name.
+#[tokio::test]
+async fn ingest_reports_dedup_resolved_without_a_model() {
+    let fixture = Fixture::new().await;
+    let model = ScriptedModel::new(EXTRACTION, r#"{"decision": "skip", "reason": "dup"}"#);
+    let context = IngestContext::new(SESSION, Some(1));
+
+    let first = fixture
+        .graph
+        .ingest_archive(ARCHIVE, &context, Some(&model))
+        .await
+        .expect("first ingest");
+    assert_eq!(first.entities_created, 1);
+    assert_eq!(first.dedup_llm_calls, 0);
+    assert_eq!(first.dedup_fast_path, 1);
+    assert_eq!(
+        first.estimated_tokens, 2_500,
+        "the estimate bills extraction only when dedup costs nothing"
+    );
+
+    let second = fixture
+        .graph
+        .ingest_archive(ARCHIVE, &context, Some(&model))
+        .await
+        .expect("second ingest");
+    assert_eq!(second.entities_skipped, 1);
+    assert_eq!(second.dedup_llm_calls, 0);
+    assert_eq!(second.dedup_fast_path, 1);
+    assert_eq!(model.dedup_calls(), 0, "no dedup decision needed a model");
+}
+
+/// And when a candidate does land in the ambiguous band, the counter says so.
+#[tokio::test]
+async fn ingest_counts_the_candidates_that_needed_a_model() {
+    let fixture =
+        Fixture::with_dedup_config("certain_similarity = 1.0\nreview_similarity = 0.0\n").await;
+    fixture
+        .seed("Rusty", EntityType::Person, "A dog Caroline adopted")
+        .await;
+
+    let model = ScriptedModel::new(EXTRACTION, r#"{"decision": "create", "reason": "new dog"}"#);
+    let context = IngestContext::new(SESSION, Some(1));
+
+    let report = fixture
+        .graph
+        .ingest_archive(ARCHIVE, &context, Some(&model))
+        .await
+        .expect("ingest");
+
+    assert_eq!(report.dedup_llm_calls, 1);
+    assert_eq!(report.dedup_fast_path, 0);
+    assert_eq!(model.dedup_calls(), 1);
+    assert_eq!(report.entities_created, 1);
+}

--- a/tests/mcp_protocol.rs
+++ b/tests/mcp_protocol.rs
@@ -104,6 +104,7 @@ fn scored_entity_typed() -> ScoredEntity {
     ScoredEntity {
         entity: entity_detail(),
         score: 0.842,
+        similarity: 0.913,
         source: MatchSource::Semantic,
     }
 }

--- a/tests/mcp_protocol.rs
+++ b/tests/mcp_protocol.rs
@@ -1,0 +1,775 @@
+//! MCP protocol conformance: the handshake, the tool catalogue, and what a
+//! client sees on every failure mode.
+//!
+//! These run entirely against a stubbed [`GraphBackend`], so nothing here
+//! opens a store, starts a daemon or loads an embedding model. What is under
+//! test is the wire contract — a client that follows the spec must never see
+//! a panic, a dropped response, or a shape it cannot parse.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use recall_echo::error::RecallError;
+use recall_echo::graph::types::{
+    EntityDetail, EntitySummary, EntityType, Episode, EpisodeSearchResult, GraphStats, MatchSource,
+    QueryResult, ScoredEntity, TraversalEdge, TraversalNode,
+};
+use recall_echo::mcp::{GraphBackend, McpServer, PREFERRED_PROTOCOL_VERSION};
+use recall_echo::serve::Request;
+use serde_json::{json, Value};
+
+// ── Stub backend ─────────────────────────────────────────────────────────
+
+/// What the stubbed daemon does with whatever request reaches it.
+enum Outcome {
+    /// Answer with a payload shaped like the real operation's output.
+    Canned,
+    /// Answer with this exact payload, whatever was asked.
+    Data(Value),
+    /// Fail the way the daemon reports a named error.
+    Remote {
+        code: &'static str,
+        message: &'static str,
+    },
+}
+
+struct Stub {
+    outcome: Outcome,
+    calls: Mutex<Vec<Request>>,
+}
+
+impl Stub {
+    fn new(outcome: Outcome) -> Self {
+        Self {
+            outcome,
+            calls: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl GraphBackend for Stub {
+    async fn execute(&self, request: &Request) -> Result<Value, RecallError> {
+        self.calls.lock().unwrap().push(request.clone());
+        match &self.outcome {
+            Outcome::Canned => Ok(canned_payload(request)),
+            Outcome::Data(data) => Ok(data.clone()),
+            Outcome::Remote { code, message } => Err(RecallError::Remote {
+                code: (*code).to_string(),
+                message: (*message).to_string(),
+            }),
+        }
+    }
+}
+
+/// Payloads built from the real result types, so the test cannot drift from
+/// the shapes the daemon actually serializes.
+fn canned_payload(request: &Request) -> Value {
+    match request {
+        Request::Search(_) => json!([scored_entity()]),
+        Request::Query(_) => serde_json::to_value(QueryResult {
+            entities: vec![scored_entity_typed()],
+            episodes: vec![episode_typed()],
+        })
+        .unwrap(),
+        Request::SearchEpisodes(_) => json!([episode()]),
+        Request::Traverse(_) => serde_json::to_value(traversal_tree()).unwrap(),
+        Request::Status => serde_json::to_value(GraphStats {
+            entity_count: 12,
+            relationship_count: 30,
+            episode_count: 400,
+            entity_type_counts: HashMap::from([("project".to_string(), 7)]),
+        })
+        .unwrap(),
+        other => panic!("no MCP tool builds a {} request", other.op_name()),
+    }
+}
+
+fn entity_detail() -> EntityDetail {
+    EntityDetail {
+        id: json!("entity:rust"),
+        name: "Rust".into(),
+        entity_type: EntityType::Tool,
+        abstract_text: "Systems language with ownership.".into(),
+        overview: "Rust enforces memory safety without a garbage collector.".into(),
+        attributes: None,
+        access_count: 4,
+        utility_score: 0.77,
+        updated_at: json!("2026-05-01T09:15:30.123Z"),
+        source: Some("archive-log-042".into()),
+    }
+}
+
+fn scored_entity_typed() -> ScoredEntity {
+    ScoredEntity {
+        entity: entity_detail(),
+        score: 0.842,
+        source: MatchSource::Semantic,
+    }
+}
+
+fn scored_entity() -> Value {
+    serde_json::to_value(scored_entity_typed()).unwrap()
+}
+
+fn episode() -> Value {
+    serde_json::to_value(episode_typed()).unwrap()
+}
+
+fn episode_typed() -> EpisodeSearchResult {
+    EpisodeSearchResult {
+        episode: Episode {
+            id: json!("episode:1"),
+            session_id: "sess-9".into(),
+            timestamp: json!("2026-04-02T18:00:00Z"),
+            abstract_text: "Talked about the release pipeline.".into(),
+            overview: None,
+            content: Some("We tag v3 and CI drafts the release.".into()),
+            embedding: None,
+            log_number: Some(42),
+            provenance: Some("human".into()),
+            access_count: 1,
+        },
+        score: 0.66,
+        distance: 0.3,
+    }
+}
+
+fn traversal_tree() -> TraversalNode {
+    TraversalNode {
+        entity: EntitySummary {
+            id: json!("entity:rust"),
+            name: "Rust".into(),
+            entity_type: EntityType::Tool,
+            abstract_text: "Systems language with ownership.".into(),
+        },
+        edges: vec![TraversalEdge {
+            rel_type: "USES".into(),
+            direction: "->".into(),
+            target: TraversalNode {
+                entity: EntitySummary {
+                    id: json!("entity:cargo"),
+                    name: "Cargo".into(),
+                    entity_type: EntityType::Tool,
+                    abstract_text: "Rust's build tool.".into(),
+                },
+                edges: Vec::new(),
+            },
+            valid_from: json!("2026-01-01T00:00:00Z"),
+            valid_until: None,
+            confidence: 0.62,
+        }],
+    }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────
+
+fn server(outcome: Outcome) -> McpServer<Stub> {
+    McpServer::new(Stub::new(outcome))
+}
+
+async fn send(server: &McpServer<Stub>, message: Value) -> Option<Value> {
+    server.handle_line(&message.to_string()).await
+}
+
+/// Send and require an answer — for requests, which always get one.
+async fn answer(server: &McpServer<Stub>, message: Value) -> Value {
+    send(server, message)
+        .await
+        .expect("a request must be answered")
+}
+
+fn call(id: u32, tool: &str, arguments: Value) -> Value {
+    json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "method": "tools/call",
+        "params": { "name": tool, "arguments": arguments }
+    })
+}
+
+fn text_of(result: &Value) -> &str {
+    result["content"][0]["text"]
+        .as_str()
+        .expect("a text content block")
+}
+
+// ── Initialization ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn initialize_answers_with_capabilities_and_identity() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "initialize",
+            "params": {
+                "protocolVersion": PREFERRED_PROTOCOL_VERSION,
+                "capabilities": {},
+                "clientInfo": { "name": "test-client", "version": "0.1.0" }
+            }
+        }),
+    )
+    .await;
+
+    assert_eq!(response["jsonrpc"], "2.0");
+    assert_eq!(response["id"], 1);
+    assert!(response.get("error").is_none(), "{response}");
+
+    let result = &response["result"];
+    assert_eq!(result["protocolVersion"], PREFERRED_PROTOCOL_VERSION);
+    assert!(result["capabilities"]["tools"].is_object(), "{result}");
+    assert_eq!(result["serverInfo"]["name"], "recall-echo");
+    assert_eq!(result["serverInfo"]["version"], env!("CARGO_PKG_VERSION"));
+    // The handshake is the only place to tell an agent when to use memory.
+    let instructions = result["instructions"].as_str().unwrap();
+    assert!(instructions.contains("recall_query"), "{instructions}");
+}
+
+#[tokio::test]
+async fn initialize_offers_our_version_when_the_client_asks_for_one_we_lack() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "initialize",
+            "params": { "protocolVersion": "1900-01-01" }
+        }),
+    )
+    .await;
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        PREFERRED_PROTOCOL_VERSION
+    );
+}
+
+#[tokio::test]
+async fn initialize_survives_absent_params() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "initialize"}),
+    )
+    .await;
+    assert_eq!(
+        response["result"]["protocolVersion"],
+        PREFERRED_PROTOCOL_VERSION
+    );
+}
+
+#[tokio::test]
+async fn notifications_are_never_answered() {
+    let server = server(Outcome::Canned);
+    assert!(send(
+        &server,
+        json!({ "jsonrpc": "2.0", "method": "notifications/initialized" })
+    )
+    .await
+    .is_none());
+    assert!(send(
+        &server,
+        json!({ "jsonrpc": "2.0", "method": "notifications/cancelled", "params": { "requestId": 3 } })
+    )
+    .await
+    .is_none());
+    // Even an id on a notification method must not produce a response.
+    assert!(send(
+        &server,
+        json!({ "jsonrpc": "2.0", "id": 7, "method": "notifications/initialized" })
+    )
+    .await
+    .is_none());
+}
+
+#[tokio::test]
+async fn ping_answers_an_empty_result() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 2, "method": "ping"}),
+    )
+    .await;
+    assert_eq!(response["result"], json!({}));
+}
+
+// ── tools/list ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn tools_list_describes_every_tool() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 3, "method": "tools/list"}),
+    )
+    .await;
+
+    let tools = response["result"]["tools"]
+        .as_array()
+        .expect("a tool array");
+    let names: Vec<&str> = tools
+        .iter()
+        .map(|tool| tool["name"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        names,
+        vec![
+            "recall_query",
+            "recall_search",
+            "recall_episodes",
+            "recall_traverse",
+            "recall_status"
+        ]
+    );
+
+    for tool in tools {
+        let name = tool["name"].as_str().unwrap();
+        assert!(tool["title"].is_string(), "{name} has no title");
+        assert!(
+            tool["description"].as_str().is_some_and(|d| d.len() > 80),
+            "{name} has no usable description"
+        );
+        let schema = &tool["inputSchema"];
+        assert_eq!(schema["type"], "object", "{name} schema is not an object");
+        assert!(schema["properties"].is_object(), "{name} has no properties");
+    }
+}
+
+#[tokio::test]
+async fn tools_list_is_stable_across_calls() {
+    let server = server(Outcome::Canned);
+    let first = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+    )
+    .await;
+    let second = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 2, "method": "tools/list"}),
+    )
+    .await;
+    assert_eq!(first["result"], second["result"]);
+}
+
+#[tokio::test]
+async fn tools_list_rejects_a_cursor_it_never_issued() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 4, "method": "tools/list", "params": {"cursor": "page-2"}}),
+    )
+    .await;
+    assert_eq!(response["error"]["code"], -32602);
+}
+
+// ── tools/call, happy paths ──────────────────────────────────────────────
+
+#[tokio::test]
+async fn every_advertised_tool_can_be_called() {
+    let server = server(Outcome::Canned);
+    let listed = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+    )
+    .await;
+
+    for tool in listed["result"]["tools"].as_array().unwrap() {
+        let name = tool["name"].as_str().unwrap();
+        let arguments = match name {
+            "recall_traverse" => json!({ "entity": "Rust" }),
+            "recall_status" => json!({}),
+            _ => json!({ "query": "release pipeline" }),
+        };
+        let response = answer(&server, call(9, name, arguments)).await;
+        assert!(
+            response.get("error").is_none(),
+            "{name} produced a protocol error: {response}"
+        );
+        assert_eq!(response["result"]["isError"], false, "{name}: {response}");
+        assert!(
+            !text_of(&response["result"]).is_empty(),
+            "{name} returned no text"
+        );
+    }
+}
+
+#[tokio::test]
+async fn recall_search_returns_named_entities_with_scores() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        call(
+            1,
+            "recall_search",
+            json!({ "query": "ownership", "limit": 3 }),
+        ),
+    )
+    .await;
+
+    let text = text_of(&response["result"]);
+    assert!(text.contains("Rust [tool]"), "{text}");
+    assert!(text.contains("score 0.84"), "{text}");
+    assert!(text.contains("Systems language with ownership."), "{text}");
+    // Not a JSON dump.
+    assert!(!text.contains("\"entity\""), "{text}");
+}
+
+#[tokio::test]
+async fn recall_query_reaches_the_daemon_with_the_arguments_it_was_given() {
+    let stub = Stub::new(Outcome::Canned);
+    let server = McpServer::new(stub);
+    answer(
+        &server,
+        call(
+            1,
+            "recall_query",
+            json!({ "query": "how we ship", "limit": 4, "include_episodes": false }),
+        ),
+    )
+    .await;
+
+    // The daemon protocol is the only path to the store; assert we speak it.
+    let Request::Query(args) = &server.backend_calls()[0] else {
+        panic!("recall_query must issue a Query request");
+    };
+    assert_eq!(args.query, "how we ship");
+    assert_eq!(args.limit, 4);
+    assert!(!args.episodes);
+}
+
+#[tokio::test]
+async fn recall_query_renders_entities_and_conversation_fragments() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        call(1, "recall_query", json!({ "query": "release" })),
+    )
+    .await;
+    let text = text_of(&response["result"]);
+    assert!(text.contains("1 entity:"), "{text}");
+    assert!(text.contains("1 conversation fragment:"), "{text}");
+    assert!(
+        text.contains("We tag v3 and CI drafts the release."),
+        "{text}"
+    );
+}
+
+#[tokio::test]
+async fn recall_traverse_renders_a_tree_with_confidence() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        call(
+            1,
+            "recall_traverse",
+            json!({ "entity": "Rust", "depth": 1 }),
+        ),
+    )
+    .await;
+    let text = text_of(&response["result"]);
+    assert!(text.contains("Relationships from \"Rust\""), "{text}");
+    assert!(text.contains("USES Cargo"), "{text}");
+    assert!(text.contains("[62%]"), "{text}");
+}
+
+#[tokio::test]
+async fn recall_status_reports_counts() {
+    let server = server(Outcome::Canned);
+    let response = answer(&server, call(1, "recall_status", json!({}))).await;
+    let text = text_of(&response["result"]);
+    assert!(text.contains("12 entities"), "{text}");
+    assert!(text.contains("400 conversation episodes"), "{text}");
+    assert!(text.contains("project 7"), "{text}");
+}
+
+#[tokio::test]
+async fn a_tool_call_without_arguments_uses_the_defaults() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({
+            "jsonrpc": "2.0", "id": 1, "method": "tools/call",
+            "params": { "name": "recall_status" }
+        }),
+    )
+    .await;
+    assert_eq!(response["result"]["isError"], false, "{response}");
+}
+
+#[tokio::test]
+async fn an_empty_result_set_explains_itself() {
+    let server = server(Outcome::Data(json!([])));
+    let response = answer(
+        &server,
+        call(1, "recall_search", json!({ "query": "quantum" })),
+    )
+    .await;
+    assert_eq!(response["result"]["isError"], false);
+    let text = text_of(&response["result"]);
+    assert!(text.contains("No entities"), "{text}");
+    assert!(text.contains("recall_episodes"), "{text}");
+}
+
+// ── tools/call, failure paths ────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_backend_failure_is_a_tool_error_not_a_protocol_error() {
+    let server = server(Outcome::Remote {
+        code: "not_found",
+        message: "entity not found: Rsut",
+    });
+    let response = answer(
+        &server,
+        call(1, "recall_traverse", json!({ "entity": "Rsut" })),
+    )
+    .await;
+
+    assert!(response.get("error").is_none(), "{response}");
+    assert_eq!(response["result"]["isError"], true);
+    let text = text_of(&response["result"]);
+    assert!(text.contains("recall_traverse failed"), "{text}");
+    assert!(text.contains("entity not found: Rsut"), "{text}");
+    assert!(text.contains("recall_search"), "{text}");
+}
+
+#[tokio::test]
+async fn an_unavailable_store_tells_the_agent_not_to_retry() {
+    let server = server(Outcome::Remote {
+        code: "embedding",
+        message: "embedding model unavailable",
+    });
+    let response = answer(&server, call(1, "recall_search", json!({ "query": "x" }))).await;
+    assert_eq!(response["result"]["isError"], true);
+    assert!(text_of(&response["result"]).contains("do not retry"));
+}
+
+#[tokio::test]
+async fn invalid_arguments_are_a_tool_error_the_model_can_fix() {
+    let server = server(Outcome::Canned);
+
+    let missing = answer(&server, call(1, "recall_search", json!({}))).await;
+    assert!(missing.get("error").is_none(), "{missing}");
+    assert_eq!(missing["result"]["isError"], true);
+    assert!(text_of(&missing["result"]).contains("`query` is required"));
+
+    let mistyped = answer(&server, call(2, "recall_search", json!({ "query": 7 }))).await;
+    assert_eq!(mistyped["result"]["isError"], true);
+    assert!(text_of(&mistyped["result"]).contains("must be a string"));
+}
+
+#[tokio::test]
+async fn an_unreadable_payload_fails_the_call_rather_than_the_process() {
+    let server = server(Outcome::Data(json!({ "unexpected": "shape" })));
+    let response = answer(&server, call(1, "recall_search", json!({ "query": "x" }))).await;
+    assert_eq!(response["result"]["isError"], true, "{response}");
+    assert!(text_of(&response["result"]).contains("could not read"));
+}
+
+#[tokio::test]
+async fn an_unknown_tool_is_a_protocol_error() {
+    let server = server(Outcome::Canned);
+    let response = answer(&server, call(1, "recall_forget", json!({}))).await;
+
+    assert!(response.get("result").is_none(), "{response}");
+    assert_eq!(response["error"]["code"], -32602);
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("recall_forget"));
+    // The client is told what it could have called instead.
+    assert!(response["error"]["data"]["available"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|name| name == "recall_query"));
+}
+
+#[tokio::test]
+async fn a_tool_call_without_a_name_is_a_protocol_error() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "tools/call", "params": {}}),
+    )
+    .await;
+    assert_eq!(response["error"]["code"], -32602);
+}
+
+// ── Malformed and unknown traffic ────────────────────────────────────────
+
+#[tokio::test]
+async fn an_unknown_method_is_method_not_found() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 5, "method": "resources/list"}),
+    )
+    .await;
+    assert_eq!(response["id"], 5);
+    assert_eq!(response["error"]["code"], -32601);
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("resources/list"));
+}
+
+#[tokio::test]
+async fn malformed_json_is_a_parse_error_against_a_null_id() {
+    let server = server(Outcome::Canned);
+    let response = server
+        .handle_line("{\"jsonrpc\": \"2.0\", \"id\": 1, ")
+        .await
+        .expect("a parse error must be reported");
+    assert_eq!(response["jsonrpc"], "2.0");
+    assert_eq!(response["id"], Value::Null);
+    assert_eq!(response["error"]["code"], -32700);
+}
+
+#[tokio::test]
+async fn a_request_without_a_method_is_an_invalid_request() {
+    let server = server(Outcome::Canned);
+    let response = answer(&server, json!({"jsonrpc": "2.0", "id": 6, "params": {}})).await;
+    assert_eq!(response["id"], 6);
+    assert_eq!(response["error"]["code"], -32600);
+}
+
+#[tokio::test]
+async fn a_foreign_jsonrpc_version_is_rejected() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!({"jsonrpc": "1.0", "id": 7, "method": "ping"}),
+    )
+    .await;
+    assert_eq!(response["error"]["code"], -32600);
+    assert!(response["error"]["message"]
+        .as_str()
+        .unwrap()
+        .contains("2.0"));
+}
+
+#[tokio::test]
+async fn a_structurally_invalid_message_is_answered_against_a_null_id() {
+    let server = server(Outcome::Canned);
+    // Not a notification — a notification is a *valid* request without an id,
+    // and JSON-RPC 2.0 answers anything else against a null id.
+    for message in [
+        json!({"jsonrpc": "2.0", "params": {}}),
+        json!({"jsonrpc": "9.9", "method": "ping"}),
+    ] {
+        let response = answer(&server, message).await;
+        assert_eq!(response["id"], Value::Null, "{response}");
+        assert_eq!(response["error"]["code"], -32600, "{response}");
+    }
+}
+
+#[tokio::test]
+async fn a_null_id_is_treated_as_a_notification() {
+    let server = server(Outcome::Canned);
+    assert!(send(
+        &server,
+        json!({"jsonrpc": "2.0", "id": null, "method": "ping"})
+    )
+    .await
+    .is_none());
+}
+
+#[tokio::test]
+async fn a_non_object_message_is_rejected_without_panicking() {
+    let server = server(Outcome::Canned);
+    let response = answer(&server, json!("hello")).await;
+    assert_eq!(response["error"]["code"], -32600);
+    assert_eq!(response["id"], Value::Null);
+}
+
+#[tokio::test]
+async fn a_batch_is_answered_once_per_request() {
+    let server = server(Outcome::Canned);
+    let response = answer(
+        &server,
+        json!([
+            {"jsonrpc": "2.0", "id": 1, "method": "ping"},
+            {"jsonrpc": "2.0", "method": "notifications/initialized"},
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/list"}
+        ]),
+    )
+    .await;
+
+    let responses = response.as_array().expect("a batch response");
+    assert_eq!(responses.len(), 2);
+    assert_eq!(responses[0]["id"], 1);
+    assert_eq!(responses[1]["id"], 2);
+}
+
+#[tokio::test]
+async fn a_batch_of_only_notifications_is_silent() {
+    let server = server(Outcome::Canned);
+    assert!(send(
+        &server,
+        json!([{"jsonrpc": "2.0", "method": "notifications/initialized"}])
+    )
+    .await
+    .is_none());
+}
+
+#[tokio::test]
+async fn an_empty_batch_is_an_invalid_request() {
+    let server = server(Outcome::Canned);
+    let response = answer(&server, json!([])).await;
+    assert_eq!(response["error"]["code"], -32600);
+}
+
+// ── Read-only contract ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn no_tool_can_write_to_the_graph() {
+    let server = server(Outcome::Canned);
+    let listed = answer(
+        &server,
+        json!({"jsonrpc": "2.0", "id": 1, "method": "tools/list"}),
+    )
+    .await;
+
+    for tool in listed["result"]["tools"].as_array().unwrap() {
+        let name = tool["name"].as_str().unwrap();
+        let arguments = match name {
+            "recall_traverse" => json!({ "entity": "Rust" }),
+            "recall_status" => json!({}),
+            _ => json!({ "query": "anything" }),
+        };
+        answer(&server, call(2, name, arguments)).await;
+    }
+
+    for request in server.backend_calls() {
+        assert!(
+            request.is_retryable(),
+            "{} mutates the graph; MCP tools are read-only",
+            request.op_name()
+        );
+        assert!(
+            !matches!(
+                request,
+                Request::AddEntity(_)
+                    | Request::Relate(_)
+                    | Request::IngestArchive(_)
+                    | Request::SyncPipeline(_)
+                    | Request::Feedback(_)
+                    | Request::Shutdown
+            ),
+            "{} is not a read operation",
+            request.op_name()
+        );
+    }
+}
+
+/// Access to what the stub recorded.
+trait BackendCalls {
+    fn backend_calls(&self) -> Vec<Request>;
+}
+
+impl BackendCalls for McpServer<Stub> {
+    fn backend_calls(&self) -> Vec<Request> {
+        self.backend().calls.lock().unwrap().clone()
+    }
+}

--- a/tests/query_golden.rs
+++ b/tests/query_golden.rs
@@ -1,11 +1,19 @@
 //! Golden-set integration tests for the hybrid recall path (`src/graph/query.rs`).
 //!
 //! The hybrid path is: semantic KNN (`limit * 2` candidates) → 1-hop expansion
-//! from the top 3 candidates scored `parent_score * effective_confidence` →
-//! merge/dedup → sort → truncate. This file pins the behaviors that Phase 2
-//! retrieval work must not silently change: recall@k membership, confidence
-//! weighting (including read-time decay and the `< 0.1` edge drop), scoring
-//! weight sensitivity, and expansion depth.
+//! from the top 3 candidates → merge → sort → truncate. Both channels score
+//! through the same `w_semantic * similarity + w_hotness * hotness +
+//! w_utility * utility`; the channel decides only where `similarity` comes
+//! from (measured against the query vector, or propagated from a parent as
+//! `similarity_parent * effective_confidence`). An entity that arrives on both
+//! channels keeps its measured similarity, raised by
+//! `1 + corroboration_boost * effective_confidence`.
+//!
+//! This file pins the behaviors that Phase 2 retrieval work must not silently
+//! change: recall@k membership, confidence weighting (including read-time
+//! decay and the `< 0.1` edge drop), the parity of the two channels' score
+//! terms, corroboration and its bound, access-count symmetry, scoring weight
+//! sensitivity, and expansion depth.
 //!
 //! These tests drive the graph layer one level below `GraphMemory` (raw
 //! `Surreal<Db>` + `query::query`) for two reasons the higher-level API cannot
@@ -410,6 +418,7 @@ fn semantic_only() -> GraphScoringConfig {
         weight_semantic: 1.0,
         weight_hotness: 0.0,
         weight_utility: 0.0,
+        ..GraphScoringConfig::default()
     }
 }
 
@@ -418,6 +427,16 @@ fn utility_only() -> GraphScoringConfig {
         weight_semantic: 0.0,
         weight_hotness: 0.0,
         weight_utility: 1.0,
+        ..GraphScoringConfig::default()
+    }
+}
+
+/// Default weights with graph corroboration switched off — the control for
+/// measuring what corroboration is worth.
+fn no_corroboration() -> GraphScoringConfig {
+    GraphScoringConfig {
+        corroboration_boost: 0.0,
+        ..GraphScoringConfig::default()
     }
 }
 
@@ -463,8 +482,8 @@ async fn golden_query_recall_at_k_ordering() {
 }
 
 /// Confidence weighting: neighbors reached over a fresh high-confidence edge
-/// outrank neighbors reached over an old one, and the graph score is exactly
-/// `parent_score * effective_confidence` — decay included.
+/// outrank neighbors reached over an old one, and effective confidence — decay
+/// included — is exactly the fraction of the parent's relevance they inherit.
 #[tokio::test]
 async fn golden_query_confidence_weighting_orders_neighbors() {
     let graph = GoldenGraph::seed().await;
@@ -472,23 +491,182 @@ async fn golden_query_confidence_weighting_orders_neighbors() {
     let ranked = names(&result.entities);
 
     let parent = find(&result.entities, BORROW_CHECKER)
-        .unwrap_or_else(|| panic!("anchor missing: {ranked:?}"))
-        .score;
+        .unwrap_or_else(|| panic!("anchor missing: {ranked:?}"));
     let fresh = find(&result.entities, INES)
-        .unwrap_or_else(|| panic!("fresh-edge neighbor missing: {ranked:?}"))
-        .score;
+        .unwrap_or_else(|| panic!("fresh-edge neighbor missing: {ranked:?}"));
     let decayed = find(&result.entities, LUCIA)
-        .unwrap_or_else(|| panic!("decayed-edge neighbor missing: {ranked:?}"))
-        .score;
+        .unwrap_or_else(|| panic!("decayed-edge neighbor missing: {ranked:?}"));
 
     // 0.95, reinforced at creation — no decay yet.
-    assert_close(fresh / parent, 0.95, 1e-6, "fresh edge multiplier");
+    assert_close(
+        fresh.similarity / parent.similarity,
+        0.95,
+        1e-6,
+        "fresh edge multiplier",
+    );
     // 0.90 stored, never reinforced, 180 days old: 0.90 x 0.5^(180/90).
-    assert_close(decayed / parent, 0.225, 1e-3, "decayed edge multiplier");
+    assert_close(
+        decayed.similarity / parent.similarity,
+        0.225,
+        1e-3,
+        "decayed edge multiplier",
+    );
 
     assert!(
         rank(&result.entities, INES) < rank(&result.entities, LUCIA),
         "fresh high-confidence neighbor must outrank the decayed one: {ranked:?}"
+    );
+}
+
+/// Channel parity: confidence discounts a neighbor's *relevance*, and nothing
+/// else. Hotness and utility are read off the neighbor exactly as they are off
+/// a semantic hit, so the non-similarity part of the score is identical for
+/// both channels — no graph candidate has to out-confidence a base that every
+/// semantic candidate gets for free.
+#[tokio::test]
+async fn golden_query_graph_candidates_earn_the_same_score_terms() {
+    let graph = GoldenGraph::seed().await;
+    let result = graph.query(RUST_QUERY, &borrow_checker_anchor()).await;
+    let ranked = names(&result.entities);
+
+    let weights = GraphScoringConfig::default();
+    // Every fixture entity is seeded in the same second and unread until this
+    // query, so hotness is equal across them and the remainder is exact.
+    let base = |scored: &ScoredEntity| scored.score - weights.weight_semantic * scored.similarity;
+
+    let parent = find(&result.entities, BORROW_CHECKER)
+        .unwrap_or_else(|| panic!("anchor missing: {ranked:?}"));
+    for neighbor in [INES, LUCIA, OWNERSHIP_MODEL] {
+        let scored =
+            find(&result.entities, neighbor).unwrap_or_else(|| panic!("{neighbor} missing"));
+        assert!(
+            matches!(scored.source, MatchSource::Graph { .. }),
+            "{neighbor} must have arrived over the graph for this test to mean anything"
+        );
+        assert_close(
+            base(scored),
+            base(parent),
+            1e-9,
+            &format!("{neighbor} hotness+utility base"),
+        );
+        assert!(
+            base(scored) > 0.0,
+            "{neighbor} earned no hotness/utility at all: {:?}",
+            scored.score
+        );
+    }
+}
+
+/// Corroboration: an entity the query finds *and* the graph reaches from a top
+/// hit is worth more than the same entity found by the query alone. The lift
+/// is exactly `1 + corroboration_boost * effective_confidence` on the measured
+/// similarity — the measurement stays the base, the graph adds to it.
+#[tokio::test]
+async fn golden_query_graph_corroboration_boosts_a_semantic_hit() {
+    let graph = GoldenGraph::seed().await;
+    let options = QueryOptions {
+        limit: 8,
+        graph_depth: 1,
+        ..Default::default()
+    };
+
+    // MIREIA is a semantic hit for the baking query and also sits one fresh,
+    // 0.95-confidence edge from SOURDOUGH_STARTER, the query's top hit.
+    let uncorroborated = graph
+        .query_scored(BAKING_QUERY, &options, &no_corroboration())
+        .await
+        .entities;
+    let corroborated = graph.query(BAKING_QUERY, &options).await.entities;
+
+    let plain = find(&uncorroborated, MIREIA)
+        .unwrap_or_else(|| panic!("baker missing: {:?}", names(&uncorroborated)));
+    let boosted = find(&corroborated, MIREIA)
+        .unwrap_or_else(|| panic!("baker missing: {:?}", names(&corroborated)));
+
+    assert!(
+        matches!(plain.source, MatchSource::Semantic),
+        "MIREIA must be a semantic hit for this to be corroboration and not expansion"
+    );
+    let expected = 1.0 + GraphScoringConfig::default().corroboration_boost * 0.95;
+    assert_close(
+        boosted.similarity / plain.similarity,
+        expected,
+        1e-6,
+        "corroboration lift",
+    );
+    // Scores are compared across two queries, so only similarity is stable —
+    // the first query warms access counts and moves every hotness term.
+    assert!(
+        boosted.similarity > plain.similarity,
+        "graph corroboration must not be discarded on collision"
+    );
+}
+
+/// Corroboration is bounded: similarity is a `[0, 1]` quantity and stays one
+/// however absurd the boost, so no entity can run away with the ranking by
+/// being well connected.
+#[tokio::test]
+async fn golden_query_corroboration_is_clamped_at_the_similarity_ceiling() {
+    let graph = GoldenGraph::seed().await;
+    let options = QueryOptions {
+        limit: 8,
+        graph_depth: 1,
+        ..Default::default()
+    };
+
+    let runaway = GraphScoringConfig {
+        corroboration_boost: 100.0,
+        ..GraphScoringConfig::default()
+    };
+    let result = graph.query_scored(BAKING_QUERY, &options, &runaway).await;
+
+    for scored in &result.entities {
+        assert!(
+            scored.similarity <= 1.0,
+            "{} exceeded the similarity ceiling: {}",
+            scored.entity.name,
+            scored.similarity
+        );
+    }
+    let ceiling = GraphScoringConfig::default().weight_semantic
+        + GraphScoringConfig::default().weight_hotness
+        + GraphScoringConfig::default().weight_utility;
+    assert!(
+        result.entities.iter().all(|e| e.score <= ceiling),
+        "a corroborated entity outscored a perfect match: {:?}",
+        names(&result.entities)
+    );
+}
+
+/// Access counts are symmetric: an entity that only ever arrives over the
+/// graph warms up exactly like a semantic hit does. Without this the graph
+/// tail can never gain hotness, so it can never rise — a feedback loop that
+/// keeps the graph coldest where the graph is doing the work.
+#[tokio::test]
+async fn golden_query_graph_expanded_results_warm_up() {
+    let graph = GoldenGraph::seed().await;
+
+    let first = graph.query(RUST_QUERY, &borrow_checker_anchor()).await;
+    let expanded = find(&first.entities, INES).expect("expanded neighbor missing");
+    assert!(
+        matches!(expanded.source, MatchSource::Graph { .. }),
+        "INES must arrive over the graph"
+    );
+    assert_eq!(expanded.entity.access_count, 0, "unread at first query");
+
+    let second = graph.query(RUST_QUERY, &borrow_checker_anchor()).await;
+    let semantic = find(&second.entities, BORROW_CHECKER).expect("anchor missing");
+    let expanded = find(&second.entities, INES).expect("expanded neighbor missing");
+
+    assert_eq!(
+        semantic.entity.access_count, 1,
+        "semantic hit did not warm (baseline behavior)"
+    );
+    assert_eq!(
+        expanded.entity.access_count,
+        1,
+        "graph-expanded result did not warm: {:?}",
+        names(&second.entities)
     );
 }
 

--- a/tests/serve_extract.rs
+++ b/tests/serve_extract.rs
@@ -1,0 +1,566 @@
+//! Background extraction scheduling: *when* the daemon extracts.
+//!
+//! The property under test is scheduling, not extraction — so there is no
+//! store and no model here. The clock is injected, so "wait for quiet" is a
+//! decision rather than a sleep, and the unit of work is a fake that calls a
+//! test provider: `NoModel` panics if it is called at all, `CountingModel`
+//! counts, `FailingModel` fails. Every assertion about cost is an assertion
+//! about that count.
+
+#![cfg(feature = "llm")]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use async_trait::async_trait;
+use recall_echo::config::ExtractionSection;
+use recall_echo::graph::error::GraphError;
+use recall_echo::graph::llm::LlmProvider;
+use recall_echo::graph::GraphMemory;
+use recall_echo::serve::{DaemonLog, ExtractionState, IdleTracker, ShutdownSignal};
+use recall_echo::serve_extract::{
+    self, Clock, ExtractionUnit, ExtractionWorker, Plan, Schedule, Setup, UnitReport, WorkerContext,
+};
+use tempfile::TempDir;
+
+/// Quiet period every test uses. Never actually waited for — the clock moves.
+const IDLE_AFTER: Duration = Duration::from_secs(60);
+/// Real time between the worker's quiet checks.
+const POLL: Duration = Duration::from_millis(5);
+/// How long a test waits for the worker to reach an expected state.
+const SETTLE: Duration = Duration::from_secs(5);
+
+// ── Clock ────────────────────────────────────────────────────────────────
+
+/// A clock the test moves by hand.
+struct ManualClock(Mutex<Instant>);
+
+impl ManualClock {
+    fn new() -> Arc<Self> {
+        Arc::new(Self(Mutex::new(Instant::now())))
+    }
+
+    /// Place the clock at a chosen distance from real time. The idle tracker
+    /// is touched with real instants (it is the daemon's own clock, not the
+    /// worker's), so the two must be positioned relative to each other rather
+    /// than nudged forward independently.
+    fn set_ahead_of_now(&self, by: Duration) {
+        *self.0.lock().unwrap() = Instant::now() + by;
+    }
+}
+
+impl Clock for ManualClock {
+    fn now(&self) -> Instant {
+        *self.0.lock().unwrap()
+    }
+}
+
+// ── Providers ────────────────────────────────────────────────────────────
+
+/// Fatal on use: the assertion that no model call was paid for.
+struct NoModel;
+
+#[async_trait]
+impl LlmProvider for NoModel {
+    async fn complete(&self, _system: &str, user: &str, _max: u32) -> Result<String, GraphError> {
+        panic!("background extraction called a model it should not have:\n{user}");
+    }
+}
+
+/// Counts calls and answers with a canned string.
+#[derive(Default)]
+struct CountingModel {
+    calls: AtomicUsize,
+}
+
+impl CountingModel {
+    fn shared() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for CountingModel {
+    async fn complete(&self, _system: &str, _user: &str, _max: u32) -> Result<String, GraphError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Ok("{}".into())
+    }
+}
+
+/// Counts calls and fails every one of them — a wedged provider.
+#[derive(Default)]
+struct FailingModel {
+    calls: AtomicUsize,
+}
+
+impl FailingModel {
+    fn shared() -> Arc<Self> {
+        Arc::new(Self::default())
+    }
+
+    fn calls(&self) -> usize {
+        self.calls.load(Ordering::SeqCst)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for FailingModel {
+    async fn complete(&self, _system: &str, _user: &str, _max: u32) -> Result<String, GraphError> {
+        self.calls.fetch_add(1, Ordering::SeqCst);
+        Err(GraphError::Llm("provider is wedged".into()))
+    }
+}
+
+// ── Unit of work ─────────────────────────────────────────────────────────
+
+/// An archive queue backed by a test provider instead of a store.
+struct FakeUnit {
+    llm: Arc<dyn LlmProvider>,
+    pending: Mutex<Vec<u32>>,
+    extracted: Mutex<Vec<u32>>,
+    quarantined: Mutex<Vec<u32>>,
+    /// Triggered right after the first archive is extracted, to model an admin
+    /// operation arriving mid-batch.
+    stop_after_first: Option<Arc<ShutdownSignal>>,
+}
+
+impl FakeUnit {
+    fn new(llm: Arc<dyn LlmProvider>, pending: &[u32]) -> Arc<Self> {
+        Arc::new(Self {
+            llm,
+            pending: Mutex::new(pending.to_vec()),
+            extracted: Mutex::new(Vec::new()),
+            quarantined: Mutex::new(Vec::new()),
+            stop_after_first: None,
+        })
+    }
+
+    fn stopping_after_first(
+        llm: Arc<dyn LlmProvider>,
+        pending: &[u32],
+        shutdown: Arc<ShutdownSignal>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            llm,
+            pending: Mutex::new(pending.to_vec()),
+            extracted: Mutex::new(Vec::new()),
+            quarantined: Mutex::new(Vec::new()),
+            stop_after_first: Some(shutdown),
+        })
+    }
+
+    fn extracted(&self) -> Vec<u32> {
+        self.extracted.lock().unwrap().clone()
+    }
+
+    fn quarantined(&self) -> Vec<u32> {
+        self.quarantined.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl ExtractionUnit for FakeUnit {
+    async fn pending(&self, limit: usize) -> Result<Vec<u32>, GraphError> {
+        Ok(self
+            .pending
+            .lock()
+            .unwrap()
+            .iter()
+            .copied()
+            .take(limit)
+            .collect())
+    }
+
+    async fn extract(&self, log_number: u32) -> Result<UnitReport, GraphError> {
+        self.llm
+            .complete("extract", &format!("log {log_number}"), 1024)
+            .await?;
+        self.pending.lock().unwrap().retain(|n| *n != log_number);
+        self.extracted.lock().unwrap().push(log_number);
+        if let Some(shutdown) = &self.stop_after_first {
+            shutdown.trigger();
+        }
+        Ok(UnitReport {
+            entities: 2,
+            relationships: 1,
+        })
+    }
+
+    async fn quarantine(&self, log_number: u32, _reason: &str) {
+        self.quarantined.lock().unwrap().push(log_number);
+    }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────
+
+/// A worker wired to a manual clock, a live idle tracker and a throwaway log.
+struct Harness {
+    _dir: TempDir,
+    clock: Arc<ManualClock>,
+    idle: Arc<IdleTracker>,
+    shutdown: Arc<ShutdownSignal>,
+    state: Arc<ExtractionState>,
+    log: Arc<DaemonLog>,
+}
+
+impl Harness {
+    fn new() -> Self {
+        let dir = TempDir::new().expect("temp dir");
+        let clock = ManualClock::new();
+        Self {
+            idle: Arc::new(IdleTracker::new_at(
+                Some(Duration::from_secs(3600)),
+                clock.now(),
+            )),
+            shutdown: Arc::new(ShutdownSignal::new()),
+            state: ExtractionState::shared(),
+            log: Arc::new(DaemonLog::open(&dir.path().join("daemon.log"), false)),
+            clock,
+            _dir: dir,
+        }
+    }
+
+    fn schedule(&self, batch_size: usize) -> Schedule {
+        Schedule {
+            idle_after: IDLE_AFTER,
+            batch_size,
+            poll_interval: POLL,
+        }
+    }
+
+    fn spawn(
+        &self,
+        batch_size: usize,
+        unit: Arc<dyn ExtractionUnit>,
+    ) -> tokio::task::JoinHandle<()> {
+        let worker = ExtractionWorker::new(
+            self.schedule(batch_size),
+            WorkerContext {
+                idle: Arc::clone(&self.idle),
+                shutdown: Arc::clone(&self.shutdown),
+                state: Arc::clone(&self.state),
+                log: Arc::clone(&self.log),
+                clock: Arc::clone(&self.clock) as Arc<dyn Clock>,
+            },
+        );
+        tokio::spawn(worker.run(unit))
+    }
+
+    /// Move the worker's clock past the quiet threshold.
+    fn become_quiet(&self) {
+        self.clock
+            .set_ahead_of_now(IDLE_AFTER + Duration::from_secs(1));
+    }
+
+    /// Put the worker's clock back at the present: the daemon was used just now.
+    fn become_busy(&self) {
+        self.clock.set_ahead_of_now(Duration::ZERO);
+    }
+
+    async fn stop(&self, worker: tokio::task::JoinHandle<()>) {
+        self.shutdown.trigger();
+        tokio::time::timeout(SETTLE, worker)
+            .await
+            .expect("worker stops when the daemon does")
+            .expect("worker did not panic");
+    }
+}
+
+/// Wait until `condition` holds, or fail the test.
+async fn eventually(what: &str, mut condition: impl FnMut() -> bool) {
+    let deadline = Instant::now() + SETTLE;
+    while Instant::now() < deadline {
+        if condition() {
+            return;
+        }
+        tokio::time::sleep(POLL).await;
+    }
+    panic!("timed out waiting for {what}");
+}
+
+/// Give the worker several poll cycles to prove it does nothing.
+async fn let_it_run() {
+    tokio::time::sleep(POLL * 20).await;
+}
+
+// ── Scheduling ───────────────────────────────────────────────────────────
+
+/// The daemon must be quiet before a single token is spent.
+#[tokio::test]
+async fn the_worker_waits_for_quiet_before_extracting() {
+    let harness = Harness::new();
+    let model = CountingModel::shared();
+    let unit = FakeUnit::new(model.clone(), &[1, 2, 3, 4]);
+    let worker = harness.spawn(3, unit.clone());
+
+    let_it_run().await;
+    assert_eq!(
+        model.calls(),
+        0,
+        "extraction started before the quiet period"
+    );
+    assert!(unit.extracted().is_empty());
+
+    harness.become_quiet();
+    eventually("the first batch", || unit.extracted().len() == 3).await;
+    assert_eq!(model.calls(), 3);
+
+    harness.stop(worker).await;
+}
+
+/// An open connection makes the daemon un-quiet, whatever the clock says.
+#[tokio::test]
+async fn an_open_connection_holds_background_work_back() {
+    let harness = Harness::new();
+    let unit = FakeUnit::new(Arc::new(NoModel), &[1, 2, 3]);
+    harness.idle.begin();
+    harness.become_quiet();
+
+    let worker = harness.spawn(3, unit.clone());
+    let_it_run().await;
+    assert!(
+        unit.extracted().is_empty(),
+        "background work ran while a client was connected"
+    );
+
+    harness.stop(worker).await;
+}
+
+/// A connection resets the quiet clock: work resumes only after the daemon has
+/// been left alone again.
+#[tokio::test]
+async fn work_resumes_a_full_quiet_period_after_a_client_leaves() {
+    let harness = Harness::new();
+    let model = CountingModel::shared();
+    let unit = FakeUnit::new(model.clone(), &[1]);
+
+    harness.idle.begin();
+    harness.become_quiet();
+    let worker = harness.spawn(1, unit.clone());
+    let_it_run().await;
+    assert_eq!(model.calls(), 0);
+
+    // The client leaves — that touches the tracker, so the quiet period starts
+    // over from the moment of the last request.
+    harness.idle.end();
+    harness.become_busy();
+    let_it_run().await;
+    assert_eq!(
+        model.calls(),
+        0,
+        "the quiet period restarted, so must the wait"
+    );
+
+    harness.become_quiet();
+    eventually("work after the client left", || model.calls() == 1).await;
+
+    harness.stop(worker).await;
+}
+
+/// One batch is bounded; the backlog drains over successive quiet periods.
+#[tokio::test]
+async fn a_batch_is_capped_and_the_backlog_drains_across_periods() {
+    let harness = Harness::new();
+    let model = CountingModel::shared();
+    let unit = FakeUnit::new(model.clone(), &[1, 2, 3, 4, 5]);
+    let worker = harness.spawn(2, unit.clone());
+
+    for expected in [2, 4, 5] {
+        harness.become_quiet();
+        eventually("the next batch", || unit.extracted().len() == expected).await;
+    }
+    assert_eq!(unit.extracted(), vec![1, 2, 3, 4, 5]);
+    assert_eq!(model.calls(), 5);
+
+    harness.stop(worker).await;
+}
+
+// ── Stopping ─────────────────────────────────────────────────────────────
+
+/// Shutdown mid-batch stops at the unit boundary: the rest of the batch is
+/// simply still pending, which is the whole crash-only contract.
+#[tokio::test]
+async fn shutdown_stops_the_batch_at_the_next_unit() {
+    let harness = Harness::new();
+    let model = CountingModel::shared();
+    let unit =
+        FakeUnit::stopping_after_first(model.clone(), &[1, 2, 3], Arc::clone(&harness.shutdown));
+    let worker = harness.spawn(3, unit.clone());
+    harness.become_quiet();
+
+    tokio::time::timeout(SETTLE, worker)
+        .await
+        .expect("worker stops as soon as shutdown is signalled")
+        .expect("worker did not panic");
+
+    assert_eq!(unit.extracted(), vec![1], "the batch ran past shutdown");
+    assert_eq!(model.calls(), 1);
+    assert_eq!(unit.pending(10).await.unwrap(), vec![2, 3]);
+}
+
+/// A daemon told to stop before its first tick spends nothing at all.
+#[tokio::test]
+async fn a_worker_that_never_starts_makes_no_model_calls() {
+    let harness = Harness::new();
+    let unit = FakeUnit::new(Arc::new(NoModel), &[1, 2, 3]);
+    harness.become_quiet();
+    harness.shutdown.trigger();
+
+    let worker = harness.spawn(3, unit.clone());
+    tokio::time::timeout(SETTLE, worker)
+        .await
+        .expect("worker stops immediately")
+        .expect("worker did not panic");
+    assert!(unit.extracted().is_empty());
+}
+
+// ── Idle shutdown ────────────────────────────────────────────────────────
+
+/// The daemon must not idle-exit with a batch in flight, and must still exit
+/// once the work stops.
+#[tokio::test]
+async fn a_batch_in_flight_defers_idle_shutdown_but_does_not_cancel_it() {
+    let harness = Harness::new();
+    let model = CountingModel::shared();
+    let unit = FakeUnit::new(model.clone(), &[1]);
+    let worker = harness.spawn(1, unit.clone());
+
+    harness.become_quiet();
+    eventually("the only archive", || model.calls() == 1).await;
+
+    // Nothing left to do: the daemon is free to idle out again.
+    let long_after = Instant::now() + Duration::from_secs(86_400);
+    eventually("idle shutdown to become possible again", || {
+        harness.idle.is_idle_at(long_after)
+    })
+    .await;
+
+    harness.stop(worker).await;
+}
+
+// ── Failure handling ─────────────────────────────────────────────────────
+
+/// A provider that fails every call must not be retried forever.
+#[tokio::test]
+async fn a_wedged_provider_disables_the_worker_instead_of_looping() {
+    let harness = Harness::new();
+    let model = FailingModel::shared();
+    let unit = FakeUnit::new(model.clone(), &[1, 2, 3, 4, 5]);
+    let worker = harness.spawn(5, unit.clone());
+    harness.become_quiet();
+
+    tokio::time::timeout(SETTLE, worker)
+        .await
+        .expect("worker gives up on a wedged provider")
+        .expect("worker did not panic");
+
+    assert_eq!(
+        model.calls(),
+        3,
+        "the worker kept calling a wedged provider"
+    );
+    let status = harness.state.snapshot(Instant::now());
+    assert!(!status.enabled);
+    assert!(
+        status
+            .disabled_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("in a row")),
+        "{status:?}"
+    );
+    assert!(status.last_error.is_some());
+}
+
+/// One archive that cannot be extracted must not block the queue behind it or
+/// cost a model call on every pass.
+#[tokio::test]
+async fn a_failing_archive_is_quarantined_after_two_attempts() {
+    let harness = Harness::new();
+    let model = FailingModel::shared();
+    let unit = FakeUnit::new(model.clone(), &[7]);
+    let worker = harness.spawn(3, unit.clone());
+
+    harness.become_quiet();
+    eventually("the archive to be set aside", || {
+        unit.quarantined() == vec![7]
+    })
+    .await;
+
+    // Two attempts, then never again — even as quiet periods keep arriving.
+    for _ in 0..3 {
+        harness.become_quiet();
+        let_it_run().await;
+    }
+    assert_eq!(model.calls(), 2, "a quarantined archive was retried");
+
+    harness.stop(worker).await;
+}
+
+// ── Wiring ───────────────────────────────────────────────────────────────
+
+/// `background_enabled = false` must build no provider and start no worker.
+#[tokio::test]
+async fn the_disabled_path_starts_nothing() {
+    let dir = TempDir::new().expect("temp dir");
+    let memory_dir = dir.path().join("memory");
+    std::fs::create_dir_all(memory_dir.join("conversations")).expect("conversations");
+    let graph_dir = memory_dir.join("graph");
+    std::fs::create_dir_all(&graph_dir).expect("graph dir");
+    std::fs::write(
+        memory_dir.join(".recall-echo.toml"),
+        "[extraction]\nbackground_enabled = false\n",
+    )
+    .expect("write config");
+
+    let state = ExtractionState::shared();
+    let graph = GraphMemory::open_embedded(&graph_dir).await.expect("store");
+    let handle = serve_extract::spawn(Setup {
+        memory_dir: memory_dir.clone(),
+        graph: Arc::new(graph),
+        idle: Arc::new(IdleTracker::new(None)),
+        shutdown: Arc::new(ShutdownSignal::new()),
+        state: Arc::clone(&state),
+        log: Arc::new(DaemonLog::open(&graph_dir.join("daemon.log"), false)),
+    });
+
+    assert!(handle.is_none(), "a disabled worker must not be spawned");
+    let status = state.snapshot(Instant::now());
+    assert!(!status.enabled);
+    assert!(
+        status
+            .disabled_reason
+            .as_deref()
+            .is_some_and(|reason| reason.contains("background_enabled")),
+        "{status:?}"
+    );
+    assert_eq!(status.runs, 0);
+}
+
+/// The two refusals that are policy rather than accident.
+#[test]
+fn the_plan_refuses_opt_out_and_server_mode() {
+    let default = ExtractionSection::default();
+    assert!(matches!(
+        serve_extract::plan(&default, "embedded"),
+        Plan::Run(_)
+    ));
+    assert!(matches!(
+        serve_extract::plan(&default, "server"),
+        Plan::Off(_)
+    ));
+    assert!(matches!(
+        serve_extract::plan(
+            &ExtractionSection {
+                background_enabled: false,
+                ..ExtractionSection::default()
+            },
+            "embedded"
+        ),
+        Plan::Off(_)
+    ));
+}


### PR DESCRIPTION
Phase 2 of the v4 roadmap, re-plotted after measurement inverted its priorities. **0% → 77.8%** on the LongMemEval subset, with every step measured.

## The measurement that redirected the phase

The roadmap assumed retrieval quality was the lever. A context-presence analysis of the nine baseline failures said otherwise: 2 absent from retrieval, 5 dropped in assembly, 2 present-but-unused — and the store held the answer in **9 of 9**. Assembly, not retrieval, was the bottleneck.

## Results

| | baseline | +assembly | +re-ingest |
|---|---|---|---|
| Answer accuracy (n=9) | 0.0% | 55.6% | **77.8%** |
| Recall@3 | 0.648 | 0.833 | 0.972 |
| Recall@full | 0.676 | 1.000 | 1.000 |
| MRR | 0.778 | 0.903 | 0.944 |

Full record with limitations in `docs/benchmarks/phase2-final-2026-08.md`.

## What landed

**Assembly.** `ranked_search` required *every* query token to appear in a file, so the archive channel returned nothing for any natural-language question — 0 snippets across all 10 baseline prompts. Now OR-qualification with a coordination factor and corpus-frequency token selection. Episode abstracts were cut at 200 chars mid-word (one failure severed the gold answer and the model answered from the fragment); now 1,000 chars on sentence boundaries. `episode_top_k` decoupled from `archive_top_k` and raised to where the HNSW index stabilises.

**Dedup cost.** Gating on the blended retrieval score meant a *hot* entity qualified for a paid LLM comparison at ~0.33 actual similarity, and bigger graphs have more hot entities — cost grew with graph size. Now gated on raw cosine with three bands and an exact-name fast path. Measured over a full re-ingest: **25,810 decisions, 37% needed a call, 16,271 avoided** (previously ~94%), and per-conversation time no longer grows with the graph.

**Retrieval scoring.** Graph corroboration was discarded on collision; graph candidates lacked the hotness/utility terms semantic ones carried, making confidence near-binary; only semantic results warmed. All three fixed, with thresholds calibrated against measured similarity distributions from real stores rather than round numbers. Four golden tests added, one changed (it had silently encoded the defect).

**MCP server.** The graph was write-only in practice — SessionEnd ingests, SessionStart only prints EPHEMERAL.md, and nothing queried the graph during a session. `recall-echo mcp` gives any MCP client five read tools over the daemon. No write tool, deliberately: model-controlled writes would route around the provenance weighting that exists to stop the agent's own assertions counting as evidence.

**Background extraction.** Entity extraction was the last thing on the honor system — episodes ingested automatically, but the graph only gained entities if a human ran `graph extract`. The daemon now extracts during quiet periods, yielding to any arriving request, crash-safe per archive. Default on and structurally safe: the env allowlist added during the security audit means auto-started daemons cannot construct a paid provider.

**Also**: schemeless server URLs accepted again (the `engine::any` change broke live configs — caught on the running entity).

529 tests, clippy -D warnings clean, `tests/query_golden.rs` green throughout.

Closes #37