### PR TITLE
feat: tell it when it's wrong, and see what it knows

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,19 @@ On a LongMemEval subset it went from answering **0 of 9** questions correctly to
 When you *do* want to poke at it:
 
 ```bash
+recall-echo what-do-you-know            # everything it thinks it knows, and how sure it is
+recall-echo what-do-you-know --about D  # …on one subject
 recall-echo status                      # is it healthy, what has it got
 recall-echo search "deployment"         # grep your conversation history
 recall-echo graph query "auth flow"     # semantic search + related entities
 recall-echo graph traverse "recall-echo" # what's connected to what, with confidence
+```
+
+And when it has something wrong — which it will — you tell it so:
+
+```bash
+recall-echo graph correct "D" "USES" "Vim" --wrong   # that claim is mistaken
+recall-echo graph correct "Vim" --forget             # that memory should not exist
 ```
 
 And from inside your agent, once the MCP server is registered, it asks for itself:
@@ -127,6 +136,11 @@ recall-echo graph status                        # Show graph statistics
 recall-echo graph search <query>                # Semantic search across entities
 recall-echo graph query <query>                 # Hybrid: semantic + graph expansion + episodes
 recall-echo graph traverse <entity>             # Graph traversal from entity (shows confidence)
+
+# Reading and correcting it
+recall-echo what-do-you-know                    # What memory holds, and how sure it is
+recall-echo graph correct <from> <REL> <to> --wrong   # That claim is mistaken
+recall-echo graph correct <entity> --forget           # Remove it outright (asks first)
 
 # Data management
 recall-echo graph add-entity --name <n> --type <t> --abstract <a>   # Add entity manually
@@ -302,6 +316,20 @@ Knowledge graph operations. See the Architecture section above for the full comm
 - `graph ingest-all` — Scan conversations/ and ingest all un-ingested archives.
 - `graph extract` — LLM-powered entity extraction. Supports `--log <N>` (single archive), `--all` (all un-extracted), `--dry-run`, `--model`, `--provider` (any name from [LLM providers](#llm-providers)), `--delay-ms`. The daemon runs this pass on its own once the machine is quiet (see [Background extraction](#background-extraction)); this command is how you run it *now*, or in `server` mode, or after changing the model.
 
+**Correction:**
+
+- `graph correct <entity> --wrong` — Record that what memory claims about an entity is mistaken. Claims live on relationships, so this contradicts the entity's relationship — and if it has several, it lists them and asks which rather than guessing. `--all-edges` contradicts every one of them deliberately.
+- `graph correct <from> <REL> <to> --wrong` — Contradict one specific claim. Direction does not have to match how the graph stored it.
+- `graph correct <name> --forget` — Remove an entity and its relationships, or with a `<from> <REL> <to>` triple, one relationship. Prints what would go and asks before doing it; `--yes` skips the prompt, and a non-interactive stdin is never taken as consent.
+
+A correction is *evidence*, not an override. `--wrong` records one contradicting
+observation at your authority ([`weight_user`](#configuration), 0.8 by default) and
+lets the Beta posterior move: a claim resting on twenty independent
+observations survives one correction with reduced confidence, a claim resting
+on one collapses. Say it twice and it counts twice. `--forget` is the escape
+hatch for memory that should not exist at all — it leaves no trace and cannot
+be re-weighed, so prefer `--wrong`.
+
 **Daemon:**
 
 - `graph daemon status` — Socket path, pid, version and uptime of the daemon serving this graph.
@@ -314,6 +342,27 @@ Knowledge graph operations. See the Architecture section above for the full comm
 - `graph pipeline flow <entity>` — Trace an entity's lineage through the pipeline stages.
 - `graph pipeline stale` — List stale pipeline entities. Supports `--days` (threshold, default 7).
 - `graph vigil-sync` — Sync vigil-pulse metacognitive signals and caliber outcomes into the graph as Measurement and Outcome entities. Supports `--signals-path` and `--outcomes-path`.
+
+### `recall-echo what-do-you-know`
+
+What memory actually holds, written for a person rather than a program.
+
+```bash
+recall-echo what-do-you-know                 # everything, grouped by entity type
+recall-echo what-do-you-know --about "rust"  # one subject, with its relationships
+recall-echo what-do-you-know --limit 5       # entities listed per type (default 3)
+```
+
+Without `--about` it lists the strongest entities of each type, then how firmly
+the relationships between them are held, then the two things a confidence
+number cannot tell you on its own: which relationships it is least sure of, and
+which ones it believes largely because it kept repeating them (`self×N` — the
+coherence tally, deliberately kept out of confidence). With `--about` it runs
+the ordinary hybrid query and renders each hit with the claims it takes part in
+and how sure it is of each.
+
+Everything it prints ends in the same place: if a line is wrong, `graph correct`
+is how you say so.
 
 ### `recall-echo serve`
 
@@ -367,7 +416,7 @@ Or, equivalently, in a project's `.mcp.json`:
 `--entity-root` defaults to the current directory, so it can be omitted when
 the client is launched from the entity root.
 
-**Tools.** All five are read-only; none can write to the graph.
+**Tools.** All six are read-only; none can write to the graph.
 
 | Tool | Answers |
 | --- | --- |
@@ -375,6 +424,7 @@ the client is launched from the entity root.
 | `recall_search` | Semantic entity search alone — names, types, abstracts, retrieval scores |
 | `recall_episodes` | The raw conversation fragments, for what was actually said |
 | `recall_traverse` | Relationships out of one named entity, as a tree with edge confidence |
+| `recall_overview` | What memory holds without being asked for anything in particular — the content, and where it is unsure |
 | `recall_status` | Entity, relationship and episode counts — tells an empty memory from a failed lookup |
 
 Every tool runs through the same graph daemon as the CLI, so it inherits the
@@ -386,6 +436,11 @@ about itself (`[graph.provenance]`), and a tool that let the model create
 entities and edges directly would route around exactly that mechanism. Memory
 is written on the ingest path, where every episode is stamped with its
 authorship.
+
+**So is correction.** `graph correct` enters a contradiction at *user*
+authority, which is only true while a human is the one typing it — a model
+calling a correction tool would be recording its own judgement as yours.
+Corrections stay on the CLI.
 
 ## Archive Format
 

--- a/src/config_cli.rs
+++ b/src/config_cli.rs
@@ -62,6 +62,10 @@ pub fn show(memory_dir: &Path) -> Result<(), RecallError> {
         );
     }
 
+    show_capture_section(&cfg.capture);
+    show_extraction_section(&cfg.extraction);
+    show_serve_section(&cfg.serve);
+
     // Pipeline
     if let Some(ref pipeline) = cfg.pipeline {
         eprintln!("\n{BOLD}[pipeline]{RESET}");
@@ -76,6 +80,61 @@ pub fn show(memory_dir: &Path) -> Result<(), RecallError> {
     }
 
     Ok(())
+}
+
+/// Which agent CLIs the daemon sweeps transcripts from.
+///
+/// Shown even at its defaults: "sessions are being imported from every CLI on
+/// this machine" is a thing a user debugging their setup needs to know, and it
+/// is invisible in a config file that never mentions it.
+fn show_capture_section(capture: &config::CaptureSection) {
+    eprintln!("\n{BOLD}[capture]{RESET}");
+    eprintln!("  enabled     = {}", capture.enabled);
+    let sources = match &capture.sources {
+        Some(sources) if !sources.is_empty() => sources
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(", "),
+        _ => "(every CLI with sessions on this machine)".to_string(),
+    };
+    eprintln!("  sources     = {sources}");
+    eprintln!(
+        "  settle_secs = {} {DIM}(a transcript must be this quiet to count as finished){RESET}",
+        capture.settle_secs
+    );
+}
+
+/// Background entity extraction inside the graph daemon.
+fn show_extraction_section(extraction: &config::ExtractionSection) {
+    eprintln!("\n{BOLD}[extraction]{RESET}");
+    eprintln!("  background_enabled = {}", extraction.background_enabled);
+    eprintln!(
+        "  idle_after_secs    = {} {DIM}(quiet period before a batch starts){RESET}",
+        extraction.idle_after_secs
+    );
+    eprintln!(
+        "  batch_size         = {} {DIM}(archives per batch){RESET}",
+        extraction.batch_size
+    );
+}
+
+/// Where the graph daemon listens and how long it lives.
+fn show_serve_section(serve: &config::ServeSection) {
+    eprintln!("\n{BOLD}[serve]{RESET}");
+    let socket = serve
+        .socket_path
+        .as_deref()
+        .filter(|path| !path.trim().is_empty());
+    match socket {
+        Some(path) => eprintln!("  socket_path       = {path}"),
+        None => eprintln!("  socket_path       = {DIM}(derived from the memory directory){RESET}"),
+    }
+    let idle = match serve.idle_timeout_secs {
+        0 => "0 (never idle-shuts-down)".to_string(),
+        secs => format!("{secs}"),
+    };
+    eprintln!("  idle_timeout_secs = {idle}");
 }
 
 /// Show the resolved agent-CLI call, so a misconfigured vendor is visible

--- a/src/graph/correct.rs
+++ b/src/graph/correct.rs
@@ -1,0 +1,574 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Human correction — telling memory that something it learned is wrong.
+//!
+//! # Why this is evidence, not a delete
+//!
+//! Everything else in the graph moves confidence by *observation*: an edge is
+//! corroborated or contradicted, the Beta counts move, the posterior mean
+//! follows. A human saying "that's wrong" is the highest-authority observation
+//! the system can receive, so it enters the same way — as contradicting
+//! evidence at [`Provenance::User`] weight — rather than as a silent write of
+//! a lower number or a quiet delete.
+//!
+//! That buys three things a delete cannot. The correction accumulates (saying
+//! it twice is twice the evidence). It stays visible (`graph decay-report`
+//! shows the counts that moved). And it degrades gracefully: an edge that was
+//! believed for good reason survives one contradiction with reduced
+//! confidence, which is the correct posture when a human and thirty
+//! observations disagree.
+//!
+//! # What `--wrong` on an *entity* means
+//!
+//! An entity has no truth value. "Rust" is not true or false; what can be
+//! wrong is a claim *about* Rust, and claims live on edges. So contradicting
+//! an entity means contradicting the claims it takes part in.
+//!
+//! Which claims is exactly the ambiguity, so this module refuses to guess: one
+//! live edge is unambiguous and is contradicted, several are reported back for
+//! the human to choose between, and contradicting all of them is available but
+//! must be asked for. Nothing is damaged on a guess.
+//!
+//! # Removal
+//!
+//! [`Correction::Forget`] is the escape hatch for memory that should not exist
+//! at all rather than be believed less. It is destructive, so the plan and the
+//! act are two separate requests: an unconfirmed forget only reports what would
+//! go, and nothing is removed until a caller sends `confirmed`.
+
+use serde::{Deserialize, Serialize};
+use surrealdb::Surreal;
+
+use super::confidence::{Provenance, ProvenanceWeights};
+use super::edge_view::{self, EdgeView, NameCache};
+use super::error::GraphError;
+use super::store::Db;
+use super::types::Relationship;
+
+/// Near-misses shown when a name does not resolve.
+const MAX_CANDIDATES: usize = 5;
+
+/// Below this similarity a name is not a near-miss, it is a different name.
+const CANDIDATE_FLOOR: f64 = 0.34;
+
+/// What a correction is aimed at.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum CorrectTarget {
+    /// Everything the graph claims about one entity.
+    Entity { name: String },
+    /// One specific claim.
+    Edge {
+        from: String,
+        rel_type: String,
+        to: String,
+    },
+}
+
+/// What to do to the target.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum Correction {
+    /// Record contradicting evidence at user authority.
+    Wrong {
+        /// Contradict every live edge of an entity instead of refusing to
+        /// choose between them.
+        #[serde(default)]
+        all_edges: bool,
+    },
+    /// Remove outright. Nothing is deleted unless `confirmed`.
+    Forget {
+        #[serde(default)]
+        confirmed: bool,
+    },
+}
+
+/// An entity, named well enough for a person to recognise it.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EntityMatch {
+    pub id: String,
+    pub name: String,
+    pub entity_type: String,
+}
+
+/// One edge after a contradiction, next to where it stood before.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EdgeCorrection {
+    /// The edge as it now stands.
+    pub edge: EdgeView,
+    /// Posterior mean before the contradiction was recorded.
+    pub confidence_before: f64,
+    /// Evidence weight before the contradiction was recorded.
+    pub evidence_before: f64,
+}
+
+/// What a forget would take, or did.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct Removal {
+    /// The entity going away. Absent when only an edge was targeted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub entity: Option<EntityMatch>,
+    /// Every relationship going away with it, superseded ones included.
+    pub edges: Vec<EdgeView>,
+}
+
+/// The result of one correction request.
+///
+/// Every outcome that changed nothing says why, and says it with enough detail
+/// for the caller to make a better request — because the alternative to
+/// refusing is damaging the wrong memory.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "outcome", rename_all = "snake_case")]
+pub enum CorrectionReport {
+    /// The name matched no entity. `candidates` are the closest stored names.
+    UnknownEntity {
+        query: String,
+        candidates: Vec<EntityMatch>,
+    },
+    /// Both entities exist but no live edge of that type joins them.
+    /// `existing` is what does join them.
+    NoSuchEdge {
+        from: String,
+        to: String,
+        rel_type: String,
+        existing: Vec<EdgeView>,
+    },
+    /// The entity takes part in several claims; which one is wrong is the
+    /// caller's to say.
+    Ambiguous {
+        entity: String,
+        edges: Vec<EdgeView>,
+    },
+    /// The entity exists and is not connected to anything, so there is no
+    /// claim to contradict.
+    NothingToCorrect { entity: String },
+    /// Contradicting evidence was recorded.
+    Contradicted { edges: Vec<EdgeCorrection> },
+    /// What an unconfirmed forget would remove. Nothing was removed.
+    Planned { removal: Removal },
+    /// What a confirmed forget removed.
+    Removed { removal: Removal },
+}
+
+impl CorrectionReport {
+    /// Whether the store was changed.
+    #[must_use]
+    pub fn applied(&self) -> bool {
+        matches!(
+            self,
+            Self::Contradicted { .. } | Self::Removed { .. } | Self::Planned { .. }
+        )
+    }
+}
+
+/// Apply a correction, or report why it was refused.
+pub async fn correct(
+    db: &Surreal<Db>,
+    weights: &ProvenanceWeights,
+    target: &CorrectTarget,
+    correction: Correction,
+) -> Result<CorrectionReport, GraphError> {
+    match target {
+        CorrectTarget::Entity { name } => correct_entity(db, weights, name, correction).await,
+        CorrectTarget::Edge { from, rel_type, to } => {
+            correct_edge(db, weights, from, rel_type, to, correction).await
+        }
+    }
+}
+
+// ── Entity target ────────────────────────────────────────────────────────
+
+async fn correct_entity(
+    db: &Surreal<Db>,
+    weights: &ProvenanceWeights,
+    name: &str,
+    correction: Correction,
+) -> Result<CorrectionReport, GraphError> {
+    let entity = match resolve(db, name).await? {
+        Resolution::Found(entity) => entity,
+        Resolution::Unresolved(report) => return Ok(report),
+    };
+
+    match correction {
+        Correction::Wrong { all_edges } => contradict_entity(db, weights, &entity, all_edges).await,
+        Correction::Forget { confirmed } => forget_entity(db, &entity, confirmed).await,
+    }
+}
+
+/// Contradict what the graph claims about one entity.
+///
+/// One live edge is what the human meant. Several are not, and guessing which
+/// would damage a memory the human never mentioned — so the choice goes back
+/// to them, unless they asked for all of it.
+async fn contradict_entity(
+    db: &Surreal<Db>,
+    weights: &ProvenanceWeights,
+    entity: &EntityMatch,
+    all_edges: bool,
+) -> Result<CorrectionReport, GraphError> {
+    let edges = edge_view::live_edges_of(db, &entity.id).await?;
+
+    if edges.is_empty() {
+        return Ok(CorrectionReport::NothingToCorrect {
+            entity: entity.name.clone(),
+        });
+    }
+    if edges.len() > 1 && !all_edges {
+        let mut cache = NameCache::new();
+        return Ok(CorrectionReport::Ambiguous {
+            entity: entity.name.clone(),
+            edges: edge_view::views(db, &mut cache, &edges).await?,
+        });
+    }
+
+    contradict(db, weights, &edges).await
+}
+
+async fn forget_entity(
+    db: &Surreal<Db>,
+    entity: &EntityMatch,
+    confirmed: bool,
+) -> Result<CorrectionReport, GraphError> {
+    let edges = edge_view::all_edges_of(db, &entity.id).await?;
+    let mut cache = NameCache::new();
+    let removal = Removal {
+        entity: Some(entity.clone()),
+        edges: edge_view::views(db, &mut cache, &edges).await?,
+    };
+
+    if !confirmed {
+        return Ok(CorrectionReport::Planned { removal });
+    }
+    super::crud::delete_entity(db, &entity.id).await?;
+    Ok(CorrectionReport::Removed { removal })
+}
+
+// ── Edge target ──────────────────────────────────────────────────────────
+
+async fn correct_edge(
+    db: &Surreal<Db>,
+    weights: &ProvenanceWeights,
+    from: &str,
+    rel_type: &str,
+    to: &str,
+    correction: Correction,
+) -> Result<CorrectionReport, GraphError> {
+    let source = match resolve(db, from).await? {
+        Resolution::Found(entity) => entity,
+        Resolution::Unresolved(report) => return Ok(report),
+    };
+    let target = match resolve(db, to).await? {
+        Resolution::Found(entity) => entity,
+        Resolution::Unresolved(report) => return Ok(report),
+    };
+
+    let between = edge_view::live_edges_between(db, &source.id, &target.id).await?;
+    let matched: Vec<Relationship> = between
+        .iter()
+        .filter(|edge| edge.rel_type.eq_ignore_ascii_case(rel_type))
+        .cloned()
+        .collect();
+
+    if matched.is_empty() {
+        let mut cache = NameCache::new();
+        return Ok(CorrectionReport::NoSuchEdge {
+            from: source.name,
+            to: target.name,
+            rel_type: rel_type.to_string(),
+            existing: edge_view::views(db, &mut cache, &between).await?,
+        });
+    }
+
+    match correction {
+        Correction::Wrong { .. } => contradict(db, weights, &matched).await,
+        Correction::Forget { confirmed } => forget_edges(db, &matched, confirmed).await,
+    }
+}
+
+async fn forget_edges(
+    db: &Surreal<Db>,
+    edges: &[Relationship],
+    confirmed: bool,
+) -> Result<CorrectionReport, GraphError> {
+    let mut cache = NameCache::new();
+    let removal = Removal {
+        entity: None,
+        edges: edge_view::views(db, &mut cache, edges).await?,
+    };
+
+    if !confirmed {
+        return Ok(CorrectionReport::Planned { removal });
+    }
+    for edge in edges {
+        super::crud::delete_relationship(db, &edge.id_string()).await?;
+    }
+    Ok(CorrectionReport::Removed { removal })
+}
+
+// ── Contradiction ────────────────────────────────────────────────────────
+
+/// Record one contradicting observation, at user authority, on every edge.
+async fn contradict(
+    db: &Surreal<Db>,
+    weights: &ProvenanceWeights,
+    edges: &[Relationship],
+) -> Result<CorrectionReport, GraphError> {
+    let mut cache = NameCache::new();
+    let mut corrections = Vec::with_capacity(edges.len());
+
+    for edge in edges {
+        let mut evidence = edge.edge_evidence();
+        evidence.contradict(Provenance::User, weights);
+        super::crud::contradict_relationship(db, &edge.id_string(), evidence).await?;
+
+        let counts = evidence.evidence();
+        let from = cache
+            .name_of(db, &edge_view::record_id(&edge.from_id))
+            .await?;
+        let to = cache
+            .name_of(db, &edge_view::record_id(&edge.to_id))
+            .await?;
+        let mut view = EdgeView::of(edge, from, to);
+        let confidence_before = view.confidence;
+        let evidence_before = view.evidence;
+        view.confidence = counts.mean();
+        view.evidence = counts.concentration();
+
+        corrections.push(EdgeCorrection {
+            edge: view,
+            confidence_before,
+            evidence_before,
+        });
+    }
+
+    Ok(CorrectionReport::Contradicted { edges: corrections })
+}
+
+// ── Name resolution ──────────────────────────────────────────────────────
+
+/// Either the one entity a name means, or the report saying why it means no
+/// single entity.
+enum Resolution {
+    Found(EntityMatch),
+    Unresolved(CorrectionReport),
+}
+
+/// Resolve a typed name to exactly one stored entity.
+///
+/// Only an exact name — or a unique case-insensitive one — resolves. Anything
+/// else comes back as candidates for the human to choose from: a fuzzy match
+/// picked by the machine is a correction applied to a memory nobody named.
+async fn resolve(db: &Surreal<Db>, name: &str) -> Result<Resolution, GraphError> {
+    let index = entity_index(db).await?;
+    let query = name.trim();
+
+    if let Some(entity) = index.iter().find(|entity| entity.name == query) {
+        return Ok(Resolution::Found(entity.clone()));
+    }
+
+    let folded: Vec<&EntityMatch> = index
+        .iter()
+        .filter(|entity| entity.name.eq_ignore_ascii_case(query))
+        .collect();
+    if folded.len() == 1 {
+        return Ok(Resolution::Found(folded[0].clone()));
+    }
+    if folded.len() > 1 {
+        return Ok(Resolution::Unresolved(CorrectionReport::UnknownEntity {
+            query: query.to_string(),
+            candidates: folded.into_iter().cloned().collect(),
+        }));
+    }
+
+    Ok(Resolution::Unresolved(CorrectionReport::UnknownEntity {
+        query: query.to_string(),
+        candidates: nearest(query, &index),
+    }))
+}
+
+/// Every entity's identity, without the 384 floats attached to it.
+async fn entity_index(db: &Surreal<Db>) -> Result<Vec<EntityMatch>, GraphError> {
+    #[derive(serde::Deserialize)]
+    struct Row {
+        id: serde_json::Value,
+        name: String,
+        entity_type: String,
+    }
+
+    let mut response = db
+        .query("SELECT id, name, entity_type FROM entity ORDER BY name")
+        .await?;
+    let rows: Vec<Row> = super::deserialize_take(&mut response, 0)?;
+    Ok(rows
+        .into_iter()
+        .map(|row| EntityMatch {
+            id: edge_view::record_id(&row.id),
+            name: row.name,
+            entity_type: row.entity_type,
+        })
+        .collect())
+}
+
+/// The stored names closest to what was typed, best first.
+fn nearest(query: &str, index: &[EntityMatch]) -> Vec<EntityMatch> {
+    let query = query.to_lowercase();
+    let mut scored: Vec<(f64, &EntityMatch)> = index
+        .iter()
+        .map(|entity| (similarity(&query, &entity.name.to_lowercase()), entity))
+        .filter(|(score, _)| *score >= CANDIDATE_FLOOR)
+        .collect();
+
+    scored.sort_by(|left, right| {
+        right
+            .0
+            .partial_cmp(&left.0)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then_with(|| left.1.name.cmp(&right.1.name))
+    });
+    scored
+        .into_iter()
+        .take(MAX_CANDIDATES)
+        .map(|(_, entity)| entity.clone())
+        .collect()
+}
+
+/// How alike two lowercased names are, in `[0, 1]`.
+///
+/// Sørensen–Dice over character bigrams, which catches typos and word-order
+/// changes without a dependency. Containment scores high on its own: "recall"
+/// should surface "recall-echo" however few bigrams they share.
+fn similarity(query: &str, name: &str) -> f64 {
+    if query.is_empty() || name.is_empty() {
+        return 0.0;
+    }
+    if query == name {
+        return 1.0;
+    }
+
+    let dice = dice_coefficient(query, name);
+    if name.contains(query) || query.contains(name) {
+        return dice.max(0.9);
+    }
+    dice
+}
+
+fn dice_coefficient(left: &str, right: &str) -> f64 {
+    let left: Vec<[char; 2]> = bigrams(left);
+    let right: Vec<[char; 2]> = bigrams(right);
+    if left.is_empty() || right.is_empty() {
+        return 0.0;
+    }
+
+    let mut remaining = right.clone();
+    let mut shared = 0usize;
+    for bigram in &left {
+        if let Some(position) = remaining.iter().position(|other| other == bigram) {
+            remaining.swap_remove(position);
+            shared += 1;
+        }
+    }
+    (2.0 * shared as f64) / (left.len() + right.len()) as f64
+}
+
+fn bigrams(text: &str) -> Vec<[char; 2]> {
+    let chars: Vec<char> = text.chars().collect();
+    chars.windows(2).map(|pair| [pair[0], pair[1]]).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn index() -> Vec<EntityMatch> {
+        ["recall-echo", "pulse-null", "Rust", "rust", "Cargo"]
+            .into_iter()
+            .map(|name| EntityMatch {
+                id: format!("entity:{}", name.to_lowercase()),
+                name: name.to_string(),
+                entity_type: "tool".to_string(),
+            })
+            .collect()
+    }
+
+    #[test]
+    fn a_name_is_most_like_itself() {
+        assert_eq!(similarity("rust", "rust"), 1.0);
+        assert!(similarity("rust", "cargo") < CANDIDATE_FLOOR);
+    }
+
+    #[test]
+    fn a_typo_stays_a_near_miss() {
+        assert!(
+            similarity("recall-eco", "recall-echo") > CANDIDATE_FLOOR,
+            "{}",
+            similarity("recall-eco", "recall-echo")
+        );
+    }
+
+    #[test]
+    fn a_prefix_surfaces_the_whole_name() {
+        assert!(similarity("recall", "recall-echo") >= 0.9);
+    }
+
+    #[test]
+    fn candidates_are_the_closest_names_and_no_others() {
+        let candidates = nearest("recall", &index());
+        assert_eq!(
+            candidates.first().map(|entity| entity.name.as_str()),
+            Some("recall-echo")
+        );
+        assert!(
+            candidates.len() <= MAX_CANDIDATES,
+            "a wall of names is not a choice"
+        );
+        assert!(
+            !candidates.iter().any(|entity| entity.name == "Cargo"),
+            "unrelated names are not near-misses: {candidates:?}"
+        );
+    }
+
+    #[test]
+    fn nothing_is_close_to_nonsense() {
+        assert!(nearest("zzzzqqqq", &index()).is_empty());
+    }
+
+    #[test]
+    fn a_report_that_changed_nothing_says_so() {
+        assert!(!CorrectionReport::NothingToCorrect {
+            entity: "Rust".into()
+        }
+        .applied());
+        assert!(!CorrectionReport::UnknownEntity {
+            query: "Rust".into(),
+            candidates: Vec::new(),
+        }
+        .applied());
+        assert!(CorrectionReport::Contradicted { edges: Vec::new() }.applied());
+    }
+
+    #[test]
+    fn corrections_survive_the_daemon_wire_format() {
+        let target = CorrectTarget::Edge {
+            from: "D".into(),
+            rel_type: "USES".into(),
+            to: "Vim".into(),
+        };
+        let line = serde_json::to_string(&target).unwrap();
+        assert_eq!(
+            serde_json::from_str::<CorrectTarget>(&line).unwrap(),
+            target
+        );
+
+        // Optional modifiers may be omitted by an older client.
+        assert_eq!(
+            serde_json::from_str::<Correction>(r#"{"kind":"wrong"}"#).unwrap(),
+            Correction::Wrong { all_edges: false }
+        );
+        assert_eq!(
+            serde_json::from_str::<Correction>(r#"{"kind":"forget"}"#).unwrap(),
+            Correction::Forget { confirmed: false }
+        );
+    }
+}

--- a/src/graph/crud.rs
+++ b/src/graph/crud.rs
@@ -309,6 +309,41 @@ pub async fn reinforce_relationship(
     Ok(())
 }
 
+/// Persist updated evidence for a relationship **without** restarting its
+/// decay clock.
+///
+/// The write path for contradiction. [`reinforce_relationship`] sets
+/// `last_reinforced = now`, which is right for corroboration — the belief was
+/// just observed again, so it should stop decaying. Applying that to a
+/// contradiction would let "this is wrong" *raise* an edge's effective
+/// confidence: a stale edge stored at 0.6 and decayed to 0.3 would come back
+/// at 0.545 undecayed, more visible after the correction than before it.
+///
+/// Leaving the anchor alone makes the effect of a contradiction monotone: the
+/// posterior mean falls, and every decay already applied to it stays applied.
+pub async fn contradict_relationship(
+    db: &Surreal<Db>,
+    rel_id: &str,
+    evidence: EdgeEvidence,
+) -> Result<(), GraphError> {
+    let counts = evidence.evidence();
+    db.query(
+        r#"UPDATE type::record($id) SET
+               confidence = $confidence,
+               alpha = $alpha,
+               beta = $beta,
+               self_reinforcements = $self_reinforcements"#,
+    )
+    .bind(("id", rel_id.to_string()))
+    .bind(("confidence", counts.mean()))
+    .bind(("alpha", counts.alpha()))
+    .bind(("beta", counts.beta()))
+    .bind(("self_reinforcements", evidence.self_reinforcements()))
+    .await?
+    .check()?;
+    Ok(())
+}
+
 /// Supersede an existing relationship: set valid_until on the old one, create a new one.
 pub async fn supersede_relationship(
     db: &Surreal<Db>,

--- a/src/graph/edge_view.rs
+++ b/src/graph/edge_view.rs
@@ -1,0 +1,249 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Relationships as a person reads them.
+//!
+//! A stored [`Relationship`] names its endpoints by record id and reports one
+//! number. Neither is what a human needs to decide whether the memory is
+//! right: they need the two entity names, and they need to know whether the
+//! number rests on thirty independent observations or on the agent having said
+//! the same thing thirty times.
+//!
+//! [`EdgeView`] is that shape, and it is shared by both human-facing surfaces —
+//! correction ([`super::correct`]) and inspection ([`super::inspect`]) — so the
+//! two never disagree about how an edge reads.
+
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+use surrealdb::Surreal;
+
+use super::error::GraphError;
+use super::store::Db;
+use super::types::Relationship;
+
+/// One relationship, with its endpoints resolved and its evidence exposed.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EdgeView {
+    /// Record id, so a caller can act on exactly this edge.
+    pub id: String,
+    /// Name of the entity the edge points from.
+    pub from: String,
+    /// Name of the entity the edge points to.
+    pub to: String,
+    pub rel_type: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    /// Posterior mean — what retrieval scores on.
+    pub confidence: f64,
+    /// Total evidence weight behind `confidence` (the Beta concentration).
+    /// The difference between "believed at 0.9" and "believed at 0.9 for good
+    /// reason".
+    pub evidence: f64,
+    /// Corroborations the agent produced itself, counted but never laundered
+    /// into `confidence`. Non-zero is the "I might be talking to myself"
+    /// signal, and it is exactly what a human should see.
+    pub self_reinforcements: i64,
+    /// A later relationship replaced this one.
+    pub superseded: bool,
+}
+
+impl EdgeView {
+    /// The edge in the notation every recall-echo surface writes it in.
+    #[must_use]
+    pub fn arrow(&self) -> String {
+        format!("{} —[{}]→ {}", self.from, self.rel_type, self.to)
+    }
+
+    /// The view of `relationship` with the two names already resolved.
+    #[must_use]
+    pub fn of(relationship: &Relationship, from: String, to: String) -> Self {
+        let evidence = relationship.evidence();
+        Self {
+            id: relationship.id_string(),
+            from,
+            to,
+            rel_type: relationship.rel_type.clone(),
+            description: relationship.description.clone(),
+            confidence: relationship.confidence,
+            evidence: evidence.concentration(),
+            self_reinforcements: relationship.self_reinforcements.unwrap_or(0).max(0),
+            superseded: relationship.valid_until.is_some(),
+        }
+    }
+}
+
+/// The record id of a stored link, as a string.
+#[must_use]
+pub fn record_id(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(id) => id.clone(),
+        other => other.to_string(),
+    }
+}
+
+/// Resolves record ids to entity names, once per id.
+///
+/// Rendering the edges of one entity asks for the same neighbour repeatedly;
+/// rendering a whole overview asks for the same hub over and over. One lookup
+/// each is enough.
+#[derive(Debug, Default)]
+pub struct NameCache {
+    names: HashMap<String, String>,
+}
+
+impl NameCache {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The entity's name, or its record id when no entity is stored under it.
+    ///
+    /// A dangling edge is still worth showing — it is precisely the sort of
+    /// thing a person inspecting their memory should be able to see and delete.
+    pub async fn name_of(&mut self, db: &Surreal<Db>, id: &str) -> Result<String, GraphError> {
+        if let Some(name) = self.names.get(id) {
+            return Ok(name.clone());
+        }
+        let name = super::crud::get_entity_summary(db, id)
+            .await?
+            .map_or_else(|| id.to_string(), |summary| summary.name);
+        self.names.insert(id.to_string(), name.clone());
+        Ok(name)
+    }
+}
+
+/// Render `relationships` for a human, sharing one name cache.
+pub async fn views(
+    db: &Surreal<Db>,
+    cache: &mut NameCache,
+    relationships: &[Relationship],
+) -> Result<Vec<EdgeView>, GraphError> {
+    let mut views = Vec::with_capacity(relationships.len());
+    for relationship in relationships {
+        let from = cache.name_of(db, &record_id(&relationship.from_id)).await?;
+        let to = cache.name_of(db, &record_id(&relationship.to_id)).await?;
+        views.push(EdgeView::of(relationship, from, to));
+    }
+    Ok(views)
+}
+
+/// Every relationship of an entity that has not been superseded.
+pub async fn live_edges_of(
+    db: &Surreal<Db>,
+    entity_id: &str,
+) -> Result<Vec<Relationship>, GraphError> {
+    let mut response = db
+        .query(
+            r#"SELECT * FROM relates_to
+               WHERE (in = type::record($id) OR out = type::record($id))
+                 AND valid_until IS NONE
+               ORDER BY confidence DESC"#,
+        )
+        .bind(("id", entity_id.to_string()))
+        .await?;
+    super::deserialize_take(&mut response, 0)
+}
+
+/// Every relationship of an entity, superseded ones included.
+///
+/// What deleting the entity would actually take with it.
+pub async fn all_edges_of(
+    db: &Surreal<Db>,
+    entity_id: &str,
+) -> Result<Vec<Relationship>, GraphError> {
+    let mut response = db
+        .query(
+            r#"SELECT * FROM relates_to
+               WHERE in = type::record($id) OR out = type::record($id)
+               ORDER BY confidence DESC"#,
+        )
+        .bind(("id", entity_id.to_string()))
+        .await?;
+    super::deserialize_take(&mut response, 0)
+}
+
+/// Live relationships between two entities, in either direction.
+///
+/// Direction is not required to match what the user typed: someone correcting
+/// a memory says what they mean, not which way round the graph stored it.
+pub async fn live_edges_between(
+    db: &Surreal<Db>,
+    one: &str,
+    other: &str,
+) -> Result<Vec<Relationship>, GraphError> {
+    let mut response = db
+        .query(
+            r#"SELECT * FROM relates_to
+               WHERE valid_until IS NONE
+                 AND ((in = type::record($one) AND out = type::record($other))
+                   OR (in = type::record($other) AND out = type::record($one)))
+               ORDER BY confidence DESC"#,
+        )
+        .bind(("one", one.to_string()))
+        .bind(("other", other.to_string()))
+        .await?;
+    super::deserialize_take(&mut response, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn relationship(confidence: f64, self_reinforcements: Option<i64>) -> Relationship {
+        Relationship {
+            id: json!("relates_to:abc"),
+            from_id: json!("entity:rust"),
+            to_id: json!("entity:cargo"),
+            rel_type: "USES".into(),
+            description: Some("build tool".into()),
+            valid_from: json!("2026-01-01T00:00:00Z"),
+            valid_until: None,
+            confidence,
+            alpha: Some(18.0),
+            beta: Some(2.0),
+            self_reinforcements,
+            last_reinforced: None,
+            source: Some("archive-log-007".into()),
+        }
+    }
+
+    #[test]
+    fn a_view_carries_the_evidence_and_not_only_the_number() {
+        let view = EdgeView::of(&relationship(0.9, Some(4)), "Rust".into(), "Cargo".into());
+        assert_eq!(view.arrow(), "Rust —[USES]→ Cargo");
+        assert_eq!(view.confidence, 0.9);
+        assert_eq!(view.evidence, 20.0);
+        assert_eq!(view.self_reinforcements, 4);
+        assert!(!view.superseded);
+    }
+
+    #[test]
+    fn an_edge_predating_the_coherence_tally_reads_as_zero() {
+        let view = EdgeView::of(&relationship(0.9, None), "Rust".into(), "Cargo".into());
+        assert_eq!(view.self_reinforcements, 0);
+    }
+
+    #[test]
+    fn a_hand_edited_negative_tally_is_clamped() {
+        let view = EdgeView::of(&relationship(0.9, Some(-3)), "Rust".into(), "Cargo".into());
+        assert_eq!(view.self_reinforcements, 0);
+    }
+
+    #[test]
+    fn a_superseded_edge_says_so() {
+        let mut relationship = relationship(0.9, Some(0));
+        relationship.valid_until = Some(json!("2026-02-01T00:00:00Z"));
+        let view = EdgeView::of(&relationship, "Rust".into(), "Cargo".into());
+        assert!(view.superseded);
+    }
+
+    #[test]
+    fn record_ids_survive_both_stored_shapes() {
+        assert_eq!(record_id(&json!("entity:rust")), "entity:rust");
+        assert_eq!(record_id(&json!(7)), "7");
+    }
+}

--- a/src/graph/inspect.rs
+++ b/src/graph/inspect.rs
@@ -1,0 +1,324 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Inspection — what memory actually holds, for a person rather than a program.
+//!
+//! Nobody trusts a memory they cannot read. `graph status` counts rows and
+//! `graph search` answers questions, but neither answers the question a human
+//! actually has after a week of automatic ingestion: *what do you think you
+//! know about me, and how sure are you?*
+//!
+//! Two shapes answer it.
+//!
+//! [`MemoryOverview`] is the unprompted one: the strongest things the graph
+//! holds, grouped by entity type, next to an honest account of how well its
+//! relationships are believed — including the coherence tally, which is the
+//! one number that says "some of this confidence is me agreeing with myself".
+//!
+//! [`TopicReport`] is the prompted one. It runs the ordinary hybrid query — no
+//! second retrieval path, no second set of scoring weights — and then attaches
+//! the evidence behind each hit, which retrieval itself has no reason to carry.
+
+use serde::{Deserialize, Serialize};
+use surrealdb::Surreal;
+
+use super::edge_view::{self, EdgeView, NameCache};
+use super::embed::Embedder;
+use super::error::GraphError;
+use super::store::Db;
+use super::types::{EntityDetail, GraphStats, MatchSource, QueryOptions};
+use crate::config::GraphScoringConfig;
+
+/// At or above this posterior mean, a relationship is held firmly.
+pub const STRONG_CONFIDENCE: f64 = 0.8;
+/// Below this posterior mean, a relationship is barely believed at all.
+pub const DOUBTFUL_CONFIDENCE: f64 = 0.5;
+
+/// Edges listed under "least certain" and "believed partly by repetition".
+const HIGHLIGHT_EDGES: usize = 5;
+/// Relationships shown per entity in a topic report, before they are summarised
+/// as a count.
+const MAX_EDGES_PER_ENTITY: usize = 8;
+/// Graph expansion for a topic report — one hop, as the `graph query` CLI uses.
+const TOPIC_GRAPH_DEPTH: u32 = 1;
+
+/// What the graph holds, without being asked about anything in particular.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct MemoryOverview {
+    /// Row counts, including the per-type breakdown.
+    pub stats: GraphStats,
+    /// The strongest entities of each type, most populous type first.
+    pub groups: Vec<TypeGroup>,
+    /// How firmly the live relationships are held, in aggregate.
+    pub confidence: ConfidenceSummary,
+    /// The least-believed live relationships — where memory is unsure.
+    pub uncertain: Vec<EdgeView>,
+    /// The relationships carrying the most self-authored corroboration —
+    /// where memory may be agreeing with itself.
+    pub self_reinforced: Vec<EdgeView>,
+}
+
+/// One entity type, and the strongest entities in it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TypeGroup {
+    pub entity_type: String,
+    /// How many entities of this type exist, not how many are listed.
+    pub count: u64,
+    pub top: Vec<KnownEntity>,
+}
+
+/// One entity as an overview lists it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct KnownEntity {
+    pub id: String,
+    pub name: String,
+    pub entity_type: String,
+    #[serde(rename = "abstract")]
+    pub abstract_text: String,
+    #[serde(default)]
+    pub access_count: i64,
+    #[serde(default)]
+    pub utility_score: f64,
+}
+
+/// How well the live relationships are believed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ConfidenceSummary {
+    /// At or above [`STRONG_CONFIDENCE`].
+    pub strong: u64,
+    /// Between [`DOUBTFUL_CONFIDENCE`] and [`STRONG_CONFIDENCE`].
+    pub uncertain: u64,
+    /// Below [`DOUBTFUL_CONFIDENCE`].
+    pub doubtful: u64,
+}
+
+impl ConfidenceSummary {
+    /// Live relationships counted.
+    #[must_use]
+    pub fn total(&self) -> u64 {
+        self.strong + self.uncertain + self.doubtful
+    }
+
+    /// Tally one relationship's posterior mean.
+    fn record(&mut self, confidence: f64) {
+        if confidence >= STRONG_CONFIDENCE {
+            self.strong += 1;
+        } else if confidence >= DOUBTFUL_CONFIDENCE {
+            self.uncertain += 1;
+        } else {
+            self.doubtful += 1;
+        }
+    }
+}
+
+/// What the graph holds about one subject.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TopicReport {
+    pub topic: String,
+    pub entities: Vec<TopicEntity>,
+}
+
+/// One retrieved entity, with the claims it takes part in.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct TopicEntity {
+    pub entity: EntityDetail,
+    /// Retrieval score, unchanged from the hybrid query that produced it.
+    pub score: f64,
+    /// Whether it was matched directly or reached over a relationship.
+    pub source: MatchSource,
+    /// Its live relationships, strongest first.
+    pub edges: Vec<EdgeView>,
+    /// Relationships beyond the ones listed.
+    #[serde(default)]
+    pub edges_omitted: usize,
+}
+
+/// Summarise the whole graph, listing `per_type` entities of each type.
+pub async fn overview(
+    db: &Surreal<Db>,
+    stats: GraphStats,
+    per_type: usize,
+) -> Result<MemoryOverview, GraphError> {
+    let mut groups = Vec::with_capacity(stats.entity_type_counts.len());
+    for (entity_type, count) in &stats.entity_type_counts {
+        groups.push(TypeGroup {
+            entity_type: entity_type.clone(),
+            count: *count,
+            top: strongest_of_type(db, entity_type, per_type).await?,
+        });
+    }
+    groups.sort_by(|left, right| {
+        right
+            .count
+            .cmp(&left.count)
+            .then_with(|| left.entity_type.cmp(&right.entity_type))
+    });
+
+    let mut cache = NameCache::new();
+    let uncertain = edge_view::views(db, &mut cache, &least_certain(db).await?).await?;
+    let self_reinforced =
+        edge_view::views(db, &mut cache, &most_self_reinforced(db).await?).await?;
+
+    Ok(MemoryOverview {
+        stats,
+        groups,
+        confidence: confidence_summary(db).await?,
+        uncertain,
+        self_reinforced,
+    })
+}
+
+/// Answer "what do you know about X" through the ordinary hybrid query, then
+/// attach the evidence behind each hit.
+pub async fn about(
+    db: &Surreal<Db>,
+    embedder: &dyn Embedder,
+    scoring: &GraphScoringConfig,
+    topic: &str,
+    limit: usize,
+) -> Result<TopicReport, GraphError> {
+    let options = QueryOptions {
+        limit,
+        entity_type: None,
+        keyword: None,
+        graph_depth: TOPIC_GRAPH_DEPTH,
+        include_episodes: false,
+    };
+    let result = super::query::query(db, embedder, scoring, topic, &options).await?;
+
+    let mut cache = NameCache::new();
+    let mut entities = Vec::with_capacity(result.entities.len());
+    for scored in result.entities {
+        let all = edge_view::live_edges_of(db, &scored.entity.id_string()).await?;
+        let edges_omitted = all.len().saturating_sub(MAX_EDGES_PER_ENTITY);
+        let shown = &all[..all.len().min(MAX_EDGES_PER_ENTITY)];
+        entities.push(TopicEntity {
+            entity: scored.entity,
+            score: scored.score,
+            source: scored.source,
+            edges: edge_view::views(db, &mut cache, shown).await?,
+            edges_omitted,
+        });
+    }
+
+    Ok(TopicReport {
+        topic: topic.to_string(),
+        entities,
+    })
+}
+
+// ── Queries ──────────────────────────────────────────────────────────────
+
+/// The entities of one type most worth showing first: the ones feedback has
+/// found useful, then the ones retrieval keeps returning, then the freshest.
+///
+/// This is a display order, not a retrieval score — nothing here feeds ranking.
+async fn strongest_of_type(
+    db: &Surreal<Db>,
+    entity_type: &str,
+    limit: usize,
+) -> Result<Vec<KnownEntity>, GraphError> {
+    #[derive(serde::Deserialize)]
+    struct Row {
+        id: serde_json::Value,
+        name: String,
+        entity_type: String,
+        #[serde(rename = "abstract")]
+        abstract_text: String,
+        #[serde(default, deserialize_with = "super::util::count_or_zero")]
+        access_count: i64,
+        #[serde(default)]
+        utility_score: Option<f64>,
+    }
+
+    // `updated_at` is projected because it is ordered on: SurrealDB requires
+    // every ORDER BY idiom to appear in the selection.
+    let query = format!(
+        r#"SELECT id, name, entity_type, abstract, access_count, utility_score, updated_at
+           FROM entity WHERE entity_type = $entity_type
+           ORDER BY utility_score DESC, access_count DESC, updated_at DESC
+           LIMIT {}"#,
+        limit.clamp(1, 100)
+    );
+    let mut response = db
+        .query(&query)
+        .bind(("entity_type", entity_type.to_string()))
+        .await?;
+
+    let rows: Vec<Row> = super::deserialize_take(&mut response, 0)?;
+    Ok(rows
+        .into_iter()
+        .map(|row| KnownEntity {
+            id: edge_view::record_id(&row.id),
+            name: row.name,
+            entity_type: row.entity_type,
+            abstract_text: row.abstract_text,
+            access_count: row.access_count,
+            utility_score: row.utility_score.unwrap_or(0.5),
+        })
+        .collect())
+}
+
+/// Band every live relationship by how firmly it is believed.
+async fn confidence_summary(db: &Surreal<Db>) -> Result<ConfidenceSummary, GraphError> {
+    let mut response = db
+        .query("SELECT VALUE confidence FROM relates_to WHERE valid_until IS NONE")
+        .await?;
+    let confidences: Vec<f64> = super::deserialize_take(&mut response, 0)?;
+
+    let mut summary = ConfidenceSummary::default();
+    for confidence in confidences {
+        summary.record(confidence);
+    }
+    Ok(summary)
+}
+
+/// The live relationships the graph believes least.
+async fn least_certain(db: &Surreal<Db>) -> Result<Vec<super::types::Relationship>, GraphError> {
+    let query = format!(
+        r#"SELECT * FROM relates_to
+           WHERE valid_until IS NONE AND confidence < {STRONG_CONFIDENCE}
+           ORDER BY confidence ASC
+           LIMIT {HIGHLIGHT_EDGES}"#
+    );
+    let mut response = db.query(&query).await?;
+    super::deserialize_take(&mut response, 0)
+}
+
+/// The relationships carrying the most self-authored corroboration.
+async fn most_self_reinforced(
+    db: &Surreal<Db>,
+) -> Result<Vec<super::types::Relationship>, GraphError> {
+    let query = format!(
+        r#"SELECT * FROM relates_to
+           WHERE self_reinforcements IS NOT NONE AND self_reinforcements > 0
+           ORDER BY self_reinforcements DESC
+           LIMIT {HIGHLIGHT_EDGES}"#
+    );
+    let mut response = db.query(&query).await?;
+    super::deserialize_take(&mut response, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn confidence_bands_split_at_the_documented_thresholds() {
+        let mut summary = ConfidenceSummary::default();
+        for confidence in [1.0, STRONG_CONFIDENCE, 0.79, DOUBTFUL_CONFIDENCE, 0.49, 0.0] {
+            summary.record(confidence);
+        }
+        assert_eq!(summary.strong, 2);
+        assert_eq!(summary.uncertain, 2);
+        assert_eq!(summary.doubtful, 2);
+        assert_eq!(summary.total(), 6);
+    }
+
+    #[test]
+    fn an_empty_graph_has_nothing_to_be_sure_of() {
+        let summary = ConfidenceSummary::default();
+        assert_eq!(summary.total(), 0);
+    }
+}

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -8,13 +8,16 @@
 //! Used by recall-echo (pulse-null entities) and recall-claude (Claude Code users).
 
 pub mod confidence;
+pub mod correct;
 pub mod crud;
 pub mod dedup;
+pub mod edge_view;
 pub mod embed;
 pub mod error;
 pub mod extract;
 pub mod gc;
 pub mod ingest;
+pub mod inspect;
 pub mod llm;
 pub mod pipeline;
 pub mod pipeline_sync;
@@ -318,6 +321,38 @@ impl GraphMemory {
         evidence: confidence::EdgeEvidence,
     ) -> Result<(), GraphError> {
         crud::reinforce_relationship(&self.db, rel_id, evidence).await
+    }
+
+    // --- Human correction ---
+
+    /// Apply a human correction, or report why it was refused.
+    ///
+    /// Contradiction enters the Bayesian model as an observation at
+    /// [`Provenance::User`] weight rather than overwriting a number — see
+    /// [`correct`] for why, and for what correcting an *entity* means.
+    pub async fn correct(
+        &self,
+        target: &correct::CorrectTarget,
+        correction: correct::Correction,
+    ) -> Result<correct::CorrectionReport, GraphError> {
+        correct::correct(&self.db, &self.provenance, target, correction).await
+    }
+
+    // --- Inspection ---
+
+    /// Summarise what the graph holds, listing `per_type` entities of each type.
+    pub async fn overview(&self, per_type: usize) -> Result<inspect::MemoryOverview, GraphError> {
+        let stats = self.stats().await?;
+        inspect::overview(&self.db, stats, per_type).await
+    }
+
+    /// What the graph holds about one subject, over the ordinary hybrid query.
+    pub async fn about(
+        &self,
+        topic: &str,
+        limit: usize,
+    ) -> Result<inspect::TopicReport, GraphError> {
+        inspect::about(&self.db, self.embedder.get()?, &self.scoring, topic, limit).await
     }
 
     // --- Episodes ---

--- a/src/graph/types.rs
+++ b/src/graph/types.rs
@@ -250,7 +250,7 @@ impl EntitySummary {
 }
 
 /// L1 — Search result detail. Everything except content and embedding.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EntityDetail {
     pub id: serde_json::Value,
     pub name: String,
@@ -296,7 +296,7 @@ pub struct SearchOptions {
 }
 
 /// How an entity was found.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MatchSource {
     /// Found via semantic similarity.
@@ -431,7 +431,7 @@ impl EdgeRow {
 }
 
 /// Graph-level statistics.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct GraphStats {
     pub entity_count: u64,
     pub relationship_count: u64,

--- a/src/graph_cli.rs
+++ b/src/graph_cli.rs
@@ -7,11 +7,14 @@
 use std::path::{Path, PathBuf};
 
 use crate::error::RecallError;
+use crate::graph::correct::{CorrectTarget, Correction, CorrectionReport, EdgeCorrection, Removal};
+use crate::graph::edge_view::EdgeView;
 use crate::graph::traverse::format_traversal;
 use crate::graph::types::*;
 use crate::graph::{IngestContext, Provenance};
 use crate::serve::{
-    AddEntityArgs, IngestArchiveArgs, QueryArgs, RelateArgs, Request, SearchArgs, TraverseArgs,
+    AddEntityArgs, CorrectArgs, IngestArchiveArgs, QueryArgs, RelateArgs, Request, SearchArgs,
+    TraverseArgs,
 };
 use crate::serve_client;
 
@@ -1255,6 +1258,324 @@ pub async fn feedback(
     }
 
     Ok(())
+}
+
+// ── Correction ───────────────────────────────────────────────────────────
+
+/// One `graph correct` invocation, as the flags were given.
+///
+/// A struct rather than seven positional arguments, and unvalidated on purpose:
+/// turning it into a [`CorrectTarget`] and a [`Correction`] is where the
+/// contradictory combinations are named and refused.
+#[derive(Debug, Clone)]
+pub struct CorrectOptions {
+    /// Entity name, or the source entity of a relationship.
+    pub subject: String,
+    /// Relationship type — only for a relationship target.
+    pub rel_type: Option<String>,
+    /// Target entity — only for a relationship target.
+    pub object: Option<String>,
+    /// Record contradicting evidence at user authority.
+    pub wrong: bool,
+    /// Remove outright.
+    pub forget: bool,
+    /// Contradict every relationship of an entity rather than being asked which.
+    pub all_edges: bool,
+    /// Skip the confirmation a removal otherwise requires.
+    pub yes: bool,
+}
+
+impl CorrectOptions {
+    /// What the correction is aimed at.
+    fn target(&self) -> Result<CorrectTarget, RecallError> {
+        match (&self.rel_type, &self.object) {
+            (None, None) => Ok(CorrectTarget::Entity {
+                name: self.subject.clone(),
+            }),
+            (Some(rel_type), Some(object)) => Ok(CorrectTarget::Edge {
+                from: self.subject.clone(),
+                rel_type: rel_type.clone(),
+                to: object.clone(),
+            }),
+            _ => Err(RecallError::Other(
+                "a relationship needs all three names: \
+                 `graph correct <from> <REL> <to> --wrong`"
+                    .into(),
+            )),
+        }
+    }
+
+    /// What to do to it.
+    fn correction(&self) -> Result<Correction, RecallError> {
+        match (self.wrong, self.forget) {
+            (true, false) => Ok(Correction::Wrong {
+                all_edges: self.all_edges,
+            }),
+            (false, true) => Ok(Correction::Forget { confirmed: false }),
+            (true, true) => Err(RecallError::Other(
+                "--wrong and --forget are different corrections; pass one".into(),
+            )),
+            (false, false) => Err(RecallError::Other(
+                "say what to do: --wrong records that it is mistaken (confidence falls with \
+                 evidence), --forget removes it outright"
+                    .into(),
+            )),
+        }
+    }
+}
+
+/// Tell memory that something it learned is wrong.
+///
+/// A hot operation: it goes through the daemon like search and ingest, so a
+/// correction lands while a session is still using the store.
+pub async fn correct(memory_dir: &Path, options: &CorrectOptions) -> Result<(), RecallError> {
+    let target = options.target()?;
+    let report = send_correction(memory_dir, &target, options.correction()?).await?;
+
+    match report {
+        // A removal is planned before it is applied, so the human sees what
+        // goes before anything does.
+        CorrectionReport::Planned { removal } => {
+            print_removal_plan(&removal);
+            if !options.yes && !confirm_removal(&removal)? {
+                println!("{YELLOW}Nothing removed.{RESET}");
+                return Ok(());
+            }
+            let applied =
+                send_correction(memory_dir, &target, Correction::Forget { confirmed: true })
+                    .await?;
+            // Still through `refusal`: the graph can have moved between the
+            // plan and the confirmation, and a removal that found nothing to
+            // remove must not exit as though it had.
+            print_correction(&applied);
+            refusal(&applied)
+        }
+        other => {
+            print_correction(&other);
+            refusal(&other)
+        }
+    }
+}
+
+async fn send_correction(
+    memory_dir: &Path,
+    target: &CorrectTarget,
+    correction: Correction,
+) -> Result<CorrectionReport, RecallError> {
+    let request = Request::Correct(CorrectArgs {
+        target: target.clone(),
+        correction,
+    });
+    Ok(serde_json::from_value(
+        serve_client::execute(memory_dir, &request).await?,
+    )?)
+}
+
+/// A correction that changed nothing exits non-zero: the user asked for a
+/// change and did not get one, and a script must be able to tell.
+fn refusal(report: &CorrectionReport) -> Result<(), RecallError> {
+    match report {
+        CorrectionReport::UnknownEntity { query, .. } => Err(RecallError::Other(format!(
+            "no entity named \"{query}\" — nothing was changed"
+        ))),
+        CorrectionReport::NoSuchEdge {
+            from, rel_type, to, ..
+        } => Err(RecallError::Other(format!(
+            "no {rel_type} relationship between \"{from}\" and \"{to}\" — nothing was changed"
+        ))),
+        CorrectionReport::Ambiguous { entity, .. } => Err(RecallError::Other(format!(
+            "\"{entity}\" takes part in several relationships — name the one that is wrong"
+        ))),
+        CorrectionReport::NothingToCorrect { entity } => Err(RecallError::Other(format!(
+            "\"{entity}\" has no relationships to contradict"
+        ))),
+        _ => Ok(()),
+    }
+}
+
+fn print_correction(report: &CorrectionReport) {
+    match report {
+        CorrectionReport::UnknownEntity { query, candidates } => {
+            println!("{YELLOW}No entity named{RESET} {BOLD}{query}{RESET}.");
+            if candidates.is_empty() {
+                println!("  {DIM}Nothing stored is close to that name.{RESET}");
+            } else {
+                println!("\n  {DIM}Closest names in memory:{RESET}");
+                for candidate in candidates {
+                    println!(
+                        "    {BOLD}{}{RESET} {DIM}({}){RESET}",
+                        candidate.name, candidate.entity_type
+                    );
+                }
+            }
+        }
+        CorrectionReport::NoSuchEdge {
+            from,
+            rel_type,
+            to,
+            existing,
+        } => {
+            println!(
+                "{YELLOW}Memory holds no{RESET} {BOLD}{rel_type}{RESET} \
+                 {YELLOW}relationship between{RESET} {BOLD}{from}{RESET} \
+                 {YELLOW}and{RESET} {BOLD}{to}{RESET}."
+            );
+            if existing.is_empty() {
+                println!("  {DIM}They are not connected at all.{RESET}");
+            } else {
+                println!("\n  {DIM}What does connect them:{RESET}");
+                print_edges(existing);
+            }
+        }
+        CorrectionReport::Ambiguous { entity, edges } => {
+            println!(
+                "{BOLD}{entity}{RESET} takes part in {} relationships. Which one is wrong?\n",
+                edges.len()
+            );
+            print_edges(edges);
+            println!("\n  {DIM}Name it:{RESET}");
+            if let Some(edge) = edges.first() {
+                println!(
+                    "    {DIM}recall-echo graph correct \"{}\" \"{}\" \"{}\" --wrong{RESET}",
+                    edge.from, edge.rel_type, edge.to
+                );
+            }
+            println!("  {DIM}Or contradict every one of them:{RESET}");
+            println!("    {DIM}recall-echo graph correct \"{entity}\" --wrong --all-edges{RESET}");
+        }
+        CorrectionReport::NothingToCorrect { entity } => {
+            println!(
+                "{BOLD}{entity}{RESET} is in memory but takes part in no relationships, \
+                 so there is no claim to contradict."
+            );
+            println!(
+                "  {DIM}To remove the entity itself: \
+                 recall-echo graph correct \"{entity}\" --forget{RESET}"
+            );
+        }
+        CorrectionReport::Contradicted { edges } => print_contradictions(edges),
+        CorrectionReport::Planned { removal } => print_removal_plan(removal),
+        CorrectionReport::Removed { removal } => {
+            let entity = removal
+                .entity
+                .as_ref()
+                .map(|entity| format!("{BOLD}{}{RESET} and ", entity.name))
+                .unwrap_or_default();
+            println!(
+                "{GREEN}✓{RESET} Removed {entity}{} {}.",
+                removal.edges.len(),
+                plural(removal.edges.len(), "relationship", "relationships")
+            );
+        }
+    }
+}
+
+fn print_contradictions(edges: &[EdgeCorrection]) {
+    println!(
+        "{GREEN}✓{RESET} Recorded your correction on {} {}.\n",
+        edges.len(),
+        plural(edges.len(), "relationship", "relationships")
+    );
+    for correction in edges {
+        let edge = &correction.edge;
+        println!(
+            "  {} {CYAN}—[{}]→{RESET} {}",
+            edge.from, edge.rel_type, edge.to
+        );
+        println!(
+            "    confidence {YELLOW}{:.2} → {:.2}{RESET}   {DIM}evidence {:.1} → {:.1}{RESET}",
+            correction.confidence_before,
+            edge.confidence,
+            correction.evidence_before,
+            edge.evidence,
+        );
+    }
+    println!(
+        "\n  {DIM}Your correction is evidence, not a decree: confidence falls by the weight of \
+         one observation you authored. Say it again if memory is still wrong.{RESET}"
+    );
+}
+
+fn print_removal_plan(removal: &Removal) {
+    println!("{BOLD}{YELLOW}This would remove:{RESET}\n");
+    if let Some(entity) = &removal.entity {
+        println!(
+            "  {BOLD}{}{RESET} {DIM}({}){RESET}",
+            entity.name, entity.entity_type
+        );
+    }
+    if removal.edges.is_empty() {
+        println!("  {DIM}and no relationships.{RESET}");
+    } else {
+        println!(
+            "  {} {}:",
+            removal.edges.len(),
+            plural(removal.edges.len(), "relationship", "relationships")
+        );
+        print_edges(&removal.edges);
+    }
+    println!(
+        "\n  {DIM}Removal is not evidence — it leaves no trace and cannot be re-weighed. \
+         Prefer --wrong unless the memory should never have existed.{RESET}"
+    );
+}
+
+fn print_edges(edges: &[EdgeView]) {
+    for edge in edges {
+        let superseded = if edge.superseded {
+            format!(" {DIM}[superseded]{RESET}")
+        } else {
+            String::new()
+        };
+        let coherence = if edge.self_reinforcements > 0 {
+            format!(" {YELLOW}self×{}{RESET}", edge.self_reinforcements)
+        } else {
+            String::new()
+        };
+        println!(
+            "    {} {CYAN}—[{}]→{RESET} {}  {:.0}%{coherence}{superseded}",
+            edge.from,
+            edge.rel_type,
+            edge.to,
+            edge.confidence * 100.0,
+        );
+    }
+}
+
+/// Ask before destroying anything.
+///
+/// A non-interactive stdin is never taken as consent: a script that pipes into
+/// this command must say `--yes` in the script, where a reader can see it.
+///
+/// The read blocks the runtime, which is what we want — there is nothing else
+/// in flight, and the daemon connection was closed with the planning request.
+fn confirm_removal(removal: &Removal) -> Result<bool, RecallError> {
+    use std::io::{IsTerminal, Write};
+
+    if !std::io::stdin().is_terminal() {
+        return Err(RecallError::Other(
+            "refusing to remove memory without confirmation — re-run with --yes".into(),
+        ));
+    }
+
+    let what = removal
+        .entity
+        .as_ref()
+        .map_or_else(|| "these relationships".to_string(), |e| e.name.clone());
+    print!("{BOLD}Remove {what}?{RESET} [y/N] ");
+    std::io::stdout().flush()?;
+
+    let mut answer = String::new();
+    std::io::stdin().read_line(&mut answer)?;
+    Ok(matches!(answer.trim().to_lowercase().as_str(), "y" | "yes"))
+}
+
+fn plural(count: usize, one: &'static str, many: &'static str) -> &'static str {
+    if count == 1 {
+        one
+    } else {
+        many
+    }
 }
 
 /// Show relationship decay report — lists all relationships with their stored vs effective confidence.

--- a/src/inspect_cli.rs
+++ b/src/inspect_cli.rs
@@ -1,0 +1,536 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `recall-echo what-do-you-know` — memory, read out loud.
+//!
+//! Everything else in the CLI answers a question the user already knew to ask.
+//! This answers the one they have before they know anything: *what do you think
+//! you know?* It is deliberately readable rather than complete — a person
+//! should be able to scan it in ten seconds and think "yes, that's right" or
+//! "no, that's wrong", and the second thought needs somewhere to go, so every
+//! rendering points at `graph correct`.
+//!
+//! Nothing here retrieves. The overview is a projection of the store and the
+//! `--about` form is the ordinary hybrid query; this module only decides how
+//! the answer reads. Rendering builds a string and printing emits it, so what
+//! a person sees is what a test can assert.
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use crate::error::RecallError;
+use crate::graph::edge_view::EdgeView;
+use crate::graph::inspect::{
+    ConfidenceSummary, MemoryOverview, TopicEntity, TopicReport, DOUBTFUL_CONFIDENCE,
+    STRONG_CONFIDENCE,
+};
+use crate::graph::types::MatchSource;
+use crate::serve::{AboutArgs, OverviewArgs, Request};
+use crate::serve_client;
+
+const CYAN: &str = "\x1b[36m";
+const YELLOW: &str = "\x1b[33m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const RESET: &str = "\x1b[0m";
+
+/// Longest abstract shown whole. Anything longer is a paragraph, and this is a
+/// summary.
+const MAX_ABSTRACT_CHARS: usize = 140;
+
+/// Report what memory holds — everything, or one subject.
+pub async fn run(
+    memory_dir: &Path,
+    about: Option<&str>,
+    per_type: usize,
+) -> Result<(), RecallError> {
+    require_graph(memory_dir)?;
+
+    let text = match about {
+        Some(topic) => {
+            let request = Request::About(AboutArgs {
+                topic: topic.to_string(),
+                limit: per_type,
+            });
+            let report: TopicReport =
+                serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
+            render_topic(&report)
+        }
+        None => {
+            let request = Request::Overview(OverviewArgs { per_type });
+            let overview: MemoryOverview =
+                serde_json::from_value(serve_client::execute(memory_dir, &request).await?)?;
+            render_overview(&overview)
+        }
+    };
+
+    print!("{text}");
+    Ok(())
+}
+
+fn require_graph(memory_dir: &Path) -> Result<(), RecallError> {
+    if memory_dir.join("graph").exists() {
+        return Ok(());
+    }
+    Err(RecallError::NotInitialized(
+        "Graph store not initialized. Run `recall-echo graph init` first.".into(),
+    ))
+}
+
+// ── Overview ─────────────────────────────────────────────────────────────
+
+/// Everything memory holds, as a person reads it.
+#[must_use]
+pub fn render_overview(overview: &MemoryOverview) -> String {
+    let stats = &overview.stats;
+    let mut out = format!("{BOLD}What I know{RESET}\n");
+
+    if stats.entity_count == 0 && stats.episode_count == 0 {
+        let _ = writeln!(out, "\n  {YELLOW}Nothing yet.{RESET}");
+        let _ = writeln!(
+            out,
+            "  {DIM}Memory fills when sessions end. Once conversations are archived, \
+             `recall-echo graph extract --all` distils them into what you see here.{RESET}"
+        );
+        return out;
+    }
+
+    let _ = writeln!(
+        out,
+        "\n  {} entities · {} relationships · {} conversation fragments",
+        stats.entity_count, stats.relationship_count, stats.episode_count
+    );
+
+    if stats.entity_count == 0 {
+        let _ = writeln!(
+            out,
+            "\n  {YELLOW}Conversations are stored but nothing has been distilled from them \
+             yet.{RESET}"
+        );
+        let _ = writeln!(out, "  {DIM}recall-echo graph extract --all{RESET}");
+        return out;
+    }
+
+    write_groups(&mut out, overview);
+    write_confidence(&mut out, &overview.confidence);
+    write_edge_section(&mut out, "Least certain", &overview.uncertain, None);
+    write_edge_section(
+        &mut out,
+        "Believed partly because I kept saying it",
+        &overview.self_reinforced,
+        Some(
+            "self×N counts corroborations I produced myself. They are kept out of the \
+             confidence above — repetition is coherence, not evidence.",
+        ),
+    );
+
+    let _ = writeln!(
+        out,
+        "\n  {DIM}Wrong about something? recall-echo graph correct \"<name>\" --wrong{RESET}"
+    );
+    out
+}
+
+fn write_groups(out: &mut String, overview: &MemoryOverview) {
+    for group in &overview.groups {
+        let _ = writeln!(
+            out,
+            "\n  {BOLD}{}{RESET} {DIM}({}){RESET}",
+            group.entity_type, group.count
+        );
+        for entity in &group.top {
+            let _ = writeln!(
+                out,
+                "    {BOLD}{}{RESET} — {}",
+                entity.name,
+                clip(&entity.abstract_text)
+            );
+        }
+        let listed = group.top.len() as u64;
+        if group.count > listed {
+            let _ = writeln!(out, "    {DIM}… and {} more{RESET}", group.count - listed);
+        }
+    }
+}
+
+fn write_confidence(out: &mut String, summary: &ConfidenceSummary) {
+    if summary.total() == 0 {
+        let _ = writeln!(
+            out,
+            "\n  {YELLOW}No relationships yet{RESET} — I know these things but have not \
+             connected them."
+        );
+        return;
+    }
+
+    let _ = writeln!(out, "\n  {BOLD}How sure I am{RESET}");
+    let _ = writeln!(
+        out,
+        "    {} of {} relationships firmly held {DIM}(≥{:.0}%){RESET}, {} uncertain, \
+         {} doubtful {DIM}(<{:.0}%){RESET}",
+        summary.strong,
+        summary.total(),
+        STRONG_CONFIDENCE * 100.0,
+        summary.uncertain,
+        summary.doubtful,
+        DOUBTFUL_CONFIDENCE * 100.0,
+    );
+    if is_mostly_unsure(summary) {
+        let _ = writeln!(
+            out,
+            "    {DIM}Most of what I hold is unsettled — treat it as a starting point, not as \
+             fact.{RESET}"
+        );
+    }
+}
+
+/// True when the graph believes less than half of what it holds firmly.
+fn is_mostly_unsure(summary: &ConfidenceSummary) -> bool {
+    summary.total() > 0 && summary.strong * 2 < summary.total()
+}
+
+fn write_edge_section(out: &mut String, heading: &str, edges: &[EdgeView], note: Option<&str>) {
+    if edges.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\n  {BOLD}{heading}{RESET}");
+    for edge in edges {
+        write_edge_line(out, edge);
+    }
+    if let Some(note) = note {
+        let _ = writeln!(out, "    {DIM}{note}{RESET}");
+    }
+}
+
+fn write_edge_line(out: &mut String, edge: &EdgeView) {
+    let _ = writeln!(
+        out,
+        "    {} {CYAN}—[{}]→{RESET} {}  {} {DIM}({:.0}%, evidence {:.1}){RESET}{}",
+        edge.from,
+        edge.rel_type,
+        edge.to,
+        certainty(edge.confidence),
+        edge.confidence * 100.0,
+        edge.evidence,
+        coherence_tag(edge),
+    );
+}
+
+// ── One subject ──────────────────────────────────────────────────────────
+
+/// What memory holds about one subject, as a person reads it.
+#[must_use]
+pub fn render_topic(report: &TopicReport) -> String {
+    let mut out = format!("{BOLD}What I know about \"{}\"{RESET}\n", report.topic);
+
+    if report.entities.is_empty() {
+        let _ = writeln!(out, "\n  {YELLOW}Nothing distilled about that.{RESET}");
+        let _ = writeln!(
+            out,
+            "  {DIM}The raw conversations may still hold it: \
+             recall-echo graph query \"{}\" --episodes{RESET}",
+            report.topic
+        );
+        return out;
+    }
+
+    for entity in &report.entities {
+        write_topic_entity(&mut out, entity);
+    }
+
+    let _ = writeln!(
+        out,
+        "\n  {DIM}Wrong about something? recall-echo graph correct \"<from>\" \"<REL>\" \
+         \"<to>\" --wrong{RESET}"
+    );
+    out
+}
+
+fn write_topic_entity(out: &mut String, entity: &TopicEntity) {
+    let _ = writeln!(
+        out,
+        "\n  {BOLD}{}{RESET} {DIM}— {} · {} (score {:.2}){RESET}",
+        entity.entity.name,
+        entity.entity.entity_type,
+        how_it_was_found(&entity.source),
+        entity.score,
+    );
+    let _ = writeln!(out, "    {}", clip(&entity.entity.abstract_text));
+
+    if entity.edges.is_empty() {
+        let _ = writeln!(out, "    {DIM}Nothing else is recorded about it.{RESET}");
+        return;
+    }
+    for edge in &entity.edges {
+        write_edge_line(out, edge);
+    }
+    if entity.edges_omitted > 0 {
+        let _ = writeln!(
+            out,
+            "    {DIM}… and {} more relationships{RESET}",
+            entity.edges_omitted
+        );
+    }
+}
+
+fn how_it_was_found(source: &MatchSource) -> String {
+    match source {
+        MatchSource::Semantic => "matched directly".to_string(),
+        MatchSource::Keyword => "matched by keyword".to_string(),
+        MatchSource::Graph { parent, rel_type } => format!("reached from {parent} via {rel_type}"),
+    }
+}
+
+// ── Wording ──────────────────────────────────────────────────────────────
+
+/// How a posterior mean reads out loud.
+///
+/// The bands are the ones [`crate::graph::inspect`] counts by, so the summary
+/// line and the per-edge wording can never disagree.
+#[must_use]
+pub fn certainty(confidence: f64) -> &'static str {
+    match confidence {
+        c if c >= 0.9 => "near-certain",
+        c if c >= STRONG_CONFIDENCE => "confident",
+        c if c >= DOUBTFUL_CONFIDENCE => "unsure",
+        _ => "doubtful",
+    }
+}
+
+/// The "some of this is me agreeing with myself" marker, when there is one.
+fn coherence_tag(edge: &EdgeView) -> String {
+    if edge.self_reinforcements > 0 {
+        format!(" {YELLOW}self×{}{RESET}", edge.self_reinforcements)
+    } else {
+        String::new()
+    }
+}
+
+fn clip(text: &str) -> String {
+    let text = text.trim();
+    if text.chars().count() <= MAX_ABSTRACT_CHARS {
+        return text.to_string();
+    }
+    let mut clipped: String = text.chars().take(MAX_ABSTRACT_CHARS).collect();
+    clipped.push_str(" […]");
+    clipped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::graph::inspect::{KnownEntity, TypeGroup};
+    use crate::graph::types::{EntityDetail, EntityType, GraphStats};
+
+    fn stats(entities: u64, relationships: u64, episodes: u64) -> GraphStats {
+        GraphStats {
+            entity_count: entities,
+            relationship_count: relationships,
+            episode_count: episodes,
+            entity_type_counts: Default::default(),
+        }
+    }
+
+    fn edge(confidence: f64, self_reinforcements: i64) -> EdgeView {
+        EdgeView {
+            id: "relates_to:1".into(),
+            from: "Echo".into(),
+            to: "NixOS".into(),
+            rel_type: "USES".into(),
+            description: None,
+            confidence,
+            evidence: 12.4,
+            self_reinforcements,
+            superseded: false,
+        }
+    }
+
+    fn overview_with(groups: Vec<TypeGroup>, stats: GraphStats) -> MemoryOverview {
+        MemoryOverview {
+            stats,
+            groups,
+            confidence: ConfidenceSummary::default(),
+            uncertain: Vec::new(),
+            self_reinforced: Vec::new(),
+        }
+    }
+
+    fn one_group() -> Vec<TypeGroup> {
+        vec![TypeGroup {
+            entity_type: "project".into(),
+            count: 4,
+            top: vec![KnownEntity {
+                id: "entity:recall-echo".into(),
+                name: "recall-echo".into(),
+                entity_type: "project".into(),
+                abstract_text: "Persistent memory with a knowledge graph.".into(),
+                access_count: 9,
+                utility_score: 0.8,
+            }],
+        }]
+    }
+
+    #[test]
+    fn an_empty_graph_says_so_and_says_what_fills_it() {
+        let text = render_overview(&overview_with(Vec::new(), stats(0, 0, 0)));
+        assert!(text.contains("Nothing yet."), "{text}");
+        assert!(text.contains("graph extract --all"), "{text}");
+        // Confidence over nothing is not a number worth printing.
+        assert!(!text.contains("firmly held"), "{text}");
+    }
+
+    #[test]
+    fn conversations_without_entities_point_at_extraction() {
+        let text = render_overview(&overview_with(Vec::new(), stats(0, 0, 120)));
+        assert!(text.contains("120 conversation fragments"), "{text}");
+        assert!(text.contains("nothing has been distilled"), "{text}");
+    }
+
+    #[test]
+    fn entities_without_relationships_say_they_are_unconnected() {
+        let text = render_overview(&overview_with(one_group(), stats(4, 0, 12)));
+        assert!(text.contains("recall-echo"), "{text}");
+        assert!(text.contains("… and 3 more"), "{text}");
+        assert!(text.contains("No relationships yet"), "{text}");
+        assert!(!text.contains("firmly held"), "{text}");
+    }
+
+    #[test]
+    fn a_self_reinforced_edge_shows_its_tally_and_what_it_means() {
+        let mut overview = overview_with(one_group(), stats(4, 3, 12));
+        overview.confidence = ConfidenceSummary {
+            strong: 3,
+            uncertain: 0,
+            doubtful: 0,
+        };
+        overview.self_reinforced = vec![edge(0.88, 23)];
+        let text = render_overview(&overview);
+
+        assert!(text.contains("self×23"), "{text}");
+        assert!(
+            text.contains("repetition is coherence, not evidence"),
+            "{text}"
+        );
+        assert!(text.contains("—[USES]→"), "{text}");
+        assert!(text.contains("NixOS"), "{text}");
+    }
+
+    #[test]
+    fn an_edge_nobody_repeated_carries_no_tally() {
+        let mut overview = overview_with(one_group(), stats(4, 1, 12));
+        overview.confidence = ConfidenceSummary {
+            strong: 0,
+            uncertain: 0,
+            doubtful: 1,
+        };
+        overview.uncertain = vec![edge(0.31, 0)];
+        let text = render_overview(&overview);
+
+        assert!(text.contains("Least certain"), "{text}");
+        assert!(text.contains("doubtful"), "{text}");
+        assert!(!text.contains("self×"), "{text}");
+        // Believing less than half of itself is worth admitting.
+        assert!(text.contains("Most of what I hold is unsettled"), "{text}");
+    }
+
+    #[test]
+    fn every_overview_offers_the_way_to_correct_it() {
+        let text = render_overview(&overview_with(one_group(), stats(4, 0, 1)));
+        assert!(text.contains("graph correct"), "{text}");
+    }
+
+    fn topic_entity(edges: Vec<EdgeView>, omitted: usize) -> TopicEntity {
+        TopicEntity {
+            entity: EntityDetail {
+                id: serde_json::json!("entity:nixos"),
+                name: "NixOS".into(),
+                entity_type: EntityType::Tool,
+                abstract_text: "Declarative Linux distribution.".into(),
+                overview: String::new(),
+                attributes: None,
+                access_count: 3,
+                utility_score: 0.5,
+                updated_at: serde_json::json!("2026-05-01T09:15:30Z"),
+                source: None,
+            },
+            score: 0.81,
+            source: MatchSource::Semantic,
+            edges,
+            edges_omitted: omitted,
+        }
+    }
+
+    #[test]
+    fn a_topic_reads_as_claims_with_certainty_attached() {
+        let report = TopicReport {
+            topic: "nixos".into(),
+            entities: vec![topic_entity(vec![edge(0.92, 4)], 3)],
+        };
+        let text = render_topic(&report);
+
+        assert!(text.contains("What I know about \"nixos\""), "{text}");
+        assert!(text.contains("NixOS"), "{text}");
+        assert!(text.contains("matched directly"), "{text}");
+        assert!(text.contains("near-certain"), "{text}");
+        assert!(text.contains("self×4"), "{text}");
+        assert!(text.contains("… and 3 more relationships"), "{text}");
+    }
+
+    #[test]
+    fn a_subject_with_no_entities_points_at_the_raw_conversations() {
+        let text = render_topic(&TopicReport {
+            topic: "docker".into(),
+            entities: Vec::new(),
+        });
+        assert!(text.contains("Nothing distilled"), "{text}");
+        assert!(text.contains("--episodes"), "{text}");
+    }
+
+    #[test]
+    fn an_entity_with_no_relationships_says_that_plainly() {
+        let text = render_topic(&TopicReport {
+            topic: "nixos".into(),
+            entities: vec![topic_entity(Vec::new(), 0)],
+        });
+        assert!(text.contains("Nothing else is recorded about it"), "{text}");
+    }
+
+    #[test]
+    fn certainty_matches_the_bands_the_summary_counts_by() {
+        assert_eq!(certainty(1.0), "near-certain");
+        assert_eq!(certainty(STRONG_CONFIDENCE), "confident");
+        assert_eq!(certainty(DOUBTFUL_CONFIDENCE), "unsure");
+        assert_eq!(certainty(0.1), "doubtful");
+    }
+
+    #[test]
+    fn a_graph_believing_less_than_half_of_itself_says_so() {
+        assert!(is_mostly_unsure(&ConfidenceSummary {
+            strong: 4,
+            uncertain: 5,
+            doubtful: 1,
+        }));
+        assert!(!is_mostly_unsure(&ConfidenceSummary {
+            strong: 6,
+            uncertain: 4,
+            doubtful: 0,
+        }));
+        assert!(!is_mostly_unsure(&ConfidenceSummary::default()));
+    }
+
+    #[test]
+    fn long_abstracts_are_clipped_on_a_character_boundary() {
+        let long = "é".repeat(MAX_ABSTRACT_CHARS * 2);
+        let clipped = clip(&long);
+        assert!(clipped.ends_with(" […]"));
+        assert!(clipped.chars().count() < long.chars().count());
+        assert_eq!(clip("  short  "), "short");
+    }
+
+    #[test]
+    fn only_a_non_zero_tally_is_shown() {
+        assert!(coherence_tag(&edge(0.88, 0)).is_empty());
+        assert!(coherence_tag(&edge(0.88, 23)).contains("self×23"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod ephemeral;
 pub mod error;
 pub mod frontmatter;
 pub mod init;
+pub mod inspect_cli;
 pub mod jsonl;
 pub mod mcp;
 pub mod paths;

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,18 @@ enum Commands {
         #[arg(long)]
         entity_root: Option<PathBuf>,
     },
+    /// Show what memory holds — everything, or one subject
+    WhatDoYouKnow {
+        /// Narrow it to one subject
+        #[arg(long = "about", value_name = "TOPIC")]
+        about: Option<String>,
+        /// Entities listed per type (or results, with --about)
+        #[arg(long, default_value = "3")]
+        limit: usize,
+        /// Entity root directory (defaults to current directory)
+        #[arg(long)]
+        entity_root: Option<PathBuf>,
+    },
     /// Knowledge graph operations
     Graph {
         #[command(subcommand)]
@@ -382,6 +394,31 @@ enum GraphCommands {
         #[command(subcommand)]
         command: DaemonCommands,
     },
+    /// Tell memory that something it learned is wrong
+    ///
+    /// `--wrong` records contradicting evidence at your authority, which is how
+    /// confidence is supposed to move. `--forget` removes outright and leaves
+    /// no trace — prefer `--wrong` unless the memory should never have existed.
+    Correct {
+        /// Entity name, or the source entity of a relationship
+        subject: String,
+        /// Relationship type — with a target, corrects that one relationship
+        rel_type: Option<String>,
+        /// Target entity of the relationship
+        object: Option<String>,
+        /// Record that it is mistaken: confidence falls with real evidence
+        #[arg(long)]
+        wrong: bool,
+        /// Remove it and its relationships outright
+        #[arg(long)]
+        forget: bool,
+        /// With --wrong on an entity: contradict every one of its relationships
+        #[arg(long)]
+        all_edges: bool,
+        /// Skip the confirmation --forget otherwise requires
+        #[arg(long)]
+        yes: bool,
+    },
     /// Show relationship decay report — stored vs effective confidence
     DecayReport {
         /// Show only relationships for a specific entity
@@ -502,6 +539,22 @@ fn main() {
             client_runtime()
                 .map_err(recall_echo::error::RecallError::from)
                 .and_then(|rt| rt.block_on(recall_echo::mcp::run(&memory_dir)))
+        }
+        Some(Commands::WhatDoYouKnow {
+            about,
+            limit,
+            entity_root,
+        }) => {
+            let memory_dir = resolve_entity_root(entity_root).join("memory");
+            client_runtime()
+                .map_err(recall_echo::error::RecallError::from)
+                .and_then(|rt| {
+                    rt.block_on(recall_echo::inspect_cli::run(
+                        &memory_dir,
+                        about.as_deref(),
+                        limit,
+                    ))
+                })
         }
         Some(Commands::Graph {
             command,
@@ -674,6 +727,26 @@ fn main() {
                                 }
                                 DaemonCommands::Stop => graph_cli::daemon_stop(&memory_dir).await,
                             },
+                            GraphCommands::Correct {
+                                subject,
+                                rel_type,
+                                object,
+                                wrong,
+                                forget,
+                                all_edges,
+                                yes,
+                            } => {
+                                let options = graph_cli::CorrectOptions {
+                                    subject,
+                                    rel_type,
+                                    object,
+                                    wrong,
+                                    forget,
+                                    all_edges,
+                                    yes,
+                                };
+                                graph_cli::correct(&memory_dir, &options).await
+                            }
                             GraphCommands::DecayReport { entity, all } => {
                                 graph_cli::decay_report(&memory_dir, entity.as_deref(), all).await
                             }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -32,6 +32,13 @@
 //! the mechanism that keeps self-generated claims from becoming evidence.
 //! Writing stays on the ingest path, where every episode is stamped with its
 //! authorship.
+//!
+//! That applies to correction too, and for the same reason inverted:
+//! `graph correct` enters a contradiction at *user* authority, which is only
+//! true while a human is the one typing it. A model calling a correction tool
+//! would be recording its own judgement as the human's — the loudest possible
+//! version of the failure provenance weighting exists to prevent. Corrections
+//! stay on the CLI.
 
 pub mod render;
 pub mod tools;
@@ -43,6 +50,7 @@ use serde_json::{json, Value};
 use tokio::io::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt, BufReader};
 
 use crate::error::RecallError;
+use crate::graph::inspect::MemoryOverview;
 use crate::graph::types::{
     EpisodeSearchResult, GraphStats, QueryResult, ScoredEntity, TraversalNode,
 };
@@ -410,6 +418,10 @@ fn render(request: &Request, data: Value) -> Result<String, serde_json::Error> {
         Request::Status => {
             let stats: GraphStats = serde_json::from_value(data)?;
             render::status(&stats)
+        }
+        Request::Overview(_) => {
+            let overview: MemoryOverview = serde_json::from_value(data)?;
+            render::overview(&overview)
         }
         // No tool builds any other request; a payload we cannot name is
         // still better returned than dropped.

--- a/src/mcp/render.rs
+++ b/src/mcp/render.rs
@@ -18,6 +18,8 @@ use std::fmt::Write as _;
 
 use serde_json::Value;
 
+use crate::graph::edge_view::EdgeView;
+use crate::graph::inspect::{MemoryOverview, DOUBTFUL_CONFIDENCE, STRONG_CONFIDENCE};
 use crate::graph::traverse::format_traversal;
 use crate::graph::types::{
     EntityDetail, EpisodeSearchResult, GraphStats, MatchSource, QueryResult, ScoredEntity,
@@ -194,6 +196,116 @@ pub fn status(stats: &GraphStats) -> String {
     }
 
     budget(out)
+}
+
+/// What memory holds, unprompted.
+///
+/// The uncertainty is the point. An agent reading this should be able to tell
+/// a settled fact from one the graph is holding onto out of habit, and say so
+/// to the user instead of presenting both the same way.
+#[must_use]
+pub fn overview(overview: &MemoryOverview) -> String {
+    let stats = &overview.stats;
+    if stats.entity_count == 0 && stats.episode_count == 0 {
+        return "Memory is empty: no sessions have been ingested, so there is nothing known \
+                about this user or their work yet.\n"
+            .to_string();
+    }
+
+    let mut out = format!(
+        "Memory holds {} {}, {} {} and {} conversation {}.\n",
+        stats.entity_count,
+        plural(stats.entity_count as usize, "entity", "entities"),
+        stats.relationship_count,
+        plural(
+            stats.relationship_count as usize,
+            "relationship",
+            "relationships"
+        ),
+        stats.episode_count,
+        plural(stats.episode_count as usize, "episode", "episodes"),
+    );
+
+    if stats.entity_count == 0 {
+        out.push_str(
+            "Nothing has been distilled from those conversations yet, so only recall_episodes \
+             will find anything.\n",
+        );
+        return budget(out);
+    }
+
+    for group in &overview.groups {
+        let _ = writeln!(out, "\n{} ({}):", group.entity_type, group.count);
+        for entity in &group.top {
+            let _ = writeln!(
+                out,
+                "- {} — {}",
+                entity.name,
+                clip(&entity.abstract_text, MAX_ABSTRACT_CHARS)
+            );
+        }
+        let listed = group.top.len() as u64;
+        if group.count > listed {
+            let _ = writeln!(out, "- … and {} more", group.count - listed);
+        }
+    }
+
+    let confidence = &overview.confidence;
+    if confidence.total() == 0 {
+        out.push_str(
+            "\nNo relationships are recorded: these entities are known but unconnected.\n",
+        );
+    } else {
+        let _ = writeln!(
+            out,
+            "\nConfidence: {} of {} relationships firmly held (at or above {:.0}%), {} uncertain, \
+             {} doubtful (below {:.0}%).",
+            confidence.strong,
+            confidence.total(),
+            STRONG_CONFIDENCE * 100.0,
+            confidence.uncertain,
+            confidence.doubtful,
+            DOUBTFUL_CONFIDENCE * 100.0,
+        );
+    }
+
+    write_edge_list(
+        &mut out,
+        "Least certain",
+        &overview.uncertain,
+        "Treat these as open questions rather than facts.",
+    );
+    write_edge_list(
+        &mut out,
+        "Resting on repetition",
+        &overview.self_reinforced,
+        "self×N counts corroborations the agent authored itself. That tally is deliberately \
+         kept out of the confidence above, so a high one means the belief rests on being \
+         restated rather than on independent evidence — say so rather than asserting it.",
+    );
+
+    budget(out)
+}
+
+fn write_edge_list(out: &mut String, heading: &str, edges: &[EdgeView], note: &str) {
+    if edges.is_empty() {
+        return;
+    }
+    let _ = writeln!(out, "\n{heading}:");
+    for edge in edges {
+        let coherence = if edge.self_reinforcements > 0 {
+            format!(", self×{}", edge.self_reinforcements)
+        } else {
+            String::new()
+        };
+        let _ = writeln!(
+            out,
+            "- {} ({:.0}%{coherence})",
+            edge.arrow(),
+            edge.confidence * 100.0
+        );
+    }
+    let _ = writeln!(out, "{note}");
 }
 
 // ── Pieces ───────────────────────────────────────────────────────────────

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -14,7 +14,9 @@
 
 use serde_json::{json, Value};
 
-use crate::serve::{QueryArgs, Request, SearchArgs, SearchEpisodesArgs, TraverseArgs};
+use crate::serve::{
+    OverviewArgs, QueryArgs, Request, SearchArgs, SearchEpisodesArgs, TraverseArgs,
+};
 
 /// Result limits an agent may ask for. The daemon clamps far higher; these
 /// bounds keep a single tool result inside a sane share of the context window.
@@ -56,6 +58,8 @@ pub enum Tool {
     Traverse,
     /// Episode (conversation-fragment) search.
     Episodes,
+    /// What memory holds, without being asked about anything in particular.
+    Overview,
     /// Graph counts.
     Status,
 }
@@ -64,11 +68,12 @@ pub enum Tool {
 ///
 /// The order is fixed: clients cache the tool list, and a stable order keeps
 /// their prompt caches warm.
-pub const ALL: [Tool; 5] = [
+pub const ALL: [Tool; 6] = [
     Tool::Query,
     Tool::Search,
     Tool::Episodes,
     Tool::Traverse,
+    Tool::Overview,
     Tool::Status,
 ];
 
@@ -87,6 +92,7 @@ impl Tool {
             Tool::Query => "recall_query",
             Tool::Traverse => "recall_traverse",
             Tool::Episodes => "recall_episodes",
+            Tool::Overview => "recall_overview",
             Tool::Status => "recall_status",
         }
     }
@@ -99,6 +105,7 @@ impl Tool {
             Tool::Query => "Recall from memory",
             Tool::Traverse => "Explore an entity's relationships",
             Tool::Episodes => "Search past conversations",
+            Tool::Overview => "What memory holds",
             Tool::Status => "Memory graph status",
         }
     }
@@ -147,6 +154,18 @@ impl Tool {
                  annotated with a percentage are ones the graph is not fully certain of — that \
                  number is accumulated Bayesian evidence, not a guess — and edges marked \
                  [superseded] describe something that was true once and no longer is."
+            }
+            Tool::Overview => {
+                "Read out what memory actually holds, without querying for anything in \
+                 particular: the strongest entities of each type, how firmly the relationships \
+                 between them are believed, the least certain of those relationships, and the \
+                 ones whose confidence rests largely on the agent having repeated itself. Use it \
+                 at the start of working with a user you have no context on, when the user asks \
+                 what you remember about them, or before assuming memory is empty. Unlike \
+                 recall_status, which only counts rows, this returns the content — and it is the \
+                 only tool that surfaces where memory is unsure, which is worth saying out loud \
+                 rather than presenting an uncertain fact as settled. Takes no arguments; ask \
+                 recall_query instead when you have a specific subject in mind."
             }
             Tool::Status => {
                 "Report the size and shape of the memory graph: how many entities, relationships \
@@ -232,7 +251,7 @@ impl Tool {
                 }),
                 &["entity"],
             ),
-            Tool::Status => json!({
+            Tool::Overview | Tool::Status => json!({
                 "type": "object",
                 "properties": {},
                 "additionalProperties": false
@@ -283,6 +302,9 @@ impl Tool {
                     as u32,
                 type_filter: None,
             }),
+            // An overview an agent has to page through is not an overview:
+            // the daemon's default listing size is the right one, always.
+            Tool::Overview => Request::Overview(OverviewArgs { per_type: 0 }),
             Tool::Status => Request::Status,
         };
         Ok(request)

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -30,6 +30,7 @@ use tokio::net::{UnixListener, UnixStream};
 use tokio::sync::Notify;
 
 use crate::error::RecallError;
+use crate::graph::correct::{CorrectTarget, Correction};
 use crate::graph::error::GraphError;
 use crate::graph::types::{
     EntityType, NewEntity, NewRelationship, PipelineDocuments, QueryOptions, SearchOptions,
@@ -55,6 +56,11 @@ const MAX_LIMIT: usize = 1000;
 /// Deepest graph expansion a request may ask for. Expansion is exponential in
 /// the branching factor.
 const MAX_DEPTH: u32 = 8;
+/// Entities an overview lists per type when the client does not say.
+const DEFAULT_PER_TYPE: usize = 3;
+/// Most entities an overview will list per type. An overview a person cannot
+/// read in ten seconds is not an overview.
+const MAX_PER_TYPE: usize = 20;
 /// How long the daemon waits for its own store to close before giving up and
 /// unlinking the socket anyway.
 const STORE_RELEASE_TIMEOUT: Duration = Duration::from_secs(10);
@@ -92,6 +98,12 @@ pub enum Request {
     SyncPipeline(SyncPipelineArgs),
     /// Apply an outcome to the entities a session touched.
     Feedback(FeedbackArgs),
+    /// Tell memory that something it learned is wrong.
+    Correct(CorrectArgs),
+    /// Summarise what the graph holds.
+    Overview(OverviewArgs),
+    /// Summarise what the graph holds about one subject.
+    About(AboutArgs),
     /// Ask the daemon to exit.
     Shutdown,
 }
@@ -112,6 +124,9 @@ impl Request {
             Request::IngestArchive(_) => "ingest_archive",
             Request::SyncPipeline(_) => "sync_pipeline",
             Request::Feedback(_) => "feedback",
+            Request::Correct(_) => "correct",
+            Request::Overview(_) => "overview",
+            Request::About(_) => "about",
             Request::Shutdown => "shutdown",
         }
     }
@@ -135,8 +150,15 @@ impl Request {
             | Request::SyncPipeline(_)
             // Outcome records replace per (entity, session) — reruns correct.
             | Request::Feedback(_)
+            | Request::Overview(_)
+            | Request::About(_)
             | Request::Shutdown => true,
-            Request::AddEntity(_) | Request::Relate(_) | Request::IngestArchive(_) => false,
+            // A repeated contradiction is a second observation, not the same
+            // one: replaying it would record evidence the human never gave.
+            Request::AddEntity(_)
+            | Request::Relate(_)
+            | Request::IngestArchive(_)
+            | Request::Correct(_) => false,
         }
     }
 }
@@ -222,6 +244,28 @@ pub struct SyncPipelineArgs {
 pub struct FeedbackArgs {
     pub session_id: String,
     pub outcome: OutcomeKind,
+}
+
+/// One human correction: what it is aimed at, and what to do to it.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct CorrectArgs {
+    pub target: CorrectTarget,
+    pub correction: Correction,
+}
+
+/// How much of the graph an overview lists per entity type. Absent — the shape
+/// a client that does not care sends — takes the default.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct OverviewArgs {
+    #[serde(default)]
+    pub per_type: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct AboutArgs {
+    pub topic: String,
+    #[serde(default)]
+    pub limit: usize,
 }
 
 /// A daemon response. Wire form is `{"ok": true, "data": ...}` or
@@ -372,6 +416,15 @@ fn clamp_depth(depth: u32) -> u32 {
     depth.clamp(1, MAX_DEPTH)
 }
 
+/// Clamp a wire-supplied per-type listing size. Zero — what a client that
+/// omits the field sends — means "take the default".
+fn clamp_per_type(per_type: usize) -> usize {
+    if per_type == 0 {
+        return DEFAULT_PER_TYPE;
+    }
+    per_type.clamp(1, MAX_PER_TYPE)
+}
+
 /// `Ok(None)` means "not a graph operation".
 async fn execute_graph(
     graph: &GraphMemory,
@@ -467,6 +520,15 @@ async fn execute_graph(
                 .record_session_outcome(&args.session_id, args.outcome)
                 .await?,
         )?,
+        Request::Correct(args) => {
+            serde_json::to_value(graph.correct(&args.target, args.correction).await?)?
+        }
+        Request::Overview(args) => {
+            serde_json::to_value(graph.overview(clamp_per_type(args.per_type)).await?)?
+        }
+        Request::About(args) => {
+            serde_json::to_value(graph.about(&args.topic, clamp_limit(args.limit)).await?)?
+        }
     };
     Ok(Some(data))
 }
@@ -1437,6 +1499,23 @@ mod tests {
                 session_id: "s1".into(),
                 outcome: OutcomeKind::Success,
             }),
+            Request::Correct(CorrectArgs {
+                target: CorrectTarget::Edge {
+                    from: "D".into(),
+                    rel_type: "USES".into(),
+                    to: "Vim".into(),
+                },
+                correction: Correction::Wrong { all_edges: false },
+            }),
+            Request::Correct(CorrectArgs {
+                target: CorrectTarget::Entity { name: "Vim".into() },
+                correction: Correction::Forget { confirmed: true },
+            }),
+            Request::Overview(OverviewArgs { per_type: 3 }),
+            Request::About(AboutArgs {
+                topic: "rust".into(),
+                limit: 5,
+            }),
             Request::Shutdown,
         ];
 
@@ -1733,6 +1812,57 @@ mod tests {
         // and asks SurrealDB for an unbounded scan.
         assert_eq!(clamp_limit(usize::MAX), MAX_LIMIT);
         assert_eq!(clamp_limit(0), 1);
+    }
+
+    /// A correction is an observation. Replaying one because a connection
+    /// dropped would record evidence the human never gave.
+    #[test]
+    fn a_correction_is_never_replayed() {
+        assert!(!Request::Correct(CorrectArgs {
+            target: CorrectTarget::Entity { name: "Vim".into() },
+            correction: Correction::Wrong { all_edges: false },
+        })
+        .is_retryable());
+        assert!(Request::Overview(OverviewArgs { per_type: 0 }).is_retryable());
+        assert!(Request::About(AboutArgs {
+            topic: "rust".into(),
+            limit: 0,
+        })
+        .is_retryable());
+    }
+
+    /// The shape a client that does not care about listing size sends.
+    #[test]
+    fn inspection_args_may_be_omitted_on_the_wire() {
+        assert_eq!(
+            serde_json::from_str::<Request>(r#"{"op":"overview","args":{}}"#).unwrap(),
+            Request::Overview(OverviewArgs { per_type: 0 })
+        );
+        assert_eq!(
+            serde_json::from_str::<Request>(r#"{"op":"about","args":{"topic":"rust"}}"#).unwrap(),
+            Request::About(AboutArgs {
+                topic: "rust".into(),
+                limit: 0,
+            })
+        );
+        assert_eq!(
+            serde_json::from_str::<Request>(
+                r#"{"op":"correct","args":{"target":{"kind":"entity","name":"Vim"},
+                    "correction":{"kind":"wrong"}}}"#
+            )
+            .unwrap(),
+            Request::Correct(CorrectArgs {
+                target: CorrectTarget::Entity { name: "Vim".into() },
+                correction: Correction::Wrong { all_edges: false },
+            })
+        );
+    }
+
+    #[test]
+    fn an_absent_per_type_takes_the_default() {
+        assert_eq!(clamp_per_type(0), DEFAULT_PER_TYPE);
+        assert_eq!(clamp_per_type(5), 5);
+        assert_eq!(clamp_per_type(usize::MAX), MAX_PER_TYPE);
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -9,11 +9,17 @@ use tempfile::TempDir;
 
 /// An ephemeral graph database for testing.
 /// The temp directory (and all DB data) is cleaned up when this is dropped.
+///
+/// Not every test binary opens a store this way — the ones that seed with raw
+/// SurrealQL go through [`daemon::Fixture`] instead — so unused-code lints do
+/// not apply.
+#[allow(dead_code)]
 pub struct TestDb {
     pub graph: GraphMemory,
     _dir: TempDir,
 }
 
+#[allow(dead_code)]
 impl TestDb {
     /// Create a fresh, empty graph database.
     pub async fn new() -> Self {
@@ -26,6 +32,218 @@ impl TestDb {
             .expect("failed to open graph");
 
         Self { graph, _dir: dir }
+    }
+}
+
+/// A memory directory with its own graph store and daemon socket, seeded
+/// through raw SurrealQL.
+///
+/// Nothing here embeds anything: entities are written with their vectors left
+/// absent, so a test that only exercises graph writes, evidence arithmetic or
+/// rendering never loads the ONNX model.
+#[allow(dead_code)]
+pub mod daemon {
+    use std::path::PathBuf;
+    use std::sync::Once;
+
+    use recall_echo::graph::store::{self, Db};
+    use recall_echo::serve_client;
+    use surrealdb::Surreal;
+    use tempfile::TempDir;
+
+    static BIN_ENV: Once = Once::new();
+
+    /// Point the daemon client at the binary cargo just built.
+    pub fn use_test_binary() {
+        BIN_ENV.call_once(|| {
+            std::env::set_var(
+                serve_client::DAEMON_BIN_ENV,
+                env!("CARGO_BIN_EXE_recall-echo"),
+            );
+        });
+    }
+
+    pub struct Fixture {
+        _dir: TempDir,
+        pub memory_dir: PathBuf,
+        pub graph_dir: PathBuf,
+    }
+
+    impl Fixture {
+        pub fn new() -> Self {
+            use_test_binary();
+
+            let dir = TempDir::new().expect("temp dir");
+            let memory_dir = dir.path().join("e").join("memory");
+            let graph_dir = memory_dir.join("graph");
+            std::fs::create_dir_all(&graph_dir).expect("memory dir");
+
+            std::fs::write(
+                memory_dir.join(".recall-echo.toml"),
+                format!(
+                    "[serve]\nsocket_path = \"{}\"\nidle_timeout_secs = 120\n",
+                    dir.path().join("g.sock").display()
+                ),
+            )
+            .expect("write config");
+
+            Self {
+                _dir: dir,
+                memory_dir,
+                graph_dir,
+            }
+        }
+
+        /// Open the store directly. Only valid while no daemon holds it.
+        pub async fn open(&self) -> Surreal<Db> {
+            let db = store::open(&self.graph_dir).await.expect("open store");
+            store::init_schema(&db).await.expect("init schema");
+            db
+        }
+
+        /// Stop the daemon so the store can be opened directly again.
+        pub async fn stop_daemon(&self) {
+            serve_client::stop_daemon(&self.memory_dir)
+                .await
+                .expect("stop daemon");
+        }
+    }
+
+    /// Release the embedded store's process lock.
+    pub async fn close(db: Surreal<Db>) {
+        drop(db);
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+    }
+
+    pub async fn create_entity(db: &Surreal<Db>, id: &str, name: &str, entity_type: &str) {
+        db.query(
+            r#"CREATE type::record($id) SET
+                   name = $name,
+                   entity_type = $entity_type,
+                   abstract = $abstract,
+                   overview = '',
+                   mutable = true,
+                   access_count = 0,
+                   utility_score = 0.5,
+                   utility_updates = 0,
+                   created_at = time::now(),
+                   updated_at = time::now(),
+                   source = 'test'"#,
+        )
+        .bind(("id", id.to_string()))
+        .bind(("name", name.to_string()))
+        .bind(("entity_type", entity_type.to_string()))
+        .bind(("abstract", format!("{name} exists.")))
+        .await
+        .and_then(surrealdb::IndexedResults::check)
+        .unwrap_or_else(|e| panic!("failed to create entity {id}: {e}"));
+    }
+
+    /// One seeded relationship, with its evidence stated outright.
+    pub struct Edge {
+        pub from: &'static str,
+        pub to: &'static str,
+        pub rel_type: &'static str,
+        pub alpha: f64,
+        pub beta: f64,
+        pub self_reinforcements: i64,
+    }
+
+    impl Default for Edge {
+        fn default() -> Self {
+            Self {
+                from: "entity:d",
+                to: "entity:vim",
+                rel_type: "USES",
+                alpha: 9.0,
+                beta: 1.0,
+                self_reinforcements: 0,
+            }
+        }
+    }
+
+    impl Edge {
+        /// The posterior mean the seeded counts imply.
+        pub fn confidence(&self) -> f64 {
+            self.alpha / (self.alpha + self.beta)
+        }
+    }
+
+    /// Create the edge and return its record id.
+    pub async fn create_edge(db: &Surreal<Db>, edge: &Edge) -> String {
+        let mut response = db
+            .query(
+                r#"LET $from = type::record($from_id);
+                   LET $to = type::record($to_id);
+                   RELATE $from -> relates_to -> $to SET
+                       rel_type = $rel_type,
+                       description = NONE,
+                       valid_from = time::now(),
+                       valid_until = NONE,
+                       confidence = $confidence,
+                       alpha = $alpha,
+                       beta = $beta,
+                       self_reinforcements = $self_reinforcements,
+                       last_reinforced = time::now(),
+                       source = 'test'"#,
+            )
+            .bind(("from_id", edge.from.to_string()))
+            .bind(("to_id", edge.to.to_string()))
+            .bind(("rel_type", edge.rel_type.to_string()))
+            .bind(("confidence", edge.confidence()))
+            .bind(("alpha", edge.alpha))
+            .bind(("beta", edge.beta))
+            .bind(("self_reinforcements", edge.self_reinforcements))
+            .await
+            .expect("relate");
+
+        let created: Vec<serde_json::Value> = response.take(2).expect("read created edge");
+        created
+            .first()
+            .and_then(|row| row.get("id"))
+            .and_then(|id| id.as_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| panic!("RELATE returned no edge: {created:?}"))
+    }
+
+    /// Every stored relationship as (id, confidence, alpha, beta).
+    pub async fn edges(db: &Surreal<Db>) -> Vec<(String, f64, f64, f64)> {
+        let mut response = db
+            .query(
+                "SELECT type::string(id) AS id, confidence, alpha, beta \
+                 FROM relates_to ORDER BY id",
+            )
+            .await
+            .expect("list edges");
+        let rows: Vec<serde_json::Value> = response.take(0).expect("read edges");
+        rows.iter()
+            .map(|row| {
+                (
+                    row["id"].as_str().unwrap_or_default().to_string(),
+                    row["confidence"].as_f64().unwrap_or_default(),
+                    row["alpha"].as_f64().unwrap_or_default(),
+                    row["beta"].as_f64().unwrap_or_default(),
+                )
+            })
+            .collect()
+    }
+
+    /// One stored relationship as (confidence, alpha, beta), by record id.
+    pub async fn edge_state(db: &Surreal<Db>, edge_id: &str) -> Option<(f64, f64, f64)> {
+        edges(db)
+            .await
+            .into_iter()
+            .find(|(id, ..)| id == edge_id)
+            .map(|(_, confidence, alpha, beta)| (confidence, alpha, beta))
+    }
+
+    /// Names of every stored entity, sorted.
+    pub async fn entity_names(db: &Surreal<Db>) -> Vec<String> {
+        let mut response = db
+            .query("SELECT VALUE name FROM entity ORDER BY name")
+            .await
+            .expect("list entities");
+        response.take(0).expect("read entity names")
     }
 }
 

--- a/tests/config_show.rs
+++ b/tests/config_show.rs
@@ -1,0 +1,110 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! `recall-echo config show` prints the whole configuration.
+//!
+//! Run against the real binary, because what is under test is what a user
+//! debugging their setup sees. The sections that decide whether sessions are
+//! imported at all — `[capture]`, `[extraction]`, `[serve]` — are all defaulted
+//! on, which means a working install has an empty config file and the answer to
+//! "why is it doing that?" is nowhere on screen unless defaults are printed too.
+
+use std::process::Command;
+
+use tempfile::TempDir;
+
+/// `config show` writes to stderr; stdout stays free for piping.
+fn config_show(entity_root: &std::path::Path) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_recall-echo"))
+        .args(["config", "--entity-root"])
+        .arg(entity_root)
+        .arg("show")
+        .output()
+        .expect("run config show");
+    assert!(output.status.success(), "config show failed: {output:?}");
+    String::from_utf8(output.stderr).expect("utf-8 output")
+}
+
+fn entity_root(config: &str) -> TempDir {
+    let dir = TempDir::new().expect("temp dir");
+    let memory_dir = dir.path().join("memory");
+    std::fs::create_dir_all(&memory_dir).expect("memory dir");
+    if !config.is_empty() {
+        std::fs::write(memory_dir.join(".recall-echo.toml"), config).expect("write config");
+    }
+    dir
+}
+
+#[test]
+fn every_section_is_shown_even_at_its_defaults() {
+    let dir = entity_root("");
+    let shown = config_show(dir.path());
+
+    for section in [
+        "[ephemeral]",
+        "[llm]",
+        "[capture]",
+        "[extraction]",
+        "[serve]",
+    ] {
+        assert!(
+            shown.contains(section),
+            "{section} is missing from:\n{shown}"
+        );
+    }
+}
+
+#[test]
+fn capture_says_what_it_sweeps_and_how_long_it_waits() {
+    let dir = entity_root("");
+    let shown = config_show(dir.path());
+
+    assert!(shown.contains("enabled     = true"), "{shown}");
+    assert!(
+        shown.contains("every CLI with sessions on this machine"),
+        "an auto-detecting default must say what it detects:\n{shown}"
+    );
+    assert!(shown.contains("settle_secs = 300"), "{shown}");
+}
+
+#[test]
+fn configured_capture_sources_are_listed_by_name() {
+    let dir = entity_root("[capture]\nsources = [\"codex\", \"grok\"]\n");
+    let shown = config_show(dir.path());
+    assert!(shown.contains("sources     = codex, grok"), "{shown}");
+}
+
+#[test]
+fn extraction_shows_what_the_daemon_will_do_on_its_own() {
+    let dir = entity_root("");
+    let shown = config_show(dir.path());
+
+    assert!(shown.contains("background_enabled = true"), "{shown}");
+    assert!(shown.contains("idle_after_secs    = 120"), "{shown}");
+    assert!(shown.contains("batch_size         = 3"), "{shown}");
+}
+
+#[test]
+fn serve_shows_where_the_daemon_listens_and_how_long_it_lives() {
+    let dir = entity_root("");
+    let shown = config_show(dir.path());
+
+    assert!(
+        shown.contains("derived from the memory directory"),
+        "{shown}"
+    );
+    assert!(shown.contains("idle_timeout_secs = 3600"), "{shown}");
+}
+
+#[test]
+fn a_daemon_that_never_shuts_down_says_so_rather_than_printing_zero() {
+    let dir = entity_root("[serve]\nsocket_path = \"/tmp/re.sock\"\nidle_timeout_secs = 0\n");
+    let shown = config_show(dir.path());
+
+    assert!(
+        shown.contains("socket_path       = /tmp/re.sock"),
+        "{shown}"
+    );
+    assert!(shown.contains("never idle-shuts-down"), "{shown}");
+}

--- a/tests/correction.rs
+++ b/tests/correction.rs
@@ -1,0 +1,536 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Human correction, end to end through the daemon.
+//!
+//! Three properties, in order of how much they matter:
+//!
+//! - **A correction is evidence.** `--wrong` moves the Beta counts and the
+//!   posterior mean, and the move survives the daemon and a reopen.
+//! - **Nothing is damaged on a guess.** A name that does not resolve, and an
+//!   entity whose claims are ambiguous, both come back with candidates and
+//!   leave the store byte-identical.
+//! - **Destruction is confirmed.** An unconfirmed forget reports what would go
+//!   and removes nothing.
+//!
+//! Fixtures are raw SurrealQL: correction is graph writes and arithmetic, so no
+//! embedding model is involved.
+
+mod common;
+
+use common::daemon::{self, Edge, Fixture};
+use recall_echo::graph::correct::{CorrectTarget, Correction, CorrectionReport};
+use recall_echo::graph::store::Db;
+use recall_echo::serve::{CorrectArgs, Request};
+use recall_echo::serve_client;
+use std::path::Path;
+use surrealdb::Surreal;
+
+/// Weight of one user-authored observation at the default provenance weights.
+const USER_WEIGHT: f64 = 0.8;
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+/// D uses Vim (strongly held), and Vim is configured by dotfiles.
+async fn seed_two_claims(db: &Surreal<Db>) -> (String, String) {
+    daemon::create_entity(db, "entity:d", "D", "person").await;
+    daemon::create_entity(db, "entity:vim", "Vim", "tool").await;
+    daemon::create_entity(db, "entity:dotfiles", "dotfiles", "project").await;
+
+    let uses = daemon::create_edge(
+        db,
+        &Edge {
+            from: "entity:d",
+            to: "entity:vim",
+            rel_type: "USES",
+            alpha: 9.0,
+            beta: 1.0,
+            self_reinforcements: 0,
+        },
+    )
+    .await;
+    let configured = daemon::create_edge(
+        db,
+        &Edge {
+            from: "entity:vim",
+            to: "entity:dotfiles",
+            rel_type: "CONFIGURED_BY",
+            alpha: 6.0,
+            beta: 4.0,
+            self_reinforcements: 2,
+        },
+    )
+    .await;
+    (uses, configured)
+}
+
+/// Only the first claim: an entity with exactly one thing said about it.
+async fn seed_one_claim(db: &Surreal<Db>) -> String {
+    daemon::create_entity(db, "entity:d", "D", "person").await;
+    daemon::create_entity(db, "entity:vim", "Vim", "tool").await;
+    daemon::create_edge(db, &Edge::default()).await
+}
+
+async fn correct(
+    memory_dir: &Path,
+    target: CorrectTarget,
+    correction: Correction,
+) -> CorrectionReport {
+    let request = Request::Correct(CorrectArgs { target, correction });
+    let data = serve_client::execute(memory_dir, &request)
+        .await
+        .expect("correction request");
+    serde_json::from_value(data).expect("decode correction report")
+}
+
+fn entity(name: &str) -> CorrectTarget {
+    CorrectTarget::Entity {
+        name: name.to_string(),
+    }
+}
+
+fn edge(from: &str, rel_type: &str, to: &str) -> CorrectTarget {
+    CorrectTarget::Edge {
+        from: from.to_string(),
+        rel_type: rel_type.to_string(),
+        to: to.to_string(),
+    }
+}
+
+fn approx(a: f64, b: f64) -> bool {
+    (a - b).abs() < 1e-9
+}
+
+// ── Contradiction ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn contradicting_a_relationship_lowers_confidence_and_persists() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    let uses = seed_one_claim(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        edge("D", "USES", "Vim"),
+        Correction::Wrong { all_edges: false },
+    )
+    .await;
+
+    let CorrectionReport::Contradicted { edges } = report else {
+        panic!("expected a contradiction, got {report:?}");
+    };
+    assert_eq!(edges.len(), 1);
+    let correction = &edges[0];
+
+    // The user's word is one observation at user weight, not a decree: alpha
+    // is untouched, beta grows by the weight, and the mean follows.
+    assert!(approx(correction.confidence_before, 0.9));
+    assert!(approx(correction.evidence_before, 10.0));
+    assert!(
+        approx(correction.edge.confidence, 9.0 / (10.0 + USER_WEIGHT)),
+        "got {}",
+        correction.edge.confidence
+    );
+    assert!(approx(correction.edge.evidence, 10.0 + USER_WEIGHT));
+    assert_eq!(correction.edge.from, "D");
+    assert_eq!(correction.edge.to, "Vim");
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    let (confidence, alpha, beta) = daemon::edge_state(&db, &uses)
+        .await
+        .expect("the edge is still there");
+    assert!(approx(alpha, 9.0), "corroboration is not erased: {alpha}");
+    assert!(approx(beta, 1.0 + USER_WEIGHT), "got {beta}");
+    assert!(approx(confidence, 9.0 / (10.0 + USER_WEIGHT)));
+    daemon::close(db).await;
+}
+
+#[tokio::test]
+async fn saying_it_twice_is_twice_the_evidence() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    let uses = seed_one_claim(&db).await;
+    daemon::close(db).await;
+
+    for _ in 0..2 {
+        correct(
+            &fixture.memory_dir,
+            edge("D", "USES", "Vim"),
+            Correction::Wrong { all_edges: false },
+        )
+        .await;
+    }
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    let (confidence, _, beta) = daemon::edge_state(&db, &uses).await.expect("edge");
+    assert!(approx(beta, 1.0 + 2.0 * USER_WEIGHT), "got {beta}");
+    assert!(confidence < 9.0 / (10.0 + USER_WEIGHT));
+    daemon::close(db).await;
+}
+
+#[tokio::test]
+async fn an_entity_with_one_claim_needs_no_disambiguation() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    let uses = seed_one_claim(&db).await;
+    daemon::close(db).await;
+
+    // Correcting the entity means correcting what is claimed about it — and
+    // with one claim there is nothing to choose between.
+    let report = correct(
+        &fixture.memory_dir,
+        entity("Vim"),
+        Correction::Wrong { all_edges: false },
+    )
+    .await;
+    let CorrectionReport::Contradicted { edges } = report else {
+        panic!("expected a contradiction, got {report:?}");
+    };
+    assert_eq!(edges[0].edge.id, uses);
+}
+
+#[tokio::test]
+async fn an_entity_with_several_claims_asks_which_and_changes_nothing() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    let before = daemon::edges(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        entity("Vim"),
+        Correction::Wrong { all_edges: false },
+    )
+    .await;
+
+    let CorrectionReport::Ambiguous { entity, edges } = report else {
+        panic!("expected disambiguation, got {report:?}");
+    };
+    assert_eq!(entity, "Vim");
+    assert_eq!(edges.len(), 2, "both claims are offered: {edges:?}");
+    assert!(
+        edges.iter().any(|edge| edge.rel_type == "USES")
+            && edges.iter().any(|edge| edge.rel_type == "CONFIGURED_BY"),
+        "{edges:?}"
+    );
+    // The one carrying self-authored corroboration says so, unprompted.
+    assert_eq!(
+        edges
+            .iter()
+            .find(|edge| edge.rel_type == "CONFIGURED_BY")
+            .map(|edge| edge.self_reinforcements),
+        Some(2)
+    );
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    assert_eq!(
+        daemon::edges(&db).await,
+        before,
+        "a refusal to guess must not move a single count"
+    );
+    daemon::close(db).await;
+}
+
+#[tokio::test]
+async fn asking_for_all_of_them_contradicts_every_claim() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        entity("Vim"),
+        Correction::Wrong { all_edges: true },
+    )
+    .await;
+    let CorrectionReport::Contradicted { edges } = report else {
+        panic!("expected a contradiction, got {report:?}");
+    };
+    assert_eq!(edges.len(), 2);
+    assert!(
+        edges
+            .iter()
+            .all(|edge| edge.edge.confidence < edge.confidence_before),
+        "{edges:?}"
+    );
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    for (id, _, _, beta) in daemon::edges(&db).await {
+        assert!(
+            beta > 1.0,
+            "every claim took a hit — {id} is at beta {beta}"
+        );
+    }
+    daemon::close(db).await;
+}
+
+#[tokio::test]
+async fn an_entity_nothing_is_claimed_about_has_nothing_to_contradict() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    daemon::create_entity(&db, "entity:lonely", "Lonely", "concept").await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        entity("Lonely"),
+        Correction::Wrong { all_edges: false },
+    )
+    .await;
+    assert!(
+        matches!(report, CorrectionReport::NothingToCorrect { ref entity } if entity == "Lonely"),
+        "{report:?}"
+    );
+}
+
+// ── Refusing to guess ────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn a_name_that_does_not_resolve_lists_the_closest_and_changes_nothing() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    let before = daemon::edges(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        entity("dotfile"),
+        Correction::Wrong { all_edges: false },
+    )
+    .await;
+
+    let CorrectionReport::UnknownEntity { query, candidates } = report else {
+        panic!("expected a refusal, got {report:?}");
+    };
+    assert_eq!(query, "dotfile");
+    assert_eq!(
+        candidates.first().map(|entity| entity.name.as_str()),
+        Some("dotfiles"),
+        "the near-miss is offered, not applied: {candidates:?}"
+    );
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    assert_eq!(daemon::edges(&db).await, before);
+    assert_eq!(daemon::entity_names(&db).await.len(), 3);
+    daemon::close(db).await;
+}
+
+#[tokio::test]
+async fn a_name_close_to_nothing_offers_nothing() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        entity("zzzzqqqq"),
+        Correction::Wrong { all_edges: false },
+    )
+    .await;
+    let CorrectionReport::UnknownEntity { candidates, .. } = report else {
+        panic!("expected a refusal, got {report:?}");
+    };
+    assert!(candidates.is_empty(), "{candidates:?}");
+}
+
+#[tokio::test]
+async fn a_relationship_that_does_not_exist_reports_the_ones_that_do() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        edge("D", "HATES", "Vim"),
+        Correction::Wrong { all_edges: false },
+    )
+    .await;
+
+    let CorrectionReport::NoSuchEdge {
+        from,
+        to,
+        rel_type,
+        existing,
+    } = report
+    else {
+        panic!("expected a refusal, got {report:?}");
+    };
+    assert_eq!(
+        (from.as_str(), rel_type.as_str(), to.as_str()),
+        ("D", "HATES", "Vim")
+    );
+    assert_eq!(
+        existing
+            .iter()
+            .map(|edge| edge.rel_type.as_str())
+            .collect::<Vec<_>>(),
+        vec!["USES"],
+        "what does connect them is worth saying"
+    );
+}
+
+/// The graph stored the claim one way round; the human need not know which.
+#[tokio::test]
+async fn a_relationship_named_backwards_still_resolves() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_one_claim(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        edge("Vim", "uses", "D"),
+        Correction::Wrong { all_edges: false },
+    )
+    .await;
+    assert!(
+        matches!(report, CorrectionReport::Contradicted { ref edges } if edges.len() == 1),
+        "{report:?}"
+    );
+}
+
+// ── Forgetting ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn an_unconfirmed_forget_reports_what_would_go_and_removes_nothing() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        entity("Vim"),
+        Correction::Forget { confirmed: false },
+    )
+    .await;
+
+    let CorrectionReport::Planned { removal } = report else {
+        panic!("expected a plan, got {report:?}");
+    };
+    assert_eq!(
+        removal.entity.as_ref().map(|entity| entity.name.as_str()),
+        Some("Vim")
+    );
+    assert_eq!(
+        removal.edges.len(),
+        2,
+        "the plan names every relationship going with it: {:?}",
+        removal.edges
+    );
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    assert_eq!(daemon::edges(&db).await.len(), 2, "nothing was removed");
+    assert!(daemon::entity_names(&db).await.contains(&"Vim".to_string()));
+    daemon::close(db).await;
+}
+
+#[tokio::test]
+async fn a_confirmed_forget_removes_the_entity_and_its_relationships() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        entity("Vim"),
+        Correction::Forget { confirmed: true },
+    )
+    .await;
+    let CorrectionReport::Removed { removal } = report else {
+        panic!("expected a removal, got {report:?}");
+    };
+    assert_eq!(removal.edges.len(), 2);
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    assert!(
+        daemon::edges(&db).await.is_empty(),
+        "an entity's edges go with it"
+    );
+    assert_eq!(
+        daemon::entity_names(&db).await,
+        vec!["D".to_string(), "dotfiles".to_string()],
+        "its neighbours stay"
+    );
+    daemon::close(db).await;
+}
+
+#[tokio::test]
+async fn forgetting_one_relationship_leaves_both_entities() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        edge("D", "USES", "Vim"),
+        Correction::Forget { confirmed: true },
+    )
+    .await;
+    let CorrectionReport::Removed { removal } = report else {
+        panic!("expected a removal, got {report:?}");
+    };
+    assert!(removal.entity.is_none());
+    assert_eq!(removal.edges.len(), 1);
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    assert_eq!(daemon::edges(&db).await.len(), 1, "only that claim went");
+    assert_eq!(daemon::entity_names(&db).await.len(), 3);
+    daemon::close(db).await;
+}
+
+#[tokio::test]
+async fn forgetting_a_name_that_does_not_resolve_removes_nothing() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed_two_claims(&db).await;
+    daemon::close(db).await;
+
+    let report = correct(
+        &fixture.memory_dir,
+        entity("Vimm"),
+        Correction::Forget { confirmed: true },
+    )
+    .await;
+    assert!(
+        matches!(report, CorrectionReport::UnknownEntity { .. }),
+        "{report:?}"
+    );
+
+    fixture.stop_daemon().await;
+    let db = fixture.open().await;
+    assert_eq!(daemon::entity_names(&db).await.len(), 3);
+    assert_eq!(daemon::edges(&db).await.len(), 2);
+    daemon::close(db).await;
+}

--- a/tests/inspection.rs
+++ b/tests/inspection.rs
@@ -1,0 +1,211 @@
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+//! Inspection, end to end through the daemon.
+//!
+//! What a person is owed by an overview: their own entities back, grouped and
+//! counted; an honest split of how firmly the relationships are held; the
+//! least certain ones named; and the coherence tally shown wherever it is
+//! non-zero, because "believed because I kept saying it" is the one thing a
+//! confidence number cannot tell you on its own.
+//!
+//! Fixtures are raw SurrealQL and the overview is a projection, so no embedding
+//! model is loaded. The `--about` form runs the ordinary hybrid query and is
+//! covered where retrieval is covered; what is asserted here is the surface.
+
+mod common;
+
+use common::daemon::{self, Edge, Fixture};
+use recall_echo::graph::inspect::MemoryOverview;
+use recall_echo::graph::store::Db;
+use recall_echo::inspect_cli::render_overview;
+use recall_echo::serve::{OverviewArgs, Request};
+use recall_echo::serve_client;
+use std::path::Path;
+use surrealdb::Surreal;
+
+async fn overview(memory_dir: &Path) -> MemoryOverview {
+    let request = Request::Overview(OverviewArgs { per_type: 3 });
+    let data = serve_client::execute(memory_dir, &request)
+        .await
+        .expect("overview request");
+    serde_json::from_value(data).expect("decode overview")
+}
+
+/// Two people, three tools, and four claims of varying quality.
+async fn seed(db: &Surreal<Db>) {
+    daemon::create_entity(db, "entity:d", "D", "person").await;
+    daemon::create_entity(db, "entity:echo", "Echo", "person").await;
+    daemon::create_entity(db, "entity:vim", "Vim", "tool").await;
+    daemon::create_entity(db, "entity:nixos", "NixOS", "tool").await;
+    daemon::create_entity(db, "entity:rust", "Rust", "tool").await;
+
+    // Firmly held.
+    daemon::create_edge(
+        db,
+        &Edge {
+            from: "entity:d",
+            to: "entity:rust",
+            rel_type: "LEARNS",
+            alpha: 19.0,
+            beta: 1.0,
+            self_reinforcements: 0,
+        },
+    )
+    .await;
+    // Held mostly because the agent kept saying so.
+    daemon::create_edge(
+        db,
+        &Edge {
+            from: "entity:echo",
+            to: "entity:nixos",
+            rel_type: "USES",
+            alpha: 17.0,
+            beta: 3.0,
+            self_reinforcements: 23,
+        },
+    )
+    .await;
+    // Barely believed.
+    daemon::create_edge(
+        db,
+        &Edge {
+            from: "entity:d",
+            to: "entity:vim",
+            rel_type: "PREFERS",
+            alpha: 3.0,
+            beta: 7.0,
+            self_reinforcements: 1,
+        },
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn an_overview_returns_the_graph_grouped_and_counted() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed(&db).await;
+    daemon::close(db).await;
+
+    let overview = overview(&fixture.memory_dir).await;
+
+    assert_eq!(overview.stats.entity_count, 5);
+    assert_eq!(overview.stats.relationship_count, 3);
+
+    // Most populous type first, so the first thing read is the biggest thing
+    // known.
+    let types: Vec<&str> = overview
+        .groups
+        .iter()
+        .map(|group| group.entity_type.as_str())
+        .collect();
+    assert_eq!(types, vec!["tool", "person"]);
+
+    let tools = &overview.groups[0];
+    assert_eq!(
+        tools.count, 3,
+        "the count is of the type, not of the listing"
+    );
+    assert_eq!(tools.top.len(), 3);
+    let mut names: Vec<&str> = tools.top.iter().map(|e| e.name.as_str()).collect();
+    names.sort_unstable();
+    assert_eq!(names, vec!["NixOS", "Rust", "Vim"]);
+}
+
+#[tokio::test]
+async fn an_overview_is_honest_about_how_sure_it_is() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed(&db).await;
+    daemon::close(db).await;
+
+    let overview = overview(&fixture.memory_dir).await;
+
+    assert_eq!(overview.confidence.total(), 3);
+    assert_eq!(overview.confidence.strong, 2, "0.95 and 0.85");
+    assert_eq!(overview.confidence.doubtful, 1, "0.30");
+
+    // Not-strong edges are named, strongest-held ones are not: the point of
+    // the section is where to look, not a second copy of the graph.
+    let uncertain: Vec<&str> = overview
+        .uncertain
+        .iter()
+        .map(|edge| edge.rel_type.as_str())
+        .collect();
+    assert_eq!(uncertain, vec!["PREFERS"]);
+    assert_eq!(overview.uncertain[0].from, "D", "names, not record ids");
+    assert_eq!(overview.uncertain[0].to, "Vim");
+}
+
+#[tokio::test]
+async fn an_overview_surfaces_the_coherence_tally() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    seed(&db).await;
+    daemon::close(db).await;
+
+    let overview = overview(&fixture.memory_dir).await;
+
+    // Both self-reinforced edges are listed, the loudest first; the edge
+    // nobody repeated is not.
+    let tallies: Vec<i64> = overview
+        .self_reinforced
+        .iter()
+        .map(|edge| edge.self_reinforcements)
+        .collect();
+    assert_eq!(tallies, vec![23, 1], "{:?}", overview.self_reinforced);
+    assert!(
+        !overview
+            .self_reinforced
+            .iter()
+            .any(|edge| edge.rel_type == "LEARNS"),
+        "an edge nobody repeated is not a coherence risk"
+    );
+
+    let text = render_overview(&overview);
+    assert!(text.contains("self×23"), "{text}");
+    assert!(
+        text.contains("repetition is coherence, not evidence"),
+        "the tally means nothing without the sentence: {text}"
+    );
+}
+
+#[tokio::test]
+async fn an_empty_graph_says_it_is_empty() {
+    let fixture = Fixture::new();
+
+    let overview = overview(&fixture.memory_dir).await;
+    assert_eq!(overview.stats.entity_count, 0);
+    assert!(overview.groups.is_empty());
+    assert_eq!(overview.confidence.total(), 0);
+
+    let text = render_overview(&overview);
+    assert!(text.contains("Nothing yet"), "{text}");
+    assert!(!text.contains("firmly held"), "{text}");
+}
+
+#[tokio::test]
+async fn entities_without_relationships_are_reported_as_unconnected() {
+    let fixture = Fixture::new();
+
+    let db = fixture.open().await;
+    daemon::create_entity(&db, "entity:d", "D", "person").await;
+    daemon::create_entity(&db, "entity:vim", "Vim", "tool").await;
+    daemon::close(db).await;
+
+    let overview = overview(&fixture.memory_dir).await;
+    assert_eq!(overview.stats.entity_count, 2);
+    assert_eq!(overview.stats.relationship_count, 0);
+    assert_eq!(overview.confidence.total(), 0);
+    assert!(overview.uncertain.is_empty());
+    assert!(overview.self_reinforced.is_empty());
+
+    let text = render_overview(&overview);
+    assert!(text.contains("No relationships yet"), "{text}");
+    assert!(text.contains("Vim"), "{text}");
+}

--- a/tests/mcp_protocol.rs
+++ b/tests/mcp_protocol.rs
@@ -14,6 +14,8 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 
 use recall_echo::error::RecallError;
+use recall_echo::graph::edge_view::EdgeView;
+use recall_echo::graph::inspect::{ConfidenceSummary, KnownEntity, MemoryOverview, TypeGroup};
 use recall_echo::graph::types::{
     EntityDetail, EntitySummary, EntityType, Episode, EpisodeSearchResult, GraphStats, MatchSource,
     QueryResult, ScoredEntity, TraversalEdge, TraversalNode,
@@ -78,14 +80,57 @@ fn canned_payload(request: &Request) -> Value {
         .unwrap(),
         Request::SearchEpisodes(_) => json!([episode()]),
         Request::Traverse(_) => serde_json::to_value(traversal_tree()).unwrap(),
-        Request::Status => serde_json::to_value(GraphStats {
-            entity_count: 12,
-            relationship_count: 30,
-            episode_count: 400,
-            entity_type_counts: HashMap::from([("project".to_string(), 7)]),
-        })
-        .unwrap(),
+        Request::Status => serde_json::to_value(graph_stats()).unwrap(),
+        Request::Overview(_) => serde_json::to_value(memory_overview()).unwrap(),
         other => panic!("no MCP tool builds a {} request", other.op_name()),
+    }
+}
+
+fn graph_stats() -> GraphStats {
+    GraphStats {
+        entity_count: 12,
+        relationship_count: 30,
+        episode_count: 400,
+        entity_type_counts: HashMap::from([("project".to_string(), 7)]),
+    }
+}
+
+fn memory_overview() -> MemoryOverview {
+    MemoryOverview {
+        stats: graph_stats(),
+        groups: vec![TypeGroup {
+            entity_type: "project".into(),
+            count: 7,
+            top: vec![KnownEntity {
+                id: "entity:recall-echo".into(),
+                name: "recall-echo".into(),
+                entity_type: "project".into(),
+                abstract_text: "Persistent memory system with a knowledge graph.".into(),
+                access_count: 12,
+                utility_score: 0.81,
+            }],
+        }],
+        confidence: ConfidenceSummary {
+            strong: 20,
+            uncertain: 7,
+            doubtful: 3,
+        },
+        uncertain: vec![edge_view("PREFERS", 0.31, 0)],
+        self_reinforced: vec![edge_view("USES", 0.88, 23)],
+    }
+}
+
+fn edge_view(rel_type: &str, confidence: f64, self_reinforcements: i64) -> EdgeView {
+    EdgeView {
+        id: format!("relates_to:{rel_type}"),
+        from: "Echo".into(),
+        to: "NixOS".into(),
+        rel_type: rel_type.into(),
+        description: None,
+        confidence,
+        evidence: 14.0,
+        self_reinforcements,
+        superseded: false,
     }
 }
 
@@ -324,6 +369,7 @@ async fn tools_list_describes_every_tool() {
             "recall_search",
             "recall_episodes",
             "recall_traverse",
+            "recall_overview",
             "recall_status"
         ]
     );
@@ -383,7 +429,7 @@ async fn every_advertised_tool_can_be_called() {
         let name = tool["name"].as_str().unwrap();
         let arguments = match name {
             "recall_traverse" => json!({ "entity": "Rust" }),
-            "recall_status" => json!({}),
+            "recall_status" | "recall_overview" => json!({}),
             _ => json!({ "query": "release pipeline" }),
         };
         let response = answer(&server, call(9, name, arguments)).await;
@@ -486,6 +532,45 @@ async fn recall_status_reports_counts() {
     assert!(text.contains("12 entities"), "{text}");
     assert!(text.contains("400 conversation episodes"), "{text}");
     assert!(text.contains("project 7"), "{text}");
+}
+
+#[tokio::test]
+async fn recall_overview_reports_the_content_and_its_uncertainty() {
+    let server = server(Outcome::Canned);
+    let response = answer(&server, call(1, "recall_overview", json!({}))).await;
+    let text = text_of(&response["result"]);
+
+    // The content, not just the counts recall_status already gives.
+    assert!(text.contains("project (7)"), "{text}");
+    assert!(text.contains("recall-echo"), "{text}");
+    // And an honest account of how much of it is settled.
+    assert!(
+        text.contains("20 of 30 relationships firmly held"),
+        "{text}"
+    );
+    assert!(text.contains("Least certain"), "{text}");
+    assert!(
+        text.contains("Echo —[USES]→ NixOS (88%, self×23)"),
+        "{text}"
+    );
+    assert!(
+        text.contains("kept out of the confidence above"),
+        "the tally means nothing without the explanation: {text}"
+    );
+}
+
+#[tokio::test]
+async fn recall_overview_takes_no_arguments_and_tolerates_any() {
+    let server = server(Outcome::Canned);
+    let response = answer(&server, call(1, "recall_overview", json!({ "noise": 1 }))).await;
+    assert_eq!(response["result"]["isError"], false, "{response}");
+    assert_eq!(
+        server.backend_calls(),
+        vec![Request::Overview(recall_echo::serve::OverviewArgs {
+            per_type: 0
+        })],
+        "the daemon's own default listing size is the right one"
+    );
 }
 
 #[tokio::test]
@@ -740,7 +825,7 @@ async fn no_tool_can_write_to_the_graph() {
         let name = tool["name"].as_str().unwrap();
         let arguments = match name {
             "recall_traverse" => json!({ "entity": "Rust" }),
-            "recall_status" => json!({}),
+            "recall_status" | "recall_overview" => json!({}),
             _ => json!({ "query": "anything" }),
         };
         answer(&server, call(2, name, arguments)).await;


### PR DESCRIPTION
Two things a person needs from a memory that learns on its own: a way to see what it holds, and a way to correct it. Neither existed — the first time memory kept a stale preference or a dropped project, the only recourse was editing SurrealDB by hand.

## what-do-you-know

Renders what memory actually holds, grouped by type, with confidence — and surfaces the self-reinforcement tally where it is non-zero, which is the *this may be me talking to myself* signal from the provenance work. `--about <topic>` answers the same question on one subject.

## graph correct

Corrections are recorded as **evidence, not deletion**. A person saying that's wrong is the highest-authority signal the system can receive, so it enters as contradiction at User provenance and the posterior moves accordingly, with before/after confidence and evidence weight both shown. `--forget` still deletes, but prints what will go and requires confirmation — gated daemon-side, so no client can skip it.

**Subtle correctness point, caught during implementation:** contradiction must not touch `last_reinforced`. Reusing the reinforce path would have reset the decay anchor, so telling the system a memory was wrong would have made it *more* visible — an edge stored at 0.6 and decayed to 0.3 would return at 0.545. A separate write path leaves the anchor alone, so corrections are monotone. The extraction path has the same latent wart; noted for follow-up.

Ambiguity is refused rather than guessed: an entity with several live edges lists them and changes nothing; an unknown name suggests the closest stored ones. Damaging the wrong memory is worse than doing nothing.

## MCP

Gains `recall_overview` (read-only) — an agent asking what do I know is the same question. **No correction tool**, deliberately: a model calling it would record its own judgement at the *user's* authority, the loudest version of the failure provenance weighting exists to prevent.

Also: `config show` now prints `[capture]`, `[serve]` and `[extraction]`, which it silently omitted.

728 tests, clippy -D warnings clean.